### PR TITLE
Harden RabbitMQ delivery outcomes

### DIFF
--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -478,14 +478,6 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 )
 
             logger.error(f"No pending execution found in Redis: {execution_id}")
-            if is_sync:
-                await self._redis_client.push_result(
-                    execution_id=execution_id,
-                    status="Failed",
-                    error="Pending execution not found in Redis",
-                    error_type="PendingNotFound",
-                    duration_ms=0,
-                )
             raise RetryableConsumerError(
                 f"pending execution not found in Redis: {execution_id}"
             )
@@ -741,8 +733,29 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 f"Admission rejected for {execution_id[:8]}: {e}. "
                 "Will requeue for retry."
             )
-            # Don't mark as failed or delete pending state — the execution
-            # hasn't started yet, and retry needs the Redis context.
+            duration_ms = int((datetime.now(timezone.utc) - start_time).total_seconds() * 1000)
+            try:
+                from src.models.enums import ExecutionStatus
+                from src.repositories.executions import update_execution
+
+                await update_execution(
+                    execution_id=execution_id,
+                    status=ExecutionStatus.PENDING,
+                    error_message=f"Process pool admission rejected; retrying: {e}",
+                    error_type="ProcessPoolAdmissionRejected",
+                    duration_ms=duration_ms,
+                )
+                await publish_execution_update(
+                    execution_id,
+                    "Pending",
+                    {"error": str(e), "errorType": "ProcessPoolAdmissionRejected", "retrying": True},
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to compensate RUNNING execution state for retry: {execution_id}"
+                )
+            # Don't mark as terminal or delete pending state — retry needs the
+            # Redis context and may still start successfully.
             raise RetryableConsumerError(
                 f"process pool admission rejected for {execution_id}: {e}"
             ) from e

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -28,7 +28,14 @@ from typing import Any
 
 from src.core.pubsub import publish_execution_update, publish_history_update
 from src.core.redis_client import get_redis_client
