### PR TITLE
Scaffold UniFi integration (Site Manager, Fabrics, and local Network API)

### DIFF
--- a/.bifrost/integrations.yaml
+++ b/.bifrost/integrations.yaml
@@ -606,3 +606,29 @@ integrations:
     id: 0a75adc3-1bd5-4bc2-99d0-d8f4964078d3
     mappings: []
     name: Amazon Business
+  380ba6f6-bf16-4075-8002-7ae0289f3b75:
+    config_schema:
+    - description: UniFi Site Manager API key used for cloud API authentication
+      key: api_key
+      position: 0
+      required: true
+      type: secret
+    - description: Optional UniFi Site Manager API base URL (defaults to https://api.ui.com)
+      key: site_manager_base_url
+      position: 1
+      required: false
+      type: string
+    - description: Optional local UniFi Network Application base URL for self-hosted controllers (for example https://unifi.example.com)
+      key: local_network_base_url
+      position: 2
+      required: false
+      type: string
+    - description: Optional TLS verification toggle (true/false) for cloud and local API calls
+      key: verify_tls
+      position: 3
+      required: false
+      type: string
+    id: 380ba6f6-bf16-4075-8002-7ae0289f3b75
+    list_entities_data_provider_id: e1a5d021-00be-4648-895f-343967ea3e15
+    mappings: []
+    name: UniFi

--- a/.bifrost/workflows.yaml
+++ b/.bifrost/workflows.yaml
@@ -1639,3 +1639,60 @@ workflows:
     - admins
     - remove
     timeout_seconds: 600
+  e1a5d021-00be-4648-895f-343967ea3e15:
+    access_level: authenticated
+    category: UniFi
+    description: Returns UniFi sites from Site Manager for org mapping picker.
+    function_name: list_unifi_sites
+    id: e1a5d021-00be-4648-895f-343967ea3e15
+    name: 'UniFi: List Sites'
+    path: features/unifi/workflows/data_providers.py
+    tags:
+    - unifi
+    - data-provider
+    - site-manager
+    timeout_seconds: 60
+    type: data_provider
+  7d97e766-f8b4-40ae-843e-03e6895e5b45:
+    access_level: authenticated
+    category: UniFi
+    description: Returns UniFi fabrics from Site Manager for mapping policy pickers.
+    function_name: list_unifi_fabrics
+    id: 7d97e766-f8b4-40ae-843e-03e6895e5b45
+    name: 'UniFi: List Fabrics'
+    path: features/unifi/workflows/data_providers.py
+    tags:
+    - unifi
+    - data-provider
+    - fabric
+    - site-manager
+    timeout_seconds: 60
+    type: data_provider
+  a523b9a8-a76a-49d2-807d-8d8b0fa8165a:
+    access_level: authenticated
+    category: UniFi
+    description: Sync UniFi Site Manager sites into Bifrost organizations.
+    function_name: sync_unifi_sites
+    id: a523b9a8-a76a-49d2-807d-8d8b0fa8165a
+    name: 'UniFi: Sync Sites'
+    path: features/unifi/workflows/sync_sites.py
+    tags:
+    - unifi
+    - sync
+    - site-manager
+    - sites
+    timeout_seconds: 300
+  956bb3fe-7230-4140-b027-44b30cccf9f2:
+    access_level: authenticated
+    category: UniFi
+    description: Sync UniFi fabrics into Bifrost organizations for policy allocation.
+    function_name: sync_unifi_fabrics
+    id: 956bb3fe-7230-4140-b027-44b30cccf9f2
+    name: 'UniFi: Sync Fabrics'
+    path: features/unifi/workflows/sync_fabrics.py
+    tags:
+    - unifi
+    - sync
+    - site-manager
+    - fabric
+    timeout_seconds: 300

--- a/docs/plans/2026-03-29-unifi-integration-landscape.md
+++ b/docs/plans/2026-03-29-unifi-integration-landscape.md
@@ -1,0 +1,36 @@
+# 2026-03-29 UniFi integration landscape notes (Site Manager + local API)
+
+## Objective
+
+Scaffold a Bifrost UniFi integration that can:
+
+1. Use Site Manager API for cloud/global inventory and sync.
+2. Support local/self-hosted UniFi Network API surfaces for environments where cloud access is restricted.
+3. Preserve enough mapping context to allocate both sites and fabrics to customer organizations.
+
+## Current landscape summary
+
+- UniFi Site Manager is the central remote-management plane and explicitly exposes API integration support.
+- UniFi Fabrics are now a first-class management grouping above sites, with shared RBAC/identity policy boundaries.
+- For self-hosting, UniFi OS Server is now the preferred path over legacy UniFi Network Server when feature parity with UniFi OS concepts (organizations, IdP, Site Magic) is required.
+- Legacy UniFi Network Server remains available, but Ubiquiti positions it as an advanced/self-managed path and recommends UniFi-native hosting for most users.
+
+## Bifrost allocation model (recommended)
+
+- Primary mapping key for org-scoped automation: **site ID** (`entity_id`).
+- Persist fabric context on the mapping config (`fabric_id`) when available.
+- Add a separate fabric sync workflow that can create "fabric:" entity IDs for organizations that want policy-at-fabric granularity.
+- Treat local API usage as an optional override surface (via `local_network_base_url`) rather than a replacement for Site Manager in multi-tenant MSP scenarios.
+
+## Self-hosting implications for implementation
+
+- Keep TLS verification configurable (`verify_tls`) for mixed deployments and internal PKI setups.
+- Expect manual lifecycle responsibilities (patching/updating and runtime availability) for self-hosted environments.
+- Keep endpoint paths configurable in code, because both Site Manager and local Network API surfaces are still evolving.
+
+## Follow-up implementation tasks
+
+1. Validate current production endpoint paths and auth header semantics against the latest developer UI docs.
+2. Add fabric-to-site relationship reconciliation workflow once endpoint schema is confirmed.
+3. Add integration contract tests that pin expected payload shapes from both cloud and local surfaces.
+4. Add local-surface tool workflows (site settings/inventory queries) once mapping strategy is finalized.

--- a/features/unifi/workflows/data_providers.py
+++ b/features/unifi/workflows/data_providers.py
@@ -1,0 +1,52 @@
+"""UniFi data providers for Bifrost org mapping."""
+
+from bifrost import data_provider
+from modules.unifi import UniFiClient
+
+
+@data_provider(
+    name="UniFi: List Sites",
+    description="Returns UniFi sites from Site Manager for org mapping picker.",
+    category="UniFi",
+    tags=["unifi", "data-provider", "site-manager"],
+)
+async def list_unifi_sites() -> list[dict]:
+    from modules.unifi import get_client
+
+    client = await get_client(scope="global")
+    try:
+        sites = await client.list_site_manager_sites()
+    finally:
+        await client.close()
+
+    options: list[dict[str, str]] = []
+    for site in sites:
+        normalized = UniFiClient.normalize_site(site)
+        if normalized["id"] and normalized["name"]:
+            options.append({"value": normalized["id"], "label": normalized["name"]})
+
+    return sorted(options, key=lambda item: item["label"].lower())
+
+
+@data_provider(
+    name="UniFi: List Fabrics",
+    description="Returns UniFi fabrics from Site Manager for mapping policy pickers.",
+    category="UniFi",
+    tags=["unifi", "data-provider", "fabric", "site-manager"],
+)
+async def list_unifi_fabrics() -> list[dict]:
+    from modules.unifi import get_client
+
+    client = await get_client(scope="global")
+    try:
+        fabrics = await client.list_site_manager_fabrics()
+    finally:
+        await client.close()
+
+    options: list[dict[str, str]] = []
+    for fabric in fabrics:
+        normalized = UniFiClient.normalize_fabric(fabric)
+        if normalized["id"] and normalized["name"]:
+            options.append({"value": normalized["id"], "label": normalized["name"]})
+
+    return sorted(options, key=lambda item: item["label"].lower())

--- a/features/unifi/workflows/sync_fabrics.py
+++ b/features/unifi/workflows/sync_fabrics.py
@@ -1,0 +1,86 @@
+"""
+UniFi: Sync Fabrics
+
+Scaffold workflow that syncs UniFi fabrics into Bifrost organizations.
+
+Entity model:
+  entity_id   = fabric:<fabric-id>
+  entity_name = fabric name
+
+This keeps fabric mappings distinct from site mappings while still using the
+same UniFi integration.
+"""
+
+from bifrost import integrations, organizations, workflow
+from modules.unifi import UniFiClient
+
+
+@workflow(
+    name="UniFi: Sync Fabrics",
+    description="Sync UniFi fabrics into Bifrost organizations for policy allocation.",
+    category="UniFi",
+    tags=["unifi", "sync", "site-manager", "fabric"],
+)
+async def sync_unifi_fabrics() -> dict:
+    from modules.unifi import get_client
+
+    client = await get_client(scope="global")
+    try:
+        fabrics = await client.list_site_manager_fabrics()
+    finally:
+        await client.close()
+
+    existing_mappings = await integrations.list_mappings("UniFi") or []
+    existing_by_entity = {
+        mapping.entity_id: mapping
+        for mapping in existing_mappings
+        if getattr(mapping, "entity_id", None)
+    }
+
+    all_orgs = await organizations.list()
+    orgs_by_name = {org.name.lower(): org for org in all_orgs}
+
+    created_orgs = 0
+    mapped = 0
+    already_mapped = 0
+    errors: list[str] = []
+
+    for fabric in fabrics:
+        normalized = UniFiClient.normalize_fabric(fabric)
+        fabric_id = normalized["id"]
+        fabric_name = normalized["name"] or fabric_id
+
+        if not fabric_id:
+            errors.append(f"Skipped fabric with no ID: {fabric}")
+            continue
+
+        entity_id = f"fabric:{fabric_id}"
+        if entity_id in existing_by_entity:
+            already_mapped += 1
+            continue
+
+        try:
+            org = orgs_by_name.get(fabric_name.lower())
+            if org is None:
+                org = await organizations.create(fabric_name)
+                orgs_by_name[fabric_name.lower()] = org
+                created_orgs += 1
+
+            await integrations.upsert_mapping(
+                "UniFi",
+                scope=org.id,
+                entity_id=entity_id,
+                entity_name=fabric_name,
+                config={"fabric_id": fabric_id, "mapping_kind": "fabric"},
+            )
+            mapped += 1
+        except Exception as exc:
+            errors.append(f"{fabric_name} ({fabric_id}): {exc}")
+
+    return {
+        "total": len(fabrics),
+        "mapped": mapped,
+        "already_mapped": already_mapped,
+        "created_orgs": created_orgs,
+        "errors": errors,
+    }

--- a/features/unifi/workflows/sync_sites.py
+++ b/features/unifi/workflows/sync_sites.py
@@ -1,0 +1,87 @@
+"""
+UniFi: Sync Sites
+
+Syncs UniFi Site Manager sites into Bifrost organizations and creates
+IntegrationMappings for org-scoped workflows.
+
+Entity model:
+  entity_id   = UniFi site ID
+  entity_name = site name
+
+Mapping config:
+  fabric_id   = Optional UniFi fabric ID associated with the site.
+"""
+
+from bifrost import integrations, organizations, workflow
+from modules.unifi import UniFiClient
+
+
+@workflow(
+    name="UniFi: Sync Sites",
+    description="Sync UniFi Site Manager sites into Bifrost organizations.",
+    category="UniFi",
+    tags=["unifi", "sync", "site-manager", "sites"],
+)
+async def sync_unifi_sites() -> dict:
+    from modules.unifi import get_client
+
+    client = await get_client(scope="global")
+    try:
+        sites = await client.list_site_manager_sites()
+    finally:
+        await client.close()
+
+    existing_mappings = await integrations.list_mappings("UniFi") or []
+    existing_by_entity = {
+        mapping.entity_id: mapping
+        for mapping in existing_mappings
+        if getattr(mapping, "entity_id", None)
+    }
+
+    all_orgs = await organizations.list()
+    orgs_by_name = {org.name.lower(): org for org in all_orgs}
+
+    created_orgs = 0
+    mapped = 0
+    already_mapped = 0
+    errors: list[str] = []
+
+    for site in sites:
+        normalized = UniFiClient.normalize_site(site)
+        site_id = normalized["id"]
+        site_name = normalized["name"] or site_id
+        fabric_id = normalized.get("fabric_id", "")
+
+        if not site_id:
+            errors.append(f"Skipped site with no ID: {site}")
+            continue
+
+        if site_id in existing_by_entity:
+            already_mapped += 1
+            continue
+
+        try:
+            org = orgs_by_name.get(site_name.lower())
+            if org is None:
+                org = await organizations.create(site_name)
+                orgs_by_name[site_name.lower()] = org
+                created_orgs += 1
+
+            await integrations.upsert_mapping(
+                "UniFi",
+                scope=org.id,
+                entity_id=site_id,
+                entity_name=site_name,
+                config={"fabric_id": fabric_id} if fabric_id else None,
+            )
+            mapped += 1
+        except Exception as exc:
+            errors.append(f"{site_name} ({site_id}): {exc}")
+
+    return {
+        "total": len(sites),
+        "mapped": mapped,
+        "already_mapped": already_mapped,
+        "created_orgs": created_orgs,
+        "errors": errors,
+    }

--- a/modules/unifi.py
+++ b/modules/unifi.py
@@ -1,0 +1,225 @@
+"""
+UniFi Site Manager + local UniFi Network API helpers for Bifrost integrations.
+
+This module intentionally keeps endpoint paths configurable because UniFi's
+public Site Manager API and local Network Application API continue to evolve.
+
+Entity model (default):
+  entity_id   = UniFi site ID
+  entity_name = site name
+
+Optional mapping config:
+  fabric_id   = UniFi fabric ID, when the upstream API includes fabric linkage.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class UniFiClient:
+    """Thin async client for UniFi cloud (Site Manager) and local API surfaces."""
+
+    SITE_MANAGER_BASE_URL = "https://api.ui.com"
+    SITE_MANAGER_SITES_PATH = "/v1/sites"
+    SITE_MANAGER_FABRICS_PATH = "/v1/fabrics"
+
+    LOCAL_NETWORK_SITES_PATH = "/proxy/network/integration/v1/sites"
+    LOCAL_NETWORK_FABRICS_PATH = "/proxy/network/integration/v1/fabrics"
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        site_manager_base_url: str = SITE_MANAGER_BASE_URL,
+        local_network_base_url: str | None = None,
+        verify_tls: bool = True,
+        timeout: float = 30.0,
+        mapped_site_id: str | None = None,
+        mapped_fabric_id: str | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._site_manager_base_url = site_manager_base_url.rstrip("/")
+        self._local_network_base_url = (
+            local_network_base_url.rstrip("/") if local_network_base_url else None
+        )
+        self._verify_tls = verify_tls
+        self._timeout = timeout
+        self._mapped_site_id = str(mapped_site_id or "").strip() or None
+        self._mapped_fabric_id = str(mapped_fabric_id or "").strip() or None
+
+        self._site_manager_http: httpx.AsyncClient | None = None
+        self._local_network_http: httpx.AsyncClient | None = None
+
+    @property
+    def site_id(self) -> str | None:
+        return self._mapped_site_id
+
+    @property
+    def fabric_id(self) -> str | None:
+        return self._mapped_fabric_id
+
+    async def _get_site_manager_http(self) -> httpx.AsyncClient:
+        if self._site_manager_http is None:
+            self._site_manager_http = httpx.AsyncClient(
+                base_url=self._site_manager_base_url,
+                headers={
+                    "X-API-Key": self._api_key,
+                    "Accept": "application/json",
+                },
+                timeout=self._timeout,
+                verify=self._verify_tls,
+            )
+        return self._site_manager_http
+
+    async def _get_local_network_http(self) -> httpx.AsyncClient:
+        if not self._local_network_base_url:
+            raise RuntimeError(
+                "UniFi local Network API base URL is not configured. "
+                "Set 'local_network_base_url' in the UniFi integration config."
+            )
+
+        if self._local_network_http is None:
+            self._local_network_http = httpx.AsyncClient(
+                base_url=self._local_network_base_url,
+                headers={
+                    "X-API-Key": self._api_key,
+                    "Accept": "application/json",
+                },
+                timeout=self._timeout,
+                verify=self._verify_tls,
+            )
+        return self._local_network_http
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        surface: str = "site_manager",
+    ) -> httpx.Response:
+        http = (
+            await self._get_site_manager_http()
+            if surface == "site_manager"
+            else await self._get_local_network_http()
+        )
+        response = await http.request(method, path, params=params or None)
+        if not response.is_success:
+            body = response.text[:1000]
+            raise RuntimeError(
+                f"UniFi [{surface} {method.upper()} {path}] HTTP {response.status_code}: {body}"
+            )
+        return response
+
+    @staticmethod
+    def _coerce_list(payload: Any) -> list[dict[str, Any]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+
+        if isinstance(payload, dict):
+            for key in ("data", "items", "results", "sites", "fabrics"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return [item for item in value if isinstance(item, dict)]
+        return []
+
+    @staticmethod
+    def normalize_site(site: dict[str, Any]) -> dict[str, str]:
+        site_id = site.get("id") or site.get("siteId") or site.get("site_id")
+        name = site.get("name") or site.get("siteName") or site.get("desc")
+        fabric_id = (
+            site.get("fabricId")
+            or site.get("fabric_id")
+            or site.get("fabric", {}).get("id")
+            if isinstance(site.get("fabric"), dict)
+            else site.get("fabricId") or site.get("fabric_id")
+        )
+        return {
+            "id": str(site_id or ""),
+            "name": str(name or ""),
+            "fabric_id": str(fabric_id or ""),
+        }
+
+    @staticmethod
+    def normalize_fabric(fabric: dict[str, Any]) -> dict[str, str]:
+        fabric_id = fabric.get("id") or fabric.get("fabricId") or fabric.get("fabric_id")
+        name = fabric.get("name") or fabric.get("displayName") or fabric.get("slug")
+        return {
+            "id": str(fabric_id or ""),
+            "name": str(name or ""),
+        }
+
+    async def list_site_manager_sites(self) -> list[dict[str, Any]]:
+        response = await self._request(
+            "GET",
+            self.SITE_MANAGER_SITES_PATH,
+            surface="site_manager",
+        )
+        return self._coerce_list(response.json())
+
+    async def list_site_manager_fabrics(self) -> list[dict[str, Any]]:
+        response = await self._request(
+            "GET",
+            self.SITE_MANAGER_FABRICS_PATH,
+            surface="site_manager",
+        )
+        return self._coerce_list(response.json())
+
+    async def list_local_network_sites(self) -> list[dict[str, Any]]:
+        response = await self._request(
+            "GET",
+            self.LOCAL_NETWORK_SITES_PATH,
+            surface="local_network",
+        )
+        return self._coerce_list(response.json())
+
+    async def list_local_network_fabrics(self) -> list[dict[str, Any]]:
+        response = await self._request(
+            "GET",
+            self.LOCAL_NETWORK_FABRICS_PATH,
+            surface="local_network",
+        )
+        return self._coerce_list(response.json())
+
+    async def close(self) -> None:
+        if self._site_manager_http is not None:
+            await self._site_manager_http.aclose()
+            self._site_manager_http = None
+        if self._local_network_http is not None:
+            await self._local_network_http.aclose()
+            self._local_network_http = None
+
+
+async def get_client(scope: str | None = None) -> UniFiClient:
+    """Build a UniFi client from Bifrost integration config and mapping context."""
+    from bifrost import integrations
+
+    integration = await integrations.get("UniFi", scope=scope)
+    if not integration:
+        raise RuntimeError("Integration 'UniFi' not found in Bifrost")
+
+    config = integration.config or {}
+    api_key = config.get("api_key")
+    if not api_key:
+        raise RuntimeError("UniFi integration missing required config: ['api_key']")
+
+    mapping_config = {}
+    if getattr(integration, "mapping", None) and getattr(integration.mapping, "config", None):
+        mapping_config = integration.mapping.config or {}
+
+    verify_tls_value = str(config.get("verify_tls", "true")).strip().lower()
+    verify_tls = verify_tls_value not in {"0", "false", "no", "off"}
+
+    return UniFiClient(
+        api_key=api_key,
+        site_manager_base_url=config.get(
+            "site_manager_base_url", UniFiClient.SITE_MANAGER_BASE_URL
+        ),
+        local_network_base_url=config.get("local_network_base_url") or None,
+        verify_tls=verify_tls,
+        mapped_site_id=getattr(integration, "entity_id", None),
+        mapped_fabric_id=mapping_config.get("fabric_id") if isinstance(mapping_config, dict) else None,
+    )

--- a/tests/integrations/test_unifi_integration.py
+++ b/tests/integrations/test_unifi_integration.py
@@ -1,0 +1,286 @@
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+API_ROOT = REPO_ROOT / "api"
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from bifrost import integrations, organizations
+from features.unifi.workflows.data_providers import list_unifi_fabrics, list_unifi_sites
+from features.unifi.workflows.sync_fabrics import sync_unifi_fabrics
+from features.unifi.workflows.sync_sites import sync_unifi_sites
+from modules import unifi
+
+
+def _site(site_id: str | None, name: str | None, fabric_id: str | None = None) -> dict:
+    payload: dict[str, str] = {
+        "id": site_id or "",
+        "name": name or "",
+    }
+    if fabric_id is not None:
+        payload["fabricId"] = fabric_id
+    return payload
+
+
+def _fabric(fabric_id: str | None, name: str | None) -> dict:
+    return {
+        "id": fabric_id or "",
+        "name": name or "",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_client_uses_scoped_mapping(monkeypatch):
+    async def fake_get(name: str, scope: str | None = None):
+        assert name == "UniFi"
+        assert scope == "org-123"
+        return SimpleNamespace(config={"api_key": "key-123"}, entity_id="site-1")
+
+    monkeypatch.setattr(integrations, "get", fake_get)
+
+    client = await unifi.get_client(scope="org-123")
+    try:
+        assert client.site_id == "site-1"
+        assert client._site_manager_base_url == unifi.UniFiClient.SITE_MANAGER_BASE_URL
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_client_requires_api_key(monkeypatch):
+    async def fake_get(name: str, scope: str | None = None):
+        return SimpleNamespace(config={}, entity_id=None)
+
+    monkeypatch.setattr(integrations, "get", fake_get)
+
+    with pytest.raises(RuntimeError, match="api_key"):
+        await unifi.get_client(scope="global")
+
+
+@pytest.mark.asyncio
+async def test_list_unifi_sites_returns_sorted_options(monkeypatch):
+    class FakeClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def list_site_manager_sites(self):
+            return [
+                _site("2", "Zulu"),
+                _site("1", "Alpha"),
+                _site("", "Missing ID"),
+                _site("3", ""),
+            ]
+
+        async def close(self) -> None:
+            self.closed = True
+
+    fake_client = FakeClient()
+
+    async def fake_get_client(scope: str | None = None):
+        assert scope == "global"
+        return fake_client
+
+    monkeypatch.setattr(unifi, "get_client", fake_get_client)
+
+    result = await list_unifi_sites()
+
+    assert result == [
+        {"value": "1", "label": "Alpha"},
+        {"value": "2", "label": "Zulu"},
+    ]
+    assert fake_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_list_unifi_fabrics_returns_sorted_options(monkeypatch):
+    class FakeClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def list_site_manager_fabrics(self):
+            return [
+                _fabric("fab-2", "Zulu Fabric"),
+                _fabric("fab-1", "Alpha Fabric"),
+                _fabric("", "Missing ID"),
+                _fabric("fab-3", ""),
+            ]
+
+        async def close(self) -> None:
+            self.closed = True
+
+    fake_client = FakeClient()
+
+    async def fake_get_client(scope: str | None = None):
+        assert scope == "global"
+        return fake_client
+
+    monkeypatch.setattr(unifi, "get_client", fake_get_client)
+
+    result = await list_unifi_fabrics()
+
+    assert result == [
+        {"value": "fab-1", "label": "Alpha Fabric"},
+        {"value": "fab-2", "label": "Zulu Fabric"},
+    ]
+    assert fake_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_sync_unifi_sites_maps_unmapped_sites(monkeypatch):
+    class FakeClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def list_site_manager_sites(self):
+            return [
+                _site("site-100", "Already Mapped", "fab-100"),
+                _site("site-200", "Existing Org", "fab-200"),
+                _site("site-300", "New Org", None),
+                _site(None, "Broken Site", None),
+            ]
+
+        async def close(self) -> None:
+            self.closed = True
+
+    fake_client = FakeClient()
+    created_names: list[str] = []
+    mapping_calls: list[tuple[str, str, str, str, dict | None]] = []
+
+    async def fake_get_client(scope: str | None = None):
+        assert scope == "global"
+        return fake_client
+
+    async def fake_list_mappings(name: str):
+        assert name == "UniFi"
+        return [SimpleNamespace(entity_id="site-100")]
+
+    existing_org = SimpleNamespace(id="org-existing", name="Existing Org")
+
+    async def fake_list_orgs():
+        return [existing_org]
+
+    async def fake_create_org(name: str):
+        created_names.append(name)
+        return SimpleNamespace(id="org-new", name=name)
+
+    async def fake_upsert_mapping(
+        name: str,
+        *,
+        scope: str,
+        entity_id: str,
+        entity_name: str,
+        config: dict | None = None,
+    ):
+        mapping_calls.append((name, scope, entity_id, entity_name, config))
+
+    monkeypatch.setattr(unifi, "get_client", fake_get_client)
+    monkeypatch.setattr(integrations, "list_mappings", fake_list_mappings)
+    monkeypatch.setattr(integrations, "upsert_mapping", fake_upsert_mapping)
+    monkeypatch.setattr(organizations, "list", fake_list_orgs)
+    monkeypatch.setattr(organizations, "create", fake_create_org)
+
+    result = await sync_unifi_sites()
+
+    assert result == {
+        "total": 4,
+        "mapped": 2,
+        "already_mapped": 1,
+        "created_orgs": 1,
+        "errors": ["Skipped site with no ID: {'id': '', 'name': 'Broken Site'}"],
+    }
+    assert created_names == ["New Org"]
+    assert mapping_calls == [
+        ("UniFi", "org-existing", "site-200", "Existing Org", {"fabric_id": "fab-200"}),
+        ("UniFi", "org-new", "site-300", "New Org", None),
+    ]
+    assert fake_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_sync_unifi_fabrics_maps_unmapped_fabrics(monkeypatch):
+    class FakeClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def list_site_manager_fabrics(self):
+            return [
+                _fabric("fab-100", "Already Mapped"),
+                _fabric("fab-200", "Existing Org Fabric"),
+                _fabric("fab-300", "New Org Fabric"),
+                _fabric(None, "Broken Fabric"),
+            ]
+
+        async def close(self) -> None:
+            self.closed = True
+
+    fake_client = FakeClient()
+    created_names: list[str] = []
+    mapping_calls: list[tuple[str, str, str, str, dict | None]] = []
+
+    async def fake_get_client(scope: str | None = None):
+        assert scope == "global"
+        return fake_client
+
+    async def fake_list_mappings(name: str):
+        assert name == "UniFi"
+        return [SimpleNamespace(entity_id="fabric:fab-100")]
+
+    existing_org = SimpleNamespace(id="org-existing", name="Existing Org Fabric")
+
+    async def fake_list_orgs():
+        return [existing_org]
+
+    async def fake_create_org(name: str):
+        created_names.append(name)
+        return SimpleNamespace(id="org-new", name=name)
+
+    async def fake_upsert_mapping(
+        name: str,
+        *,
+        scope: str,
+        entity_id: str,
+        entity_name: str,
+        config: dict | None = None,
+    ):
+        mapping_calls.append((name, scope, entity_id, entity_name, config))
+
+    monkeypatch.setattr(unifi, "get_client", fake_get_client)
+    monkeypatch.setattr(integrations, "list_mappings", fake_list_mappings)
+    monkeypatch.setattr(integrations, "upsert_mapping", fake_upsert_mapping)
+    monkeypatch.setattr(organizations, "list", fake_list_orgs)
+    monkeypatch.setattr(organizations, "create", fake_create_org)
+
+    result = await sync_unifi_fabrics()
+
+    assert result == {
+        "total": 4,
+        "mapped": 2,
+        "already_mapped": 1,
+        "created_orgs": 1,
+        "errors": ["Skipped fabric with no ID: {'id': '', 'name': 'Broken Fabric'}"],
+    }
+    assert created_names == ["New Org Fabric"]
+    assert mapping_calls == [
+        (
+            "UniFi",
+            "org-existing",
+            "fabric:fab-200",
+            "Existing Org Fabric",
+            {"fabric_id": "fab-200", "mapping_kind": "fabric"},
+        ),
+        (
+            "UniFi",
+            "org-new",
+            "fabric:fab-300",
+            "New Org Fabric",
+            {"fabric_id": "fab-300", "mapping_kind": "fabric"},
+        ),
+    ]
+    assert fake_client.closed is True


### PR DESCRIPTION
### Motivation
- Add a first-class UniFi integration to let Bifrost discover and map UniFi Site Manager sites and Fabrics to customer organizations. 
- Support self-hosted/local controller scenarios by making the local UniFi Network API an optional surface with configurable base URL and TLS verification.
- Preserve fabric context on mappings so policies can be applied at site or fabric granularity.

### Description
- Added a thin async client in `modules/unifi.py` that supports UniFi Site Manager and an optional local Network API, configurable endpoints, TLS verification, `get_client(scope=...)`, and payload normalization via `normalize_site` and `normalize_fabric`.
- Implemented data providers in `features/unifi/workflows/data_providers.py` for `UniFi: List Sites` and `UniFi: List Fabrics` that return sorted `{value,label}` picker options.
- Implemented sync workflows in `features/unifi/workflows/sync_sites.py` and `features/unifi/workflows/sync_fabrics.py` that create/upsert `IntegrationMapping` entries and idempotently match-or-create Bifrost organizations; fabric mappings use `entity_id` prefixed as `fabric:<id>` and include `fabric_id` in mapping config when present.
- Registered the integration and workflow metadata in `.bifrost/integrations.yaml` and `.bifrost/workflows.yaml` so the integration and data providers are discoverable by platform tooling.
- Added integration tests in `tests/integrations/test_unifi_integration.py` that cover client config contract, data-provider sorting, and sync/mapping behavior, and added research notes at `docs/plans/2026-03-29-unifi-integration-landscape.md` documenting Site Manager vs self-hosting and recommended allocation model.

### Testing
- Ran `pytest -q tests/integrations/test_unifi_integration.py` and all tests passed (`6 passed`).
- Ran `python -m compileall modules/unifi.py features/unifi/workflows` to verify syntax/byte-compile; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c924a3dc348328af10f0d0ef5d6c91)