### PR TITLE
ci: support fork-local release images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  API_IMAGE: mtg-thomas/bifrost-api
-  CLIENT_IMAGE: mtg-thomas/bifrost-client
+  IMAGE_NAMESPACE: mtg-thomas
+  API_IMAGE: bifrost-api
+  CLIENT_IMAGE: bifrost-client
 
 permissions:
   contents: read
@@ -225,9 +226,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/${{ env.API_IMAGE }}:${{ steps.version.outputs.version }}
-            ghcr.io/${{ env.API_IMAGE }}:dev
-            ghcr.io/${{ env.API_IMAGE }}:sha-${{ steps.version.outputs.short_sha }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}:dev
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}:sha-${{ steps.version.outputs.short_sha }}
           build-args: |
             BIFROST_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
@@ -238,12 +239,12 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign --yes \
-            ghcr.io/${{ env.API_IMAGE }}@${{ steps.build-api.outputs.digest }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}@${{ steps.build-api.outputs.digest }}
 
       - name: Attest API dev image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: ghcr.io/${{ env.API_IMAGE }}
+          subject-name: ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}
           subject-digest: ${{ steps.build-api.outputs.digest }}
           push-to-registry: true
 
@@ -257,9 +258,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/${{ env.CLIENT_IMAGE }}:${{ steps.version.outputs.version }}
-            ghcr.io/${{ env.CLIENT_IMAGE }}:dev
-            ghcr.io/${{ env.CLIENT_IMAGE }}:sha-${{ steps.version.outputs.short_sha }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}:dev
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}:sha-${{ steps.version.outputs.short_sha }}
           build-args: |
             VITE_BIFROST_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
@@ -270,12 +271,12 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign --yes \
-            ghcr.io/${{ env.CLIENT_IMAGE }}@${{ steps.build-client.outputs.digest }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}@${{ steps.build-client.outputs.digest }}
 
       - name: Attest client dev image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: ghcr.io/${{ env.CLIENT_IMAGE }}
+          subject-name: ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}
           subject-digest: ${{ steps.build-client.outputs.digest }}
           push-to-registry: true
 
@@ -459,7 +460,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.API_IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}
           tags: |
             # Semantic version tags
             type=semver,pattern={{version}}
@@ -489,12 +490,12 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign --yes \
-            ghcr.io/${{ env.API_IMAGE }}@${{ steps.build-api.outputs.digest }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}@${{ steps.build-api.outputs.digest }}
 
       - name: Attest API image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: ghcr.io/${{ env.API_IMAGE }}
+          subject-name: ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}
           subject-digest: ${{ steps.build-api.outputs.digest }}
           push-to-registry: true
 
@@ -541,7 +542,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.CLIENT_IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}
           tags: |
             # Semantic version tags
             type=semver,pattern={{version}}
@@ -572,12 +573,12 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign --yes \
-            ghcr.io/${{ env.CLIENT_IMAGE }}@${{ steps.build-client.outputs.digest }}
+            ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}@${{ steps.build-client.outputs.digest }}
 
       - name: Attest client image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: ghcr.io/${{ env.CLIENT_IMAGE }}
+          subject-name: ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}
           subject-digest: ${{ steps.build-client.outputs.digest }}
           push-to-registry: true
 
@@ -683,12 +684,12 @@ jobs:
 
             **API:**
             ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.API_IMAGE }}:${{ steps.get_version.outputs.version }}
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}:${{ steps.get_version.outputs.version }}
             ```
 
             **Client:**
             ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.CLIENT_IMAGE }}:${{ steps.get_version.outputs.version }}
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}:${{ steps.get_version.outputs.version }}
             ```
 
             ### Type Stubs for IDEs
@@ -716,7 +717,7 @@ jobs:
 
             ```bash
             gh attestation verify bifrost-${{ steps.get_version.outputs.version }}-source.tar.gz \
-              --owner jackmusick
+              --owner MTG-Thomas
             ```
 
           draft: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "image_tag=${VERSION#v}" >> $GITHUB_OUTPUT
           # Check if this is a pre-release (contains hyphen like v1.0.0-beta)
           if [[ "$VERSION" == *-* ]]; then
             echo "prerelease=true" >> $GITHUB_OUTPUT
@@ -684,12 +685,12 @@ jobs:
 
             **API:**
             ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}:${{ steps.get_version.outputs.version }}
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}:${{ steps.get_version.outputs.image_tag }}
             ```
 
             **Client:**
             ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}:${{ steps.get_version.outputs.version }}
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}:${{ steps.get_version.outputs.image_tag }}
             ```
 
             ### Type Stubs for IDEs

--- a/scripts/compute-dev-version.sh
+++ b/scripts/compute-dev-version.sh
@@ -5,10 +5,17 @@
 # Example: latest tag v0.8.0, 47 commits ahead -> 0.8.1-dev.47
 #
 # Requires: a `v<MAJOR>.<MINOR>.<PATCH>` tag in history.
