### PR TITLE
workflows: add canonical smoke and ninjaone workflow templates

### DIFF
--- a/workflows/infra/api-sync-smoke.yaml
+++ b/workflows/infra/api-sync-smoke.yaml
@@ -1,0 +1,7 @@
+# Purpose: Exercise the API sync path to validate end-to-end sync
+# Name: api-sync-smoke
+steps:
+  - name: sync-smoke-placeholder
+    run: |
+      echo "Placeholder: trigger a sync/push and verify API returns 200."
+      echo "Replace with actual bifrost CLI commands or API calls for your environment."

--- a/workflows/ninjaone/winget-install-template.yaml
+++ b/workflows/ninjaone/winget-install-template.yaml
@@ -1,0 +1,8 @@
+# Purpose: NinjaOne PowerShell winget install template
+# Name: ninjaone-winget-install-template
+# Usage: This template is a starting point for packaging winget install scripts for NinjaOne.
+# PowerShell script should be idempotent and non-interactive.
+ps1: |
+  # Placeholder PowerShell script - replace with extracted functions from winutil
+  Write-Output 'Ensure-WinGetInstalled - Implemented elsewhere'
+  # Example: winget install --id=Git.Git -e --silent

--- a/workflows/smoke/get-public-ip.yaml
+++ b/workflows/smoke/get-public-ip.yaml
@@ -1,0 +1,8 @@
+# Purpose: Sample workflow to return the public IP of the runner using an external service
+# Name: get-public-ip
+# Run instructions: This is a simple workflow that executes a single HTTP GET.
+steps:
+  - name: get-public-ip
+    run: |
+      echo "Fetching public IP..."
+      curl -sS https://api.ipify.org?format=json

--- a/workflows/smoke/minio-put-list.yaml
+++ b/workflows/smoke/minio-put-list.yaml
@@ -1,0 +1,8 @@
+# Purpose: MinIO S3 put/list smoke test
+# Name: minio-put-list
+# NOTE: Replace this placeholder with an executable S3 task that uses BIFROST_S3_* settings
+steps:
+  - name: minio-smoke-placeholder
+    run: |
+      echo "This workflow should perform an S3 put and then list to verify writes."
+      echo "Implement using boto3/aiobotocore in a task runner with access to BIFROST_S3_* env vars."


### PR DESCRIPTION
Add canonical workflows/smoke and ninjaone placeholders for discoverability and to follow Bifrost naming conventions.

Files added: workflows/smoke/get-public-ip.yaml, workflows/smoke/minio-put-list.yaml, workflows/infra/api-sync-smoke.yaml, workflows/ninjaone/winget-install-template.yaml