-from src.jobs.rabbitmq import BaseConsumer
+from src.jobs.rabbitmq import (
+    BaseConsumer,
+    ConsumerDeliveryError,
+    DomainFailureHandled,
+    DuplicateMessage,
+    MalformedMessage,
+    RetryableConsumerError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +102,33 @@ class WorkflowExecutionConsumer(BaseConsumer):
 
         # Call parent stop
         await super().stop()
+
+    async def _get_existing_execution_status(self, execution_id: str) -> str | None:
+        """Return existing durable execution status for duplicate classification."""
+        from uuid import UUID
+
+        from sqlalchemy import select
+
+        from src.core.database import get_session_factory
+        from src.models.orm.executions import Execution
+
+        try:
+            execution_uuid = UUID(execution_id)
+        except ValueError as e:
+            raise MalformedMessage(f"invalid execution_id UUID: {execution_id}") from e
+
+        session_factory = get_session_factory()
+        async with session_factory() as session:
+            result = await session.execute(
+                select(Execution.status).where(Execution.id == execution_uuid)
+            )
+            status = result.scalar_one_or_none()
+
+        if status is None:
+            return None
+        if hasattr(status, "value"):
+            return status.value
+        return str(status)
 
     async def _handle_result(self, result: dict[str, Any]) -> None:
         """
@@ -423,6 +457,9 @@ class WorkflowExecutionConsumer(BaseConsumer):
         file_path: str | None = None  # Will be set from workflow metadata lookup
         start_time = datetime.now(timezone.utc)
 
+        if not execution_id:
+            raise MalformedMessage("workflow execution message missing execution_id")
+
         # Remove from queue tracking (execution is now being processed)
         await remove_from_queue(execution_id)
 
@@ -430,6 +467,16 @@ class WorkflowExecutionConsumer(BaseConsumer):
         pending = await self._redis_client.get_pending_execution(execution_id)
 
         if pending is None:
+            existing_status = await self._get_existing_execution_status(execution_id)
+            if existing_status is not None:
+                logger.info(
+                    f"No pending execution found in Redis for {execution_id}, "
+                    f"but durable execution already exists with status {existing_status}"
+                )
+                raise DuplicateMessage(
+                    f"workflow execution {execution_id} already exists with status {existing_status}"
+                )
+
             logger.error(f"No pending execution found in Redis: {execution_id}")
             if is_sync:
                 await self._redis_client.push_result(
@@ -439,7 +486,9 @@ class WorkflowExecutionConsumer(BaseConsumer):
                     error_type="PendingNotFound",
                     duration_ms=0,
                 )
-            return
+            raise RetryableConsumerError(
+                f"pending execution not found in Redis: {execution_id}"
+            )
 
         # Extract context from Redis pending record
         parameters = pending["parameters"]
@@ -692,10 +741,13 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 f"Admission rejected for {execution_id[:8]}: {e}. "
                 "Will requeue for retry."
             )
-            # Don't mark as failed — the execution hasn't started yet.
-            # Clean up pending state so it can be re-routed.
-            await self._redis_client.delete_pending_execution(execution_id)
-            # Re-raise so the consumer framework NACKs with requeue=True
+            # Don't mark as failed or delete pending state — the execution
+            # hasn't started yet, and retry needs the Redis context.
+            raise RetryableConsumerError(
+                f"process pool admission rejected for {execution_id}: {e}"
+            ) from e
+
+        except ConsumerDeliveryError:
             raise
 
         except Exception as e:
@@ -755,4 +807,6 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 },
                 exc_info=True,
             )
-            raise
+            raise DomainFailureHandled(
+                f"workflow setup failure recorded for {execution_id}: {error_type}"
+            ) from e

--- a/api/src/jobs/rabbitmq.py
+++ b/api/src/jobs/rabbitmq.py
@@ -6,6 +6,7 @@ background jobs from RabbitMQ queues.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = "1"
 DEFAULT_RETRY_DELAYS_SECONDS = [10, 60, 300, 1800]
+AMQP_SHORTSTR_MAX_BYTES = 255
 
 
 class ConsumerDeliveryError(Exception):
@@ -588,6 +590,13 @@ def infer_idempotency_key(queue_name: str, message: dict[str, Any]) -> str:
     return str(message.get("id") or json.dumps(message, sort_keys=True, default=str))
 
 
+def _bounded_message_id(message_id: str) -> str:
+    """Return a value safe for AMQP shortstr message_id properties."""
+    if len(message_id.encode("utf-8")) <= AMQP_SHORTSTR_MAX_BYTES:
+        return message_id
+    return f"sha256:{hashlib.sha256(message_id.encode('utf-8')).hexdigest()}"
+
+
 def _message_headers(
     message: dict[str, Any],
     origin_queue: str,
@@ -1015,29 +1024,21 @@ async def _publish_once(
                 },
             )
 
-            for idx, delay in enumerate(DEFAULT_RETRY_DELAYS_SECONDS, start=1):
-                await channel.declare_queue(
-                    f"{queue_name}-retry-{idx}",
-                    durable=True,
-                    arguments={
-                        "x-message-ttl": delay * 1000,
-                        "x-dead-letter-exchange": "",
-                        "x-dead-letter-routing-key": queue_name,
-                    },
-                )
-
-            stable_id = message_id or infer_idempotency_key(queue_name, message)
+            stable_id = str(message_id or infer_idempotency_key(queue_name, message))
+            bounded_message_id = _bounded_message_id(stable_id)
+            message_headers = dict(headers or {})
+            message_headers.setdefault("x-idempotency-key", stable_id)
             await channel.default_exchange.publish(
                 aio_pika.Message(
                     body=json.dumps(message).encode(),
                     delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
                     priority=priority,
-                    message_id=stable_id,
+                    message_id=bounded_message_id,
                     headers=_message_headers(
                         message,
                         queue_name,
                         message_id=stable_id,
-                        headers=headers,
+                        headers=message_headers,
                     ),
                 ),
                 routing_key=queue_name,

--- a/api/src/jobs/rabbitmq.py
+++ b/api/src/jobs/rabbitmq.py
@@ -9,6 +9,8 @@ import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 import aio_pika
@@ -19,6 +21,54 @@ from aio_pika.pool import Pool
 from src.config import get_settings
 
 logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1"
+DEFAULT_RETRY_DELAYS_SECONDS = [10, 60, 300, 1800]
+
+
+class ConsumerDeliveryError(Exception):
+    """Base class for explicit consumer delivery outcomes."""
+
+
+class RetryableConsumerError(ConsumerDeliveryError):
+    """Transient infrastructure or admission failure that should retry later."""
+
+
+class PermanentConsumerError(ConsumerDeliveryError):
+    """Message state that cannot succeed by trying again."""
+
+
+class DuplicateMessage(ConsumerDeliveryError):
+    """Message already has durable state and should be acknowledged."""
+
+
+class MalformedMessage(PermanentConsumerError):
+    """Message body or required metadata is malformed."""
+
+
+class DomainFailureHandled(ConsumerDeliveryError):
+    """Domain failure was recorded; broker message can be acknowledged."""
+
+
+class ConsumerShutdown(RetryableConsumerError):
+    """Consumer is stopping and the message should be retried safely."""
+
+
+@dataclass(frozen=True)
+class DeliveryContext:
+    queue_name: str
+    body: dict[str, Any]
+    message_id: str | None
+    correlation_id: str | None
+    headers: dict[str, Any]
+    redelivered: bool
+    delivery_tag: int | None
+    routing_key: str | None
+    exchange: str | None
+    retry_count: int
+    replay_count: int
+    idempotency_key: str | None
+    enqueued_at: str | None
 
 
 class RabbitMQConnection:
@@ -103,6 +153,8 @@ class BaseConsumer(ABC):
         queue_name: str,
         prefetch_count: int = 1,
         dead_letter_exchange: str | None = None,
+        retry_delays_seconds: list[int] | None = None,
+        max_retry_attempts: int | None = None,
     ):
         """
         Initialize consumer.
@@ -115,6 +167,8 @@ class BaseConsumer(ABC):
         self.queue_name = queue_name
         self.prefetch_count = prefetch_count
         self.dead_letter_exchange = dead_letter_exchange or f"{queue_name}-dlx"
+        self.retry_delays_seconds = retry_delays_seconds or DEFAULT_RETRY_DELAYS_SECONDS
+        self.max_retry_attempts = max_retry_attempts or len(self.retry_delays_seconds)
 
         self._channel: AbstractRobustChannel | None = None
         self._queue: aio_pika.Queue | None = None
@@ -149,6 +203,17 @@ class BaseConsumer(ABC):
             durable=True,
         )
         await dlq.bind(dlx, routing_key=self.queue_name)
