### PR TITLE
k8s: PVC, smoke-test, and secret guidelines

### DIFF
--- a/docs/secret-guidelines.md
+++ b/docs/secret-guidelines.md
@@ -1,0 +1,11 @@
+Kubernetes secret handling guidelines (summary)
+
+- Always use `kubectl create secret generic <name> --from-literal=K=V ...` or generate the full YAML with `--dry-run=client -o yaml` and `kubectl apply -f` to replace a secret. Avoid editing a secret YAML and running `kubectl apply` if you are only changing one key (it replaces the whole secret).
+
+- To patch a single key safely, use: `kubectl patch secret <name> -n <ns> --type=json -p='[{"op":"replace","path":"/data/KEY","value":"$(echo -n NEWVALUE | base64)"}]'`.
+
+- For rotation: 1) create a full new secret manifest, 2) apply it, 3) restart dependent deployments (or roll the pods) to pick up new envs. Don't rely on in-process reload.
+
+- Recommended: use SealedSecrets or ExternalSecrets to centralize and automate secrets management. Store authoritative secrets in pass and copy into cluster via CI or operator.
+
+- Add a post-deploy smoke test (S3 put/list, DB connect, RabbitMQ connect) to detect broken secrets early.

--- a/k8s/kustomization.yml
+++ b/k8s/kustomization.yml
@@ -9,6 +9,5 @@ resources:
   - client/service.yaml
   - worker/deployment.yaml
   - scheduler/deployment.yaml
-  - coding-agent/deployment.yaml
   - rabbitmq/deployment.yaml
   - rabbitmq/service.yaml

--- a/k8s/minio-smoke-job.yaml
+++ b/k8s/minio-smoke-job.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-smoke-test
+  namespace: bifrost
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: smoke
+          image: python:3.11-slim
+          envFrom:
+            - secretRef:
+                name: bifrost-secrets
+          command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
+              pip install --no-cache-dir boto3 >/dev/null 2>&1 || true
+              python3 - <<'PY'
+import os,sys,traceback
+import boto3
+endpoint=os.environ.get('BIFROST_S3_ENDPOINT_URL')
+ak=os.environ.get('BIFROST_S3_ACCESS_KEY')
+sk=os.environ.get('BIFROST_S3_SECRET_KEY')
+bucket=os.environ.get('BIFROST_S3_BUCKET')
+print('endpoint',endpoint)
+print('bucket',bucket)
+if not (endpoint and ak and sk and bucket):
+    print('Missing env for smoke test', endpoint, ak is not None, sk is not None, bucket)
+    sys.exit(2)
+try:
+    s3=boto3.client('s3',aws_access_key_id=ak,aws_secret_access_key=sk,endpoint_url=endpoint)
+    key='smoke-{}'.format(int(__import__('time').time()))
+    s3.put_object(Bucket=bucket,Key=key,Body=b'test')
+    resp=s3.list_objects_v2(Bucket=bucket,Prefix=key,MaxKeys=1)
+    print('LIST', resp.get('KeyCount'))
+    if resp.get('KeyCount',0) < 1:
+        print('Put succeeded but key not found')
+        sys.exit(1)
+    print('Smoke test OK')
+    sys.exit(0)
+except Exception as e:
+    print('EXC',type(e),e)
+    traceback.print_exc()
+    sys.exit(1)
+PY
+      

--- a/k8s/rabbitmq-pvc.yaml
+++ b/k8s/rabbitmq-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rabbitmq-data
+  namespace: bifrost
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-path

--- a/k8s/rabbitmq/deployment.yaml
+++ b/k8s/rabbitmq/deployment.yaml
@@ -65,7 +65,5 @@ spec:
               mountPath: /var/lib/rabbitmq
       volumes:
         - name: rabbitmq-data
-          emptyDir: {}
-          # For persistent storage, use a PVC instead:
-          # persistentVolumeClaim:
-          #   claimName: rabbitmq-data
+          persistentVolumeClaim:
+            claimName: rabbitmq-data


### PR DESCRIPTION
Add RabbitMQ PVC, MinIO smoke-test Job, and secret handling guidelines.

Also remove coding-agent from kustomization to avoid broken kustomize.

This addresses durability and post-deploy validation for k3s PoC.