### PR TITLE
ci: warm Docker test image cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Warm Docker test image cache
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./api/Dockerfile.dev
+          load: true
+          tags: bifrost-test-dev:ci
+          cache-from: type=gha,scope=bifrost-test-dev
+          cache-to: type=gha,scope=bifrost-test-dev,mode=max
+
       - name: Run unit tests with coverage
         run: |
           chmod +x test.sh
@@ -52,6 +62,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Warm Docker test image cache
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./api/Dockerfile.dev
+          load: true
+          tags: bifrost-test-dev:ci
+          cache-from: type=gha,scope=bifrost-test-dev
+          cache-to: type=gha,scope=bifrost-test-dev,mode=max
 
       - name: Run E2E tests
         run: |


### PR DESCRIPTION
## Summary
- warm the shared `api/Dockerfile.dev` image in each CI test job before `test.sh` runs
- back that prebuild with GitHub Actions Docker cache storage
- keep the existing test harness semantics unchanged so this only measures cache impact

## Why
The current CI path spends a large fraction of its time on image build and environment startup. This is the lowest-risk follow-up after the unit/e2e split: improve cold-run image reuse without changing which services start or which tests run.

## Notes
- stacked on top of #63
- not locally benchmarked against GitHub cache behavior, because the benefit depends on Actions cache reuse across runs
- local behavior should remain functionally identical because `test.sh` still performs the same build/startup/test sequence