### PR TITLE
Fix dev image versioning for upstream tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch upstream release tags
+        run: |
+          git fetch --tags https://github.com/jackmusick/bifrost.git
+
       - name: Compute version
         id: version
         run: |

--- a/docs/runbooks/dev-version-format.md
+++ b/docs/runbooks/dev-version-format.md
@@ -13,6 +13,10 @@ When a release is cut (e.g. `v0.8.1`), the next merge to main produces
 `0.8.2-dev.1`. The next dev cycle's floor is automatically whatever
 release tag was last cut — no script changes required.
 
+Both annotated and lightweight `vMAJOR.MINOR.PATCH` tags are valid. The dev
+image workflow fetches upstream release tags before computing the version so a
+fork does not need every upstream tag manually mirrored before each sync.
+
 ## Where it's computed
 
 - `scripts/compute-dev-version.sh` — pure shell, takes no args, prints
@@ -62,8 +66,9 @@ After this change ships, in-flight users will see exactly one of:
 
 **Symptom: build fails with `compute-dev-version: no v* tag found in history`**
 
-The job's checkout step doesn't have `fetch-depth: 0`. Check the
-`actions/checkout` invocation in the dev-build job (currently line 191).
+The job cannot see any `vMAJOR.MINOR.PATCH` release tag. Check that the
+dev-build job has `fetch-depth: 0` and that its upstream-tag fetch step still
+runs before `scripts/compute-dev-version.sh`.
 
 **Symptom: build fails with `compute-dev-version: latest tag 'X' is not vMAJOR.MINOR.PATCH`**
 

--- a/scripts/compute-dev-version.sh
+++ b/scripts/compute-dev-version.sh
@@ -4,11 +4,11 @@
 # Format: <next-patch>-dev.<commits-since-tag>
 # Example: latest tag v0.8.0, 47 commits ahead -> 0.8.1-dev.47
 #
-# Requires: a `v<MAJOR>.<MINOR>.<PATCH>` annotated tag in history.
+# Requires: a `v<MAJOR>.<MINOR>.<PATCH>` tag in history.
 # Exits non-zero with a diagnostic on stderr if no usable tag exists.
 set -euo pipefail
 
-last_tag=$(git describe --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || true)
+last_tag=$(git describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || true)
 if [[ -z "$last_tag" ]]; then
   echo "compute-dev-version: no v* tag found in history" >&2
   exit 1

--- a/scripts/test-compute-dev-version.sh
+++ b/scripts/test-compute-dev-version.sh
@@ -70,9 +70,13 @@ run_test "non-v prefixed tag is ignored, falls back" \
   'git commit --allow-empty -m init -q && git tag 1.0.0' \
   '' 1
 
-run_test "lightweight release tag is ignored" \
+run_test "lightweight release tag is accepted" \
   'git commit --allow-empty -m init -q && git tag v1.0.0' \
-  '' 1
+  '1.0.1-dev.0' 0
+
+run_test "latest lightweight tag beats older annotated tag" \
+  'git commit --allow-empty -m init -q && git tag -a v1.0.0 -m v1.0.0 && git commit --allow-empty -m c1 -q && git tag v1.1.0 && git commit --allow-empty -m c2 -q' \
+  '1.1.1-dev.1' 0
 
 echo
 echo "$pass passed, $fail failed"


### PR DESCRIPTION
## Summary
- accept lightweight `vMAJOR.MINOR.PATCH` tags when computing dev image versions
- fetch upstream release tags in the dev-image workflow before version computation, so fork CI does not depend on manually mirrored tags
- update the dev-version runbook and shell test harness for the upstream tag case

## Verification
- `bash scripts/test-compute-dev-version.sh` -> `10 passed, 0 failed`
- `bash -n scripts/compute-dev-version.sh scripts/test-compute-dev-version.sh`
- cloned `MTG-Thomas/bifrost:main` with `--no-tags`: version script failed before fetching tags, then after `git fetch --tags https://github.com/jackmusick/bifrost.git` produced `0.9.1-dev.81`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MTG-Thomas/codesmith/bifrost/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->