+
+        for idx, delay in enumerate(self.retry_delays_seconds, start=1):
+            await channel.declare_queue(
+                f"{self.queue_name}-retry-{idx}",
+                durable=True,
+                arguments={
+                    "x-message-ttl": delay * 1000,
+                    "x-dead-letter-exchange": "",
+                    "x-dead-letter-routing-key": self.queue_name,
+                },
+            )
 
         # Declare main queue with dead letter routing
         queue = await channel.declare_queue(
@@ -251,36 +316,245 @@ class BaseConsumer(ABC):
 
         This runs as a separate task to enable concurrent message processing.
         """
-        async with message.process(requeue=False):
-            try:
-                # Parse message body
-                body = json.loads(message.body.decode())
+        started = asyncio.get_running_loop().time()
+        context: DeliveryContext | None = None
+        try:
+            context = self._build_context(message)
 
-                logger.info(
-                    f"Processing message from {self.queue_name}",
-                    extra={"message_id": message.message_id},
-                )
+            logger.info(
+                f"Processing message from {self.queue_name}",
+                extra=self._log_extra(context),
+            )
 
-                # Process the message
-                await self.process_message(body)
+            await self.process_message(context.body)
+            await message.ack()
+            self._log_decision("ack", context, duration=self._duration(started))
+        except DuplicateMessage as e:
+            await message.ack()
+            self._log_decision("duplicate_ack", context, reason=str(e), duration=self._duration(started))
+        except DomainFailureHandled as e:
+            await message.ack()
+            self._log_decision("domain_failure_ack", context, reason=str(e), duration=self._duration(started))
+        except RetryableConsumerError as e:
+            await self._retry_or_poison(message, context, reason=str(e), started=started)
+        except PermanentConsumerError as e:
+            await self._dead_letter_and_ack(message, context, reason=str(e), started=started)
+        except json.JSONDecodeError as e:
+            malformed = self._malformed_context(message)
+            await self._dead_letter_and_ack(message, malformed, reason=f"malformed JSON: {e}", started=started)
+        except asyncio.CancelledError:
+            if context is None:
+                await message.nack(requeue=True)
+            else:
+                await self._retry_or_poison(message, context, reason="consumer shutdown", started=started)
+            raise
+        except Exception as e:
+            logger.exception(
+                "Unhandled consumer exception; dead-lettering message",
+                extra=self._log_extra(context, reason=str(e), error_type=type(e).__name__),
+            )
+            await self._dead_letter_and_ack(message, context, reason=str(e), started=started)
 
-                logger.info(
-                    "Message processed successfully",
-                    extra={"message_id": message.message_id},
-                )
+    def _build_context(self, message: IncomingMessage) -> DeliveryContext:
+        body = json.loads(message.body.decode())
+        if not isinstance(body, dict):
+            raise MalformedMessage("message body must be a JSON object")
+        headers = dict(message.headers or {})
+        retry_count = int(headers.get("x-retry-count") or 0)
+        replay_count = int(headers.get("x-replayed-count") or 0)
+        return DeliveryContext(
+            queue_name=self.queue_name,
+            body=body,
+            message_id=message.message_id,
+            correlation_id=message.correlation_id,
+            headers=headers,
+            redelivered=bool(message.redelivered),
+            delivery_tag=getattr(message, "delivery_tag", None),
+            routing_key=getattr(message, "routing_key", None),
+            exchange=getattr(message, "exchange", None),
+            retry_count=retry_count,
+            replay_count=replay_count,
+            idempotency_key=headers.get("x-idempotency-key") or message.message_id,
+            enqueued_at=headers.get("x-enqueued-at"),
+        )
 
-            except Exception as e:
-                logger.error(
-                    f"Error processing message from {self.queue_name}: {e}",
-                    extra={
-                        "message_id": message.message_id,
-                        "error": str(e),
-                        "error_type": type(e).__name__,
-                    },
-                    exc_info=True,
-                )
-                # Message will be moved to DLQ due to requeue=False
-                raise
+    def _malformed_context(self, message: IncomingMessage) -> DeliveryContext:
+        headers = dict(message.headers or {})
+        return DeliveryContext(
+            queue_name=self.queue_name,
+            body={"_malformed_body": message.body.decode(errors="replace")},
+            message_id=message.message_id,
+            correlation_id=message.correlation_id,
+            headers=headers,
+            redelivered=bool(message.redelivered),
+            delivery_tag=getattr(message, "delivery_tag", None),
+            routing_key=getattr(message, "routing_key", None),
+            exchange=getattr(message, "exchange", None),
+            retry_count=int(headers.get("x-retry-count") or 0),
+            replay_count=int(headers.get("x-replayed-count") or 0),
+            idempotency_key=headers.get("x-idempotency-key") or message.message_id,
+            enqueued_at=headers.get("x-enqueued-at"),
+        )
+
+    async def _retry_or_poison(
+        self,
+        message: IncomingMessage,
+        context: DeliveryContext | None,
+        *,
+        reason: str,
+        started: float,
+    ) -> None:
+        if context is None:
+            await message.nack(requeue=True)
+            return
+        if context.retry_count >= self.max_retry_attempts:
+            await self._dead_letter_and_ack(
+                message,
+                context,
+                reason=f"retry attempts exhausted: {reason}",
+                started=started,
+            )
+            return
+        try:
+            await self._publish_retry(message, context, reason=reason)
+        except Exception:
+            logger.exception(
+                "Failed to publish delayed retry; requeueing original message",
+                extra=self._log_extra(context, reason=reason),
+            )
+            await message.nack(requeue=True)
+            return
+        await message.ack()
+        self._log_decision("retry_scheduled", context, reason=reason, duration=self._duration(started))
+
+    async def _dead_letter_and_ack(
+        self,
+        message: IncomingMessage,
+        context: DeliveryContext | None,
+        *,
+        reason: str,
+        started: float,
+    ) -> None:
+        if context is None:
+            await message.reject(requeue=False)
+            return
+        try:
+            await self._publish_poison(message, context, reason=reason)
+        except Exception:
+            logger.exception(
+                "Failed to publish poison message; requeueing original",
+                extra=self._log_extra(context, reason=reason),
+            )
+            await message.nack(requeue=True)
+            return
+        await message.ack()
+        self._log_decision("dead_lettered", context, reason=reason, duration=self._duration(started))
+
+    async def _publish_retry(self, message: IncomingMessage, context: DeliveryContext, *, reason: str) -> None:
+        if self._channel is None:
+            raise RuntimeError("consumer channel is not available")
+        next_retry = context.retry_count + 1
+        retry_queue = f"{self.queue_name}-retry-{min(next_retry, len(self.retry_delays_seconds))}"
+        context_headers = dict(context.headers)
+        if context.idempotency_key:
+            context_headers.setdefault("x-idempotency-key", context.idempotency_key)
+        headers = _message_headers(
+            context.body,
+            self.queue_name,
+            message_id=context.message_id,
+            headers=context_headers,
+            retry_count=next_retry,
+            replay_count=context.replay_count,
+        )
+        headers["x-last-error"] = reason[:500]
+        await self._channel.default_exchange.publish(
+            aio_pika.Message(
+                body=json.dumps(context.body).encode(),
+                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                message_id=context.message_id,
+                correlation_id=context.correlation_id,
+                headers=headers,
+            ),
+            routing_key=retry_queue,
+        )
+
+    async def _publish_poison(self, message: IncomingMessage, context: DeliveryContext, *, reason: str) -> None:
+        if self._channel is None:
+            raise RuntimeError("consumer channel is not available")
+        context_headers = dict(context.headers)
+        if context.idempotency_key:
+            context_headers.setdefault("x-idempotency-key", context.idempotency_key)
+        headers = _message_headers(
+            context.body,
+            self.queue_name,
+            message_id=context.message_id,
+            headers=context_headers,
+            retry_count=context.retry_count,
+            replay_count=context.replay_count,
+        )
+        headers["x-poison-reason"] = reason[:500]
+        headers["x-poisoned-at"] = datetime.now(timezone.utc).isoformat()
+        exchange = await self._channel.declare_exchange(
+            self.dead_letter_exchange,
+            aio_pika.ExchangeType.DIRECT,
+            durable=True,
+        )
+        await exchange.publish(
+            aio_pika.Message(
+                body=json.dumps(context.body).encode(),
+                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                message_id=context.message_id,
+                correlation_id=context.correlation_id,
+                headers=headers,
+            ),
+            routing_key=self.queue_name,
+        )
+
+    def _duration(self, started: float) -> float:
+        return asyncio.get_running_loop().time() - started
+
+    def _log_extra(
+        self,
+        context: DeliveryContext | None,
+        *,
+        reason: str | None = None,
+        error_type: str | None = None,
+        duration: float | None = None,
+    ) -> dict[str, Any]:
+        extra: dict[str, Any] = {"queue": self.queue_name}
+        if reason is not None:
+            extra["reason"] = reason
+        if error_type is not None:
+            extra["error_type"] = error_type
+        if duration is not None:
+            extra["duration_seconds"] = duration
+        if context is not None:
+            extra.update(
+                {
+                    "message_id": context.message_id,
+                    "correlation_id": context.correlation_id,
+                    "idempotency_key": context.idempotency_key,
+                    "retry_count": context.retry_count,
+                    "replay_count": context.replay_count,
+                    "redelivered": context.redelivered,
+                }
+            )
+            if context.enqueued_at:
+                extra["enqueued_at"] = context.enqueued_at
+        return extra
+
+    def _log_decision(
+        self,
+        decision: str,
+        context: DeliveryContext | None,
+        *,
+        reason: str | None = None,
+        duration: float | None = None,
+    ) -> None:
+        logger.info(
+            "RabbitMQ message decision",
+            extra={"decision": decision, **self._log_extra(context, reason=reason, duration=duration)},
+        )
 
     @abstractmethod
     async def process_message(self, body: dict[str, Any]) -> None:
@@ -293,6 +567,51 @@ class BaseConsumer(ABC):
             body: Parsed message body
         """
         pass
+
+
+def infer_idempotency_key(queue_name: str, message: dict[str, Any]) -> str:
+    """Return a stable key used in broker headers for observability and replay."""
+    if "idempotency_key" in message:
+        return str(message["idempotency_key"])
+    if queue_name == "workflow-executions" and message.get("execution_id"):
+        return str(message["execution_id"])
+    if queue_name == "agent-runs" and message.get("run_id"):
+        return str(message["run_id"])
+    if queue_name == "agent-summarization" and message.get("run_id"):
+        return str(message["run_id"])
+    if queue_name == "agent-summarization-backfill" and message.get("run_id"):
+        return f"{message['run_id']}:{message.get('backfill_job_id') or 'live'}"
+    if queue_name == "agent-tuning-chat" and message.get("turn_id"):
+        return str(message["turn_id"])
+    if queue_name == "agent-tuning-chat" and message.get("run_id"):
+        return f"{message['run_id']}:{message.get('message_id') or message.get('content')}"
+    return str(message.get("id") or json.dumps(message, sort_keys=True, default=str))
+
+
+def _message_headers(
+    message: dict[str, Any],
+    origin_queue: str,
+    *,
+    message_id: str | None = None,
+    headers: dict[str, Any] | None = None,
+    retry_count: int = 0,
+    replay_count: int = 0,
+) -> dict[str, Any]:
+    merged = dict(headers or {})
+    idempotency_key = merged.get("x-idempotency-key") or infer_idempotency_key(origin_queue, message)
+    merged.update(
+        {
+            "x-idempotency-key": str(idempotency_key),
+            "x-origin-queue": merged.get("x-origin-queue") or origin_queue,
+            "x-schema-version": merged.get("x-schema-version") or SCHEMA_VERSION,
+            "x-enqueued-at": merged.get("x-enqueued-at") or datetime.now(timezone.utc).isoformat(),
+            "x-retry-count": retry_count,
+            "x-replayed-count": replay_count,
+        }
+    )
+    if message_id and "x-original-message-id" not in merged:
+        merged["x-original-message-id"] = message_id
+    return merged
 
 
 class BroadcastConsumer(ABC):
@@ -666,6 +985,9 @@ async def _publish_once(
     queue_name: str,
     message: dict[str, Any],
     priority: int,
+    *,
+    message_id: str | None = None,
+    headers: dict[str, Any] | None = None,
 ) -> None:
     async with rabbitmq.get_connection() as connection:
         channel = await connection.channel()
@@ -693,11 +1015,30 @@ async def _publish_once(
                 },
             )
 
