### PR TITLE
test: make playwright workers configurable

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,5 +1,20 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const DEFAULT_WORKERS = process.env.CI ? 2 : 4;
+
+function parseWorkers(value: string | undefined): number {
+	if (!value) {
+		return DEFAULT_WORKERS;
+	}
+
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed < 1) {
+		return DEFAULT_WORKERS;
+	}
+
+	return parsed;
+}
+
 /**
  * Playwright E2E Test Configuration
  *
@@ -17,7 +32,7 @@ export default defineConfig({
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
-	workers: process.env.CI ? 1 : 4,
+	workers: parseWorkers(process.env.PLAYWRIGHT_WORKERS),
 	timeout: 30000,
 
 	reporter: [

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -416,6 +416,7 @@ services:
       TEST_BASE_URL: http://client:80
       TEST_API_URL: http://api:8000
       CI: "true"
+      PLAYWRIGHT_WORKERS: ${PLAYWRIGHT_WORKERS:-2}
     volumes:
       - ./client/e2e:/app/e2e
       - ./client/playwright.config.ts:/app/playwright.config.ts:ro

--- a/docs/test-performance.md
+++ b/docs/test-performance.md
@@ -1,0 +1,50 @@
+# Test Performance Notes
+
+## Current test paths
+
+`main` now uses the verb-style test runner and split CI jobs:
+
+- `./test.sh stack up` starts the reusable test stack.
+- `./test.sh unit` runs backend unit tests.
+- `./test.sh e2e` runs backend E2E tests.
+- `./test.sh client e2e` runs Playwright browser tests.
+- `./test.sh ci` runs the isolated full local CI path.
+
+PR117 is superseded by this smaller change because the previous branch also carried a stale OAuth fix and old `test.sh` edits. Current `main` already has the larger test runner refactor, so this PR keeps only the remaining low-risk speed knob.
+
+## Playwright workers
+
+Playwright worker count is controlled with `PLAYWRIGHT_WORKERS`.
+
+- CI defaults to `2` workers.
+- Local runs default to `4` workers.
+- Set `PLAYWRIGHT_WORKERS=1` to restore the previous serialized CI behavior.
+- Invalid values fall back to the default instead of failing config load.
+
+When Playwright runs through Docker Compose, `playwright-runner` receives `PLAYWRIGHT_WORKERS` from the host and defaults to `2`.
+
+## Benchmark commands
+
+Use a clean stack for comparable timings:
+
+```bash
+Measure-Command { bash ./test.sh stack up }
+Measure-Command { bash ./test.sh unit }
+Measure-Command { bash ./test.sh e2e }
+Measure-Command { bash ./test.sh client e2e }
+```
+
+Compare Playwright worker settings directly:
+
+```bash
+Measure-Command { $env:PLAYWRIGHT_WORKERS='1'; bash ./test.sh client e2e }
+Measure-Command { $env:PLAYWRIGHT_WORKERS='2'; bash ./test.sh client e2e }
+```
+
+For a config-only check from `client/`:
+
+```bash
+PLAYWRIGHT_WORKERS=1 npx playwright test --list
+PLAYWRIGHT_WORKERS=2 npx playwright test --list
+PLAYWRIGHT_WORKERS=bogus npx playwright test --list
+```


### PR DESCRIPTION
## Summary
- Supersedes #117 with a clean branch from current `main`
- Makes Playwright worker count configurable through `PLAYWRIGHT_WORKERS`
- Passes the worker setting into the Docker Compose Playwright runner
- Adds short test-performance notes for the current verb-style test runner

## Why this replaces #117
#117 carried an older OAuth scope fix that has already landed on `main`, plus edits to the old `test.sh` runner. Current `main` now has split unit/e2e jobs and a rewritten verb-style test runner, so this PR intentionally drops the stale OAuth and shell-runner changes and keeps only the low-risk Playwright efficiency knob.

## Verification
- `git diff --check`
- `docker compose -f docker-compose.test.yml config --quiet`
- confirmed Compose renders `PLAYWRIGHT_WORKERS: "2"` by default
- `PLAYWRIGHT_WORKERS=2 npx playwright test --list --reporter=list`
- `PLAYWRIGHT_WORKERS=1 npx playwright test --list --reporter=list`
- `PLAYWRIGHT_WORKERS=bogus npx playwright test --list --reporter=list`
- `npm run tsc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test execution now supports configurable worker concurrency via the `PLAYWRIGHT_WORKERS` environment variable to control parallel test runs.

* **Documentation**
  * Added test performance guide with instructions on configuring worker counts and benchmarking test execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->