### PR TITLE
ci: notify infra after publishing main images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,18 +166,59 @@ jobs:
     needs: [test, build-api, build-client]
     runs-on: ubuntu-latest
     name: Notify Infra Promotion
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
+      - name: Log in to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install GitHub App auth dependencies
+        run: python3 -m pip install --quiet 'PyJWT[crypto]'
+
       - name: Dispatch infra promotion workflow
         env:
-          GH_TOKEN: ${{ secrets.BIFROST_INFRA_DISPATCH_TOKEN }}
+          KEY_VAULT_NAME: ${{ vars.BIFROST_KEY_VAULT_NAME }}
           SOURCE_SHA: ${{ github.sha }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::BIFROST_INFRA_DISPATCH_TOKEN is required to notify bifrost-infra"
+          if [ -z "${KEY_VAULT_NAME:-}" ]; then
+            echo "::error::BIFROST_KEY_VAULT_NAME repo variable is required"
+            exit 1
+          fi
+
+          app_id="$(az keyvault secret show \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name bifrost--poc--github-app-id \
+            --query value -o tsv)"
+          installation_id="$(az keyvault secret show \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name bifrost--poc--github-app-installation-id \
+            --query value -o tsv)"
+          private_key_file="$(mktemp)"
+          az keyvault secret show \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name bifrost--poc--github-app-private-key \
+            --query value -o tsv > "$private_key_file"
+
+          app_jwt="$(python3 -c 'import pathlib, sys, time, jwt; app_id = sys.argv[1]; private_key = pathlib.Path(sys.argv[2]).read_text(); issued_at = int(time.time()) - 60; print(jwt.encode({"iat": issued_at, "exp": issued_at + 600, "iss": app_id}, private_key, algorithm="RS256"))' "$app_id" "$private_key_file")"
+          rm -f "$private_key_file"
+
+          GH_TOKEN="$(curl --fail-with-body -sS \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $app_jwt" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/app/installations/${installation_id}/access_tokens" | jq -r .token)"
+          if [ -z "$GH_TOKEN" ] || [ "$GH_TOKEN" = "null" ]; then
+            echo "::error::GitHub App installation token exchange failed"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,62 @@ jobs:
           cache-to: type=gha,mode=max
 
   # =============================================================================
+  # Notify Infra - Open/update promotion PR after main images are published
+  # =============================================================================
+  notify-infra:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test, build-api, build-client]
+    runs-on: ubuntu-latest
+    name: Notify Infra Promotion
+
+    steps:
+      - name: Dispatch infra promotion workflow
+        env:
+          GH_TOKEN: ${{ secrets.BIFROST_INFRA_DISPATCH_TOKEN }}
+          SOURCE_SHA: ${{ github.sha }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::BIFROST_INFRA_DISPATCH_TOKEN is required to notify bifrost-infra"
+            exit 1
+          fi
+
+          short_sha="${SOURCE_SHA:0:7}"
+          owner_lc="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          api_image_tag="ghcr.io/${owner_lc}/bifrost-api:sha-${short_sha}"
+          client_image_tag="ghcr.io/${owner_lc}/bifrost-client:sha-${short_sha}"
+          payload="$(jq -n \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg workflow_run_id "$WORKFLOW_RUN_ID" \
+            --arg workflow_run_url "$WORKFLOW_RUN_URL" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg branch "main" \
+            --arg api_image_tag "$api_image_tag" \
+            --arg client_image_tag "$client_image_tag" \
+            '{
+              event_type: "bifrost-platform-images-published",
+              client_payload: {
+                source_sha: $source_sha,
+                workflow_run_id: $workflow_run_id,
+                workflow_run_url: $workflow_run_url,
+                repository: $repository,
+                branch: $branch,
+                api_image_tag: $api_image_tag,
+                client_image_tag: $client_image_tag
+              }
+            }')"
+
+          curl --fail-with-body \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/MTG-Thomas/bifrost-infra/dispatches \
+            -d "$payload"
+
+  # =============================================================================
   # Create GitHub Release - Only on version tags, after images are built
   # =============================================================================
   create-release:


### PR DESCRIPTION
## Summary

Adds a post-publish notification path from platform CI to infra promotion.

- Adds a `notify-infra` job after `test`, `build-api`, and `build-client`.
- Runs only for `push` events on `main`.
- Sends `repository_dispatch` to `MTG-Thomas/bifrost-infra` with source commit, workflow run details, and API/client image tags.
- Uses `BIFROST_INFRA_DISPATCH_TOKEN` as the cross-repo dispatch credential.

## Deployment Boundary

This does not deploy anything. It only asks `bifrost-infra` to open or update the image promotion PR.

## Verification

- Parsed `.github/workflows/ci.yml` with Python YAML loader.
- Ran `git diff --check HEAD~1..HEAD`.

## Follow-up Required

- Add `BIFROST_INFRA_DISPATCH_TOKEN` to the `MTG-Thomas/bifrost` repository secrets before merging, otherwise the new main-only notify job will fail clearly after images publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated infrastructure notifications that trigger when builds complete successfully on the main branch, including robust error handling for configuration and authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->