+            for idx, delay in enumerate(DEFAULT_RETRY_DELAYS_SECONDS, start=1):
+                await channel.declare_queue(
+                    f"{queue_name}-retry-{idx}",
+                    durable=True,
+                    arguments={
+                        "x-message-ttl": delay * 1000,
+                        "x-dead-letter-exchange": "",
+                        "x-dead-letter-routing-key": queue_name,
+                    },
+                )
+
+            stable_id = message_id or infer_idempotency_key(queue_name, message)
             await channel.default_exchange.publish(
                 aio_pika.Message(
                     body=json.dumps(message).encode(),
                     delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
                     priority=priority,
+                    message_id=stable_id,
+                    headers=_message_headers(
+                        message,
+                        queue_name,
+                        message_id=stable_id,
+                        headers=headers,
+                    ),
                 ),
                 routing_key=queue_name,
             )
@@ -711,6 +1052,9 @@ async def publish_message(
     queue_name: str,
     message: dict[str, Any],
     priority: int = 0,
+    *,
+    message_id: str | None = None,
+    headers: dict[str, Any] | None = None,
 ) -> None:
     """
     Publish a message to a queue.
@@ -729,7 +1073,7 @@ async def publish_message(
     last_exc: BaseException | None = None
     for attempt, delay in enumerate((*_PUBLISH_RETRY_DELAYS_S, None)):
         try:
-            await _publish_once(queue_name, message, priority)
+            await _publish_once(queue_name, message, priority, message_id=message_id, headers=headers)
             return
         except Exception as exc:
             if not _is_transient_publish_error(exc):

--- a/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
+++ b/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
@@ -1,0 +1,174 @@
+"""Delivery outcome tests for the workflow execution consumer."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.jobs.consumers.workflow_execution import WorkflowExecutionConsumer
+from src.jobs.rabbitmq import (
+    DomainFailureHandled,
+    DuplicateMessage,
+    MalformedMessage,
+    RetryableConsumerError,
+)
+
+
+def make_consumer() -> WorkflowExecutionConsumer:
+    """Create a consumer without wiring real Redis, RabbitMQ, or process pool clients."""
+    with patch.object(WorkflowExecutionConsumer, "__init__", lambda self: None):
+        consumer = WorkflowExecutionConsumer()
+
+    consumer._redis_client = AsyncMock()
+    return consumer
+
+
+def pending_context() -> dict[str, object]:
+    return {
+        "parameters": {},
+        "org_id": None,
+        "user_id": str(uuid4()),
+        "user_name": "Test User",
+        "user_email": "test@example.com",
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_message_rejects_missing_execution_id() -> None:
+    consumer = make_consumer()
+    consumer._redis_client.get_pending_execution.return_value = None
+
+    with patch(
+        "src.services.execution.queue_tracker.remove_from_queue",
+        new_callable=AsyncMock,
+    ) as remove_from_queue:
+        with pytest.raises(MalformedMessage, match="execution_id"):
+            await consumer.process_message({})
+
+    remove_from_queue.assert_not_called()
+    consumer._redis_client.get_pending_execution.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_message_treats_existing_execution_without_pending_context_as_duplicate() -> None:
+    consumer = make_consumer()
+    execution_id = str(uuid4())
+    consumer._redis_client.get_pending_execution.return_value = None
+    consumer._get_existing_execution_status = AsyncMock(return_value="Success")  # type: ignore[attr-defined]
+
+    with patch(
+        "src.services.execution.queue_tracker.remove_from_queue",
+        new_callable=AsyncMock,
+    ) as remove_from_queue:
+        with pytest.raises(DuplicateMessage, match="already exists"):
+            await consumer.process_message({"execution_id": execution_id})
+
+    remove_from_queue.assert_awaited_once_with(execution_id)
+    consumer._get_existing_execution_status.assert_awaited_once_with(execution_id)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_process_message_retries_missing_pending_context() -> None:
+    consumer = make_consumer()
+    execution_id = str(uuid4())
+    consumer._redis_client.get_pending_execution.return_value = None
+    consumer._redis_client.push_result = AsyncMock()
+    consumer._get_existing_execution_status = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+
+    with patch(
+        "src.services.execution.queue_tracker.remove_from_queue",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(RetryableConsumerError, match="pending execution"):
+            await consumer.process_message({"execution_id": execution_id, "sync": True})
+
+    consumer._redis_client.push_result.assert_awaited_once_with(
+        execution_id=execution_id,
+        status="Failed",
+        error="Pending execution not found in Redis",
+        error_type="PendingNotFound",
+        duration_ms=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_message_retries_pool_admission_memory_pressure_without_deleting_pending() -> None:
+    consumer = make_consumer()
+    execution_id = str(uuid4())
+    consumer._pool = AsyncMock()
+    consumer._pool.route_execution = AsyncMock(side_effect=MemoryError("limit reached"))
+    consumer._redis_client.get_pending_execution.return_value = pending_context()
+    consumer._redis_client.delete_pending_execution = AsyncMock()
+
+    with (
+        patch(
+            "src.services.execution.queue_tracker.remove_from_queue",
+            new_callable=AsyncMock,
+        ),
+        patch("src.repositories.executions.create_execution", new_callable=AsyncMock),
+        patch(
+            "src.jobs.consumers.workflow_execution.publish_execution_update",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.jobs.consumers.workflow_execution.publish_history_update",
+            new_callable=AsyncMock,
+        ),
+    ):
+        with pytest.raises(RetryableConsumerError, match="admission"):
+            await consumer.process_message(
+                {
+                    "execution_id": execution_id,
+                    "code": "cHJpbnQoJ2hpJyk=",
+                    "script_name": "inline.py",
+                }
+            )
+
+    consumer._redis_client.delete_pending_execution.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_message_acknowledges_recorded_setup_failure_as_domain_handled() -> None:
+    consumer = make_consumer()
+    execution_id = str(uuid4())
+    consumer._pool = AsyncMock()
+    consumer._pool.route_execution = AsyncMock(side_effect=ValueError("bad setup"))
+    consumer._redis_client.get_pending_execution.return_value = pending_context()
+    consumer._redis_client.delete_pending_execution = AsyncMock()
+    consumer._redis_client.push_result = AsyncMock()
+
+    with (
+        patch(
+            "src.services.execution.queue_tracker.remove_from_queue",
+            new_callable=AsyncMock,
+        ),
+        patch("src.repositories.executions.create_execution", new_callable=AsyncMock),
+        patch("src.repositories.executions.update_execution", new_callable=AsyncMock) as update_execution,
+        patch(
+            "src.jobs.consumers.workflow_execution.publish_execution_update",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "src.jobs.consumers.workflow_execution.publish_history_update",
+            new_callable=AsyncMock,
+        ),
+    ):
+        with pytest.raises(DomainFailureHandled, match="workflow setup failure"):
+            await consumer.process_message(
+                {
+                    "execution_id": execution_id,
+                    "code": "cHJpbnQoJ2hpJyk=",
+                    "script_name": "inline.py",
+                    "sync": True,
+                }
+            )
+
+    update_execution.assert_awaited_once()
+    consumer._redis_client.delete_pending_execution.assert_awaited_once_with(execution_id)
+    consumer._redis_client.push_result.assert_awaited_once_with(
+        execution_id=execution_id,
+        status="Failed",
+        error="bad setup",
+        error_type="ValueError",
+        duration_ms=pytest.approx(0, abs=1000),
+    )

--- a/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
+++ b/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
@@ -12,6 +12,7 @@ from src.jobs.rabbitmq import (
     MalformedMessage,
     RetryableConsumerError,
 )
+from src.models.enums import ExecutionStatus
 
 
 def make_consumer() -> WorkflowExecutionConsumer:
@@ -82,13 +83,7 @@ async def test_process_message_retries_missing_pending_context() -> None:
         with pytest.raises(RetryableConsumerError, match="pending execution"):
             await consumer.process_message({"execution_id": execution_id, "sync": True})
 
-    consumer._redis_client.push_result.assert_awaited_once_with(
-        execution_id=execution_id,
-        status="Failed",
-        error="Pending execution not found in Redis",
-        error_type="PendingNotFound",
-        duration_ms=0,
-    )
+    consumer._redis_client.push_result.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -106,6 +101,7 @@ async def test_process_message_retries_pool_admission_memory_pressure_without_de
             new_callable=AsyncMock,
         ),
         patch("src.repositories.executions.create_execution", new_callable=AsyncMock),
+        patch("src.repositories.executions.update_execution", new_callable=AsyncMock) as update_execution,
         patch(
             "src.jobs.consumers.workflow_execution.publish_execution_update",
             new_callable=AsyncMock,
@@ -125,6 +121,10 @@ async def test_process_message_retries_pool_admission_memory_pressure_without_de
             )
 
     consumer._redis_client.delete_pending_execution.assert_not_called()
+    update_execution.assert_awaited_once()
+    assert update_execution.await_args is not None
+    assert update_execution.await_args.kwargs["execution_id"] == execution_id
+    assert update_execution.await_args.kwargs["status"] == ExecutionStatus.PENDING
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/jobs/test_rabbitmq_delivery.py
+++ b/api/tests/unit/jobs/test_rabbitmq_delivery.py
@@ -11,6 +11,9 @@ from src.jobs.rabbitmq import (
     DuplicateMessage,
     PermanentConsumerError,
     RetryableConsumerError,
+    _publish_once,
+    infer_idempotency_key,
+    rabbitmq,
 )
 
 
@@ -225,6 +228,80 @@ async def test_publish_poison_routes_to_dlx_with_reason_headers() -> None:
     assert published.headers["x-retry-count"] == 2
     assert published.headers["x-poison-reason"] == "bad forever"
     assert "x-poisoned-at" in published.headers
+
+
+class FakeDeclaredQueue:
+    def __init__(self) -> None:
+        self.bind = AsyncMock()
+
+
+class FakePublishChannel:
+    def __init__(self) -> None:
+        self.default_exchange = FakeExchange()
+        self.dead_letter_exchange = FakeExchange()
+        self.declare_exchange = AsyncMock(return_value=self.dead_letter_exchange)
+        self.declare_queue = AsyncMock(return_value=FakeDeclaredQueue())
+        self.close = AsyncMock()
+
+
+class FakeConnection:
+    def __init__(self, channel: FakePublishChannel) -> None:
+        self._channel = channel
+
+    async def channel(self) -> FakePublishChannel:
+        return self._channel
+
+
+class FakeConnectionContext:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._connection
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_publish_once_does_not_redeclare_retry_queues() -> None:
+    channel = FakePublishChannel()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            rabbitmq,
+            "get_connection",
+            lambda: FakeConnectionContext(FakeConnection(channel)),
+        )
+
+        await _publish_once("unit-queue", {"id": "msg-1"}, 0)
+
+    declared_names = [call.args[0] for call in channel.declare_queue.await_args_list]
+    assert declared_names == ["unit-queue-poison", "unit-queue"]
+
+
+@pytest.mark.asyncio
+async def test_publish_once_bounds_message_id_and_preserves_full_idempotency_key() -> None:
+    channel = FakePublishChannel()
+    message = {"content": "x" * 600}
+    full_idempotency_key = infer_idempotency_key("unit-queue", message)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            rabbitmq,
+            "get_connection",
+            lambda: FakeConnectionContext(FakeConnection(channel)),
+        )
+
+        await _publish_once("unit-queue", message, 0)
+
+    publish_call = channel.default_exchange.publish.await_args
+    assert publish_call is not None
+    published, = publish_call.args
+    assert len(published.message_id.encode()) <= 255
+    assert published.message_id != full_idempotency_key
+    assert published.headers["x-idempotency-key"] == full_idempotency_key
+    assert published.headers["x-original-message-id"] == full_idempotency_key
 
 
 class BasePublishConsumer(BaseConsumer):