+# Fork-local prerelease tags such as `v0.9.1-mtg.1` are intentionally ignored
+# so they do not become the dev-version floor after a Midtown release.
 # Exits non-zero with a diagnostic on stderr if no usable tag exists.
 set -euo pipefail
 
-last_tag=$(git describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || true)
+last_tag=$(git describe \
+  --tags \
+  --abbrev=0 \
+  --match "v[0-9]*.[0-9]*.[0-9]*" \
+  --exclude "v*-*" \
+  2>/dev/null || true)
 if [[ -z "$last_tag" ]]; then
   echo "compute-dev-version: no v* tag found in history" >&2
   exit 1

--- a/scripts/test-compute-dev-version.sh
+++ b/scripts/test-compute-dev-version.sh
@@ -54,6 +54,14 @@ run_test "release sets next dev cycle floor" \
   'git commit --allow-empty -m init -q && git tag -a v0.8.0 -m v0.8.0 && git commit --allow-empty -m c1 -q && git tag -a v0.9.0 -m v0.9.0 && git commit --allow-empty -m c2 -q' \
   '0.9.1-dev.1' 0
 
+run_test "fork release tag is ignored for next dev version" \
+  'git commit --allow-empty -m init -q && git tag -a v0.9.0 -m v0.9.0 && git commit --allow-empty -m fork-release -q && git tag -a v0.9.1-mtg.1 -m v0.9.1-mtg.1 && git commit --allow-empty -m next -q' \
+  '0.9.1-dev.2' 0
+
+run_test "only fork release tags still fails without stable base" \
+  'git commit --allow-empty -m init -q && git tag -a v0.9.1-mtg.1 -m v0.9.1-mtg.1' \
+  '' 1
+
 run_test "minor with double-digit patch" \
   'git commit --allow-empty -m init -q && git tag -a v1.2.10 -m v1.2.10 && git commit --allow-empty -m c1 -q' \
   '1.2.11-dev.1' 0

--- a/scripts/test-release-workflow-config.sh
+++ b/scripts/test-release-workflow-config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Static checks for fork-local image publication in .github/workflows/ci.yml.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/ci.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+grep -q "IMAGE_NAMESPACE: mtg-thomas" "$workflow" \
+  || fail "ci.yml must publish fork images under ghcr.io/mtg-thomas"
+
+if grep -q "jackmusick/bifrost-\(api\|client\)" "$workflow"; then
+  fail "ci.yml still publishes Bifrost images under jackmusick"
+fi
+
+grep -q 'ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}' "$workflow" \
+  || fail "API image refs must use IMAGE_NAMESPACE + API_IMAGE"
+
+grep -q 'ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}' "$workflow" \
+  || fail "client image refs must use IMAGE_NAMESPACE + CLIENT_IMAGE"
+
+echo "release workflow config checks passed"

--- a/scripts/test-release-workflow-config.sh
+++ b/scripts/test-release-workflow-config.sh
@@ -10,17 +10,20 @@ fail() {
   exit 1
 }
 
-grep -q "IMAGE_NAMESPACE: mtg-thomas" "$workflow" \
+grep -Fq "IMAGE_NAMESPACE: mtg-thomas" "$workflow" \
   || fail "ci.yml must publish fork images under ghcr.io/mtg-thomas"
 
 if grep -q "jackmusick/bifrost-\(api\|client\)" "$workflow"; then
   fail "ci.yml still publishes Bifrost images under jackmusick"
 fi
 
-grep -q 'ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}' "$workflow" \
+grep -Fq 'ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.API_IMAGE }}' "$workflow" \
   || fail "API image refs must use IMAGE_NAMESPACE + API_IMAGE"
 
-grep -q 'ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}' "$workflow" \
+grep -Fq 'ghcr.io/${{ env.IMAGE_NAMESPACE }}/${{ env.CLIENT_IMAGE }}' "$workflow" \
   || fail "client image refs must use IMAGE_NAMESPACE + CLIENT_IMAGE"
+
+grep -Fq "image_tag=" "$workflow" \
+  || fail "release notes must use image tags without the leading v prefix"
 
 echo "release workflow config checks passed"


### PR DESCRIPTION
## Summary

- split the GHCR image namespace from image names so fork release/dev builds publish under `ghcr.io/mtg-thomas/bifrost-*`
- keep dev image versioning based on upstream-compatible stable tags while ignoring fork prerelease tags like `v0.9.1-mtg.1`
- add shell coverage for dev-version and release workflow image-target checks

## Verification

- `bash scripts/test-compute-dev-version.sh`
- `bash scripts/test-release-workflow-config.sh`
- `bash -n scripts/compute-dev-version.sh scripts/test-compute-dev-version.sh scripts/test-release-workflow-config.sh`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text()); print('ci.yml ok')"`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MTG-Thomas/codesmith/bifrost/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Parameterized container image namespace in CI/CD workflow for improved maintainability
  * Updated version computation to exclude fork prerelease tags from baseline calculation
  * Added validation checks for release workflow configuration consistency

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/171)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->