### PR TITLE
[codex] Align event delete CI expectations

### DIFF
--- a/api/src/services/mcp_server/tools/events.py
+++ b/api/src/services/mcp_server/tools/events.py
@@ -474,7 +474,7 @@ async def delete_event_source(
     context: Any,
     source_id: str,
 ) -> ToolResult:
-    """Soft delete an event source."""
+    """Permanently delete an event source."""
     from src.models.enums import EventSourceType
     from src.repositories.events import EventSourceRepository
     from src.services.webhooks.registry import get_adapter_registry
@@ -506,8 +506,7 @@ async def delete_event_source(
                     except Exception as e:
                         logger.warning(f"Failed to unsubscribe webhook: {e}")
 
-            source.is_active = False
-            source.updated_at = datetime.now(_tz.utc)
+            await db.delete(source)
             await db.flush()
 
             display_text = f"Deleted event source: {source.name}"
@@ -717,7 +716,7 @@ async def delete_event_subscription(
     source_id: str,
     subscription_id: str,
 ) -> ToolResult:
-    """Soft delete an event subscription."""
+    """Permanently delete an event subscription."""
     from src.models.orm.events import EventSubscription
 
     logger.info(f"MCP delete_event_subscription called: sub={subscription_id}")
@@ -738,8 +737,7 @@ async def delete_event_subscription(
             if not subscription:
                 return error_result(f"Subscription not found: {subscription_id}")
 
-            subscription.is_active = False
-            subscription.updated_at = datetime.now(_tz.utc)
+            await db.delete(subscription)
             await db.flush()
 
             display_text = f"Deleted subscription {subscription_id}"
@@ -786,11 +784,11 @@ TOOLS = [
     ("create_event_source", "Create Event Source", "Create a new event source (webhook or schedule). Optionally pass workflow_id to auto-create a subscription in one call."),
     ("get_event_source", "Get Event Source", "Get details of a specific event source."),
     ("update_event_source", "Update Event Source", "Update an existing event source."),
-    ("delete_event_source", "Delete Event Source", "Soft delete an event source."),
+    ("delete_event_source", "Delete Event Source", "Permanently delete an event source."),
     ("list_event_subscriptions", "List Event Subscriptions", "List subscriptions for an event source."),
     ("create_event_subscription", "Create Event Subscription", "Create a subscription linking an event source to a workflow."),
     ("update_event_subscription", "Update Event Subscription", "Update an event subscription."),
-    ("delete_event_subscription", "Delete Event Subscription", "Soft delete an event subscription."),
+    ("delete_event_subscription", "Delete Event Subscription", "Permanently delete an event subscription."),
     ("list_webhook_adapters", "List Webhook Adapters", "List available webhook adapters."),
 ]
 

--- a/api/tests/e2e/api/test_events.py
+++ b/api/tests/e2e/api/test_events.py
@@ -82,7 +82,7 @@ def event_source(e2e_client, platform_admin):
 
     yield source
 
-    # Cleanup: soft delete the event source
+    # Cleanup: delete the event source
     e2e_client.delete(
         f"/api/events/sources/{source['id']}",
         headers=platform_admin.headers,
@@ -265,7 +265,7 @@ class TestEventSourceCRUD:
         assert source["name"] == new_name
 
     def test_delete_event_source(self, e2e_client, platform_admin):
-        """Soft delete (deactivate) event source."""
+        """Permanently delete event source."""
         # Create a source to delete
         response = e2e_client.post(
             "/api/events/sources",
@@ -285,13 +285,12 @@ class TestEventSourceCRUD:
         )
         assert response.status_code == 204, f"Delete failed: {response.text}"
 
-        # Verify it's deactivated (not hard deleted)
+        # Verify it's gone
         response = e2e_client.get(
             f"/api/events/sources/{source['id']}",
             headers=platform_admin.headers,
         )
-        assert response.status_code == 200
-        assert response.json()["is_active"] is False
+        assert response.status_code == 404
 
     def test_update_event_source_organization_id(self, e2e_client, platform_admin, org_event_source, org1):
         """Update org-scoped source: clear org (set to null), then set it back."""
@@ -463,7 +462,7 @@ class TestEventSubscriptions:
     def test_delete_subscription(
         self, e2e_client, platform_admin, event_source, test_workflow
     ):
-        """Soft delete subscription."""
+        """Permanently delete subscription."""
         # Create a subscription to delete
         response = e2e_client.post(
             f"/api/events/sources/{event_source['id']}/subscriptions",

--- a/api/tests/unit/services/mcp_server/test_event_tools.py
+++ b/api/tests/unit/services/mcp_server/test_event_tools.py
@@ -224,6 +224,37 @@ class TestDeleteEventSource:
                 assert is_error_result(result)
                 assert "not found" in result.structured_content["error"]
 
+    @pytest.mark.asyncio
+    async def test_deletes_source_row(self, context):
+        """Should permanently delete the event source."""
+        from src.models.enums import EventSourceType
+        from src.services.mcp_server.tools.events import delete_event_source
+
+        source_id = str(uuid4())
+        mock_source = MagicMock()
+        mock_source.id = source_id
+        mock_source.name = "Test source"
+        mock_source.source_type = EventSourceType.INTERNAL
+        mock_source.webhook_source = None
+
+        mock_repo = MagicMock()
+        mock_repo.get_by_id_with_details = AsyncMock(return_value=mock_source)
+
+        with patch("src.core.database.get_db_context") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_db.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with patch(
+                "src.repositories.events.EventSourceRepository",
+                return_value=mock_repo,
+            ):
+                result = await delete_event_source(context, source_id)
+
+        assert not is_error_result(result)
+        mock_session.delete.assert_awaited_once_with(mock_source)
+        mock_session.flush.assert_awaited_once()
+
 
 # ==================== Subscription Tool Tests ====================
 
@@ -340,6 +371,32 @@ class TestDeleteEventSubscription:
         result = await delete_event_subscription(context, str(uuid4()), "")
         assert is_error_result(result)
         assert "required" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_deletes_subscription_row(self, context):
+        """Should permanently delete the event subscription."""
+        from src.services.mcp_server.tools.events import delete_event_subscription
+
+        source_id = str(uuid4())
+        subscription_id = str(uuid4())
+        mock_subscription = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_subscription
+
+        with patch("src.core.database.get_db_context") as mock_db:
+            mock_session = AsyncMock()
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_db.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_db.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await delete_event_subscription(
+                context, source_id, subscription_id
+            )
+
+        assert not is_error_result(result)
+        mock_session.execute.assert_awaited_once()
+        mock_session.delete.assert_awaited_once_with(mock_subscription)
+        mock_session.flush.assert_awaited_once()
 
 
 # ==================== Webhook Adapter Tests ====================


### PR DESCRIPTION
## Summary

Fixes the current `main` CI failure in `tests/e2e/api/test_events.py::TestEventSourceCRUD::test_delete_event_source` by aligning tests and MCP event tools with the current event delete contract.

Root cause: commit `12d4f807e` intentionally changed the REST event source/subscription DELETE endpoints from soft delete to permanent delete, but the E2E test still expected `GET /api/events/sources/{id}` to return the deactivated row after DELETE.

Changes:
- Update the event source E2E delete assertion to expect `404` after permanent deletion.
- Update stale E2E comments/docstrings for event source and subscription deletion.
- Align MCP event delete tools with the same permanent delete behavior.
- Add unit coverage that MCP event source/subscription delete calls `db.delete(...)` and flushes.

## Verification

- `python -m py_compile api/src/services/mcp_server/tools/events.py api/tests/e2e/api/test_events.py api/tests/unit/services/mcp_server/test_event_tools.py`
- `git diff --check`

Not run locally:
- `python -m pytest ...` because the bare Windows Python does not have `pytest` installed.
- `./test.sh ...` because Docker Desktop / WSL Docker integration is not available to this shell. GitHub Actions should run the Docker-backed suite on this PR.

## CI Evidence

Failing run investigated: https://github.com/MTG-Thomas/bifrost/actions/runs/24510883534

Observed failure:
- `tests/e2e/api/test_events.py::TestEventSourceCRUD::test_delete_event_source`
- DELETE returned `204`, then GET returned `404`; the stale test expected `200` plus `is_active == False`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Event deletion behavior updated: event sources and subscriptions are now permanently removed from the database upon deletion, making them completely unavailable, rather than remaining in a deactivated state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->