--- a/api/tests/unit/jobs/test_rabbitmq_delivery.py
+++ b/api/tests/unit/jobs/test_rabbitmq_delivery.py
@@ -1,0 +1,235 @@
+"""Unit tests for RabbitMQ delivery outcome decisions."""
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.jobs.rabbitmq import (
+    BaseConsumer,
+    DuplicateMessage,
+    PermanentConsumerError,
+    RetryableConsumerError,
+)
+
+
+class FakeMessage:
+    def __init__(
+        self,
+        body: str | bytes,
+        *,
+        headers: dict[str, Any] | None = None,
+        message_id: str = "msg-1",
+    ):
+        self.body = body if isinstance(body, bytes) else body.encode()
+        self.headers = headers or {}
+        self.message_id = message_id
+        self.correlation_id = "corr-1"
+        self.redelivered = False
+        self.delivery_tag = 1
+        self.routing_key = "unit-queue"
+        self.exchange = ""
+        self.ack = AsyncMock()
+        self.nack = AsyncMock()
+        self.reject = AsyncMock()
+
+    def process(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("delivery outcomes should ack/nack/reject explicitly")
+
+
+class UnitConsumer(BaseConsumer):
+    def __init__(self, outcome: str = "success"):
+        super().__init__(
+            "unit-queue",
+            prefetch_count=1,
+            retry_delays_seconds=[1, 2],
+            max_retry_attempts=2,
+        )
+        self.outcome = outcome
+        self.retry_payloads: list[tuple[dict[str, Any], int, str]] = []
+        self.poison_payloads: list[tuple[dict[str, Any], str]] = []
+
+    async def process_message(self, body: dict[str, Any]) -> None:
+        if self.outcome == "duplicate":
+            raise DuplicateMessage("already handled")
+        if self.outcome == "retry":
+            raise RetryableConsumerError("temporarily broken")
+        if self.outcome == "permanent":
+            raise PermanentConsumerError("bad state")
+        if self.outcome == "unexpected":
+            raise RuntimeError("surprising failure")
+
+    async def _publish_retry(self, message: Any, context: Any, *, reason: str) -> None:
+        self.retry_payloads.append((context.body, context.retry_count + 1, reason))
+
+    async def _publish_poison(self, message: Any, context: Any, *, reason: str) -> None:
+        self.poison_payloads.append((context.body, reason))
+
+
+class FakeExchange:
+    def __init__(self) -> None:
+        self.publish = AsyncMock()
+
+
+class FakeChannel:
+    def __init__(self) -> None:
+        self.default_exchange = FakeExchange()
+        self.poison_exchange = FakeExchange()
+        self.declare_exchange = AsyncMock(return_value=self.poison_exchange)
+
+
+@pytest.mark.asyncio
+async def test_success_acks_message() -> None:
+    consumer = UnitConsumer()
+    message = FakeMessage(json.dumps({"ok": True}))
+
+    await consumer._process_message_with_ack(message)
+
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
+    message.reject.assert_not_awaited()
+    assert consumer.retry_payloads == []
+    assert consumer.poison_payloads == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_acks_message_without_retry() -> None:
+    consumer = UnitConsumer("duplicate")
+    message = FakeMessage(json.dumps({"ok": True}))
+
+    await consumer._process_message_with_ack(message)
+
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
+    assert consumer.retry_payloads == []
+    assert consumer.poison_payloads == []
+
+
+@pytest.mark.asyncio
+async def test_retryable_error_publishes_retry_then_acks_original() -> None:
+    consumer = UnitConsumer("retry")
+    message = FakeMessage(json.dumps({"ok": True}))
+
+    await consumer._process_message_with_ack(message)
+
+    assert consumer.retry_payloads == [({"ok": True}, 1, "temporarily broken")]
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
+    assert consumer.poison_payloads == []
+
+
+@pytest.mark.asyncio
+async def test_retry_publish_failure_requeues_original() -> None:
+    consumer = UnitConsumer("retry")
+    consumer._publish_retry = AsyncMock(side_effect=RuntimeError("broker down"))  # type: ignore[method-assign]
+    message = FakeMessage(json.dumps({"ok": True}))
+
+    await consumer._process_message_with_ack(message)
+
+    message.ack.assert_not_awaited()
+    message.nack.assert_awaited_once_with(requeue=True)
+
+
+@pytest.mark.asyncio
+async def test_max_retry_exhaustion_publishes_poison_then_acks_original() -> None:
+    consumer = UnitConsumer("retry")
+    message = FakeMessage(
+        json.dumps({"ok": True}),
+        headers={"x-retry-count": 2},
+    )
+
+    await consumer._process_message_with_ack(message)
+
+    assert consumer.poison_payloads
+    assert "retry attempts exhausted" in consumer.poison_payloads[0][1]
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_permanent_error_publishes_poison_then_acks_original() -> None:
+    consumer = UnitConsumer("permanent")
+    message = FakeMessage(json.dumps({"ok": True}))
+
+    await consumer._process_message_with_ack(message)
+
+    assert consumer.poison_payloads == [({"ok": True}, "bad state")]
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_publishes_poison_then_acks_original() -> None:
+    consumer = UnitConsumer("unexpected")
+    message = FakeMessage(json.dumps({"ok": True}))
+
+    await consumer._process_message_with_ack(message)
+
+    assert consumer.poison_payloads == [({"ok": True}, "surprising failure")]
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_publishes_poison_then_acks_original() -> None:
+    consumer = UnitConsumer()
+    message = FakeMessage("{not-json")
+
+    await consumer._process_message_with_ack(message)
+
+    assert consumer.poison_payloads
+    assert "malformed JSON" in consumer.poison_payloads[0][1]
+    message.ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_publish_retry_routes_to_delayed_queue_with_retry_headers() -> None:
+    consumer = BasePublishConsumer()
+    channel = FakeChannel()
+    consumer._channel = channel  # type: ignore[assignment]
+    message = FakeMessage(json.dumps({"execution_id": "exec-1"}), message_id="msg-1")
+    context = consumer._build_context(message)
+
+    await consumer._publish_retry(message, context, reason="try later")
+
+    channel.default_exchange.publish.assert_awaited_once()
+    retry_call = channel.default_exchange.publish.await_args
+    assert retry_call is not None
+    published, = retry_call.args
+    assert retry_call.kwargs == {"routing_key": "unit-queue-retry-1"}
+    assert published.message_id == "msg-1"
+    assert published.headers["x-retry-count"] == 1
+    assert published.headers["x-replayed-count"] == 0
+    assert published.headers["x-origin-queue"] == "unit-queue"
+    assert published.headers["x-idempotency-key"] == "msg-1"
+    assert published.headers["x-last-error"] == "try later"
+
+
+@pytest.mark.asyncio
+async def test_publish_poison_routes_to_dlx_with_reason_headers() -> None:
+    consumer = BasePublishConsumer()
+    channel = FakeChannel()
+    consumer._channel = channel  # type: ignore[assignment]
+    message = FakeMessage(json.dumps({"ok": True}), headers={"x-retry-count": 2})
+    context = consumer._build_context(message)
+
+    await consumer._publish_poison(message, context, reason="bad forever")
+
+    channel.declare_exchange.assert_awaited_once()
+    channel.poison_exchange.publish.assert_awaited_once()
+    poison_call = channel.poison_exchange.publish.await_args
+    assert poison_call is not None
+    published, = poison_call.args
+    assert poison_call.kwargs == {"routing_key": "unit-queue"}
+    assert published.headers["x-retry-count"] == 2
+    assert published.headers["x-poison-reason"] == "bad forever"
+    assert "x-poisoned-at" in published.headers
+
+
+class BasePublishConsumer(BaseConsumer):
+    def __init__(self) -> None:
+        super().__init__("unit-queue")
+
+    async def process_message(self, body: dict[str, Any]) -> None:
+        return None


### PR DESCRIPTION
## Summary
- add explicit RabbitMQ delivery outcome classes and retry/poison publishing paths
- classify workflow execution duplicates, malformed messages, retryable Redis-context misses, pool admission pressure, and already-recorded setup failures
- add focused unit coverage for broker outcome handling and workflow execution classification

## Verification
- ruff check api/src/jobs/consumers/workflow_execution.py api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
- ./test.sh tests/unit/jobs/consumers/test_workflow_execution_delivery.py tests/unit/jobs/consumers/test_workflow_execution_session.py tests/unit/jobs/test_rabbitmq_delivery.py tests/unit/jobs/test_rabbitmq_drain.py -q (27 passed)

## Notes
- Scope is intentionally limited to the shared RabbitMQ layer plus the workflow execution queue. Agent-run and summarization queues have separate domain semantics and can be handled as follow-up slices if we want them in the same hardening track.
- Pyright was not available on the Windows host PATH or in the Docker test-runner image for this worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MTG-Thomas/codesmith/bifrost/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable retry delays and maximum retry attempts for failed workflow executions
  * Added intelligent duplicate detection with durable state querying

* **Bug Fixes**
  * Improved handling of malformed and missing execution states
  * Enhanced failure classification to distinguish between retryable and permanent errors
  * Better preservation of message context during failures

* **Tests**
  * Added comprehensive delivery outcome testing for message processing and retry behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/170)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->