### PR TITLE
[codex] Stabilize MCP config persistence

### DIFF
--- a/api/src/services/mcp_server/config_service.py
+++ b/api/src/services/mcp_server/config_service.py
@@ -64,7 +64,7 @@ class MCPConfigService:
                 SystemConfig.category == MCP_CONFIG_CATEGORY,
                 SystemConfig.key == MCP_CONFIG_KEY,
                 SystemConfig.organization_id.is_(None),  # Platform-wide config
-            )
+            ).order_by(SystemConfig.updated_at.desc(), SystemConfig.created_at.desc())
         )
         config = result.scalars().first()
 
@@ -117,17 +117,20 @@ class MCPConfigService:
                 SystemConfig.category == MCP_CONFIG_CATEGORY,
                 SystemConfig.key == MCP_CONFIG_KEY,
                 SystemConfig.organization_id.is_(None),
-            )
+            ).order_by(SystemConfig.updated_at.desc(), SystemConfig.created_at.desc())
         )
-        existing = result.scalars().first()
+        existing_configs = list(result.scalars().all())
+        existing = existing_configs[0] if existing_configs else None
 
         now = datetime.now(timezone.utc)
 
         if existing:
-            # Update existing
-            existing.value_json = config_data
-            existing.updated_by = updated_by
-            existing.updated_at = now
+            # Update all matching rows. The table has historical duplicate rows
+            # in some test databases, while this key is intended to be singleton.
+            for config in existing_configs:
+                config.value_json = config_data
+                config.updated_by = updated_by
+                config.updated_at = now
             logger.info(f"MCP config updated by {updated_by}")
         else:
             # Create new
@@ -164,10 +167,11 @@ class MCPConfigService:
                 SystemConfig.organization_id.is_(None),
             )
         )
-        config = result.scalars().first()
+        configs = list(result.scalars().all())
 
-        if config:
-            await self.session.delete(config)
+        if configs:
+            for config in configs:
+                await self.session.delete(config)
             logger.info("MCP config deleted (reverted to defaults)")
             return True
 

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -840,7 +840,9 @@ class TestMCPConfigService:
 
         # Mock no existing config
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars.return_value = mock_scalars
         mock_session.execute = AsyncMock(return_value=mock_result)
         mock_session.add = MagicMock()
 
@@ -867,7 +869,9 @@ class TestMCPConfigService:
         mock_config = MagicMock()
         mock_config.value_json = {"enabled": True, "require_platform_admin": True}
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = mock_config
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [mock_config]
+        mock_result.scalars.return_value = mock_scalars
         mock_session.execute = AsyncMock(return_value=mock_result)
 
         service = MCPConfigService(mock_session)
@@ -885,6 +889,35 @@ class TestMCPConfigService:
         assert mock_config.updated_by == "admin@test.com"
 
     @pytest.mark.asyncio
+    async def test_save_config_updates_duplicate_existing_configs(self, mock_session):
+        """Should update duplicate singleton rows consistently."""
+        from src.services.mcp_server.config_service import MCPConfigService
+
+        first_config = MagicMock()
+        first_config.value_json = {"enabled": True, "blocked_tool_ids": []}
+        second_config = MagicMock()
+        second_config.value_json = {"enabled": True, "blocked_tool_ids": []}
+
+        mock_result = MagicMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [first_config, second_config]
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        service = MCPConfigService(mock_session)
+        config = await service.save_config(
+            enabled=True,
+            require_platform_admin=True,
+            allowed_tool_ids=None,
+            blocked_tool_ids=["search_knowledge"],
+            updated_by="admin@test.com",
+        )
+
+        assert config.blocked_tool_ids == ["search_knowledge"]
+        assert first_config.value_json["blocked_tool_ids"] == ["search_knowledge"]
+        assert second_config.value_json["blocked_tool_ids"] == ["search_knowledge"]
+
+    @pytest.mark.asyncio
     async def test_delete_config_removes_existing(self, mock_session):
         """Should delete existing config."""
         from src.services.mcp_server.config_service import MCPConfigService
@@ -892,7 +925,9 @@ class TestMCPConfigService:
         # Mock existing config
         mock_config = MagicMock()
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = mock_config
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [mock_config]
+        mock_result.scalars.return_value = mock_scalars
         mock_session.execute = AsyncMock(return_value=mock_result)
         mock_session.delete = AsyncMock()
 
@@ -900,7 +935,7 @@ class TestMCPConfigService:
         deleted = await service.delete_config()
 
         assert deleted is True
-        mock_session.delete.assert_called_once_with(mock_config)
+        mock_session.delete.assert_awaited_once_with(mock_config)
 
     @pytest.mark.asyncio
     async def test_delete_config_returns_false_when_none_exists(self, mock_session):
@@ -909,7 +944,9 @@ class TestMCPConfigService:
 
         # Mock no config
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars.return_value = mock_scalars
         mock_session.execute = AsyncMock(return_value=mock_result)
 
         service = MCPConfigService(mock_session)


### PR DESCRIPTION
## Summary

Fixes the next `main` CI failure after PR #113 merged.

Root cause: MCP server config is intended to be a singleton row in `system_configs`, but the table only has non-unique indexes. The config service read, updated, and deleted only the first matching row, so duplicate rows in the test database could make a follow-up `GET /api/mcp/config` read stale/default state after a successful `PUT`.

Changes:
- Read MCP config with newest rows first.
- Update all matching singleton rows when saving MCP config.
- Delete all matching singleton rows when resetting MCP config.
- Add unit coverage for duplicate-row save behavior and update existing mocks for the new multi-row path.

## Verification

- `python -m py_compile api/src/services/mcp_server/config_service.py api/tests/unit/services/test_mcp_tools.py`
- `git diff --check`

Not run locally:
- `python -m pytest ...` because the bare Windows Python does not have `pytest` installed.
- `./test.sh ...` because Docker Desktop / WSL Docker integration is unavailable to this shell.

## CI Evidence

Failing main run investigated: https://github.com/MTG-Thomas/bifrost/actions/runs/24887745859

Observed failure:
- `tests/e2e/api-integration/test_mcp_endpoints.py::TestMCPConfigToolFiltering::test_config_saves_blocked_tool_ids`
- `PUT /api/mcp/config` returned `blocked_tool_ids == ["search_knowledge"]`, but follow-up `GET /api/mcp/config` returned `blocked_tool_ids == []`.