### PR TITLE
Fix critical Codex Security findings

### DIFF
--- a/api/bifrost/models.py
+++ b/api/bifrost/models.py
@@ -160,8 +160,10 @@ class OAuthCredentials(BaseModel):
         For client_credentials flows, requests a new token directly.
         For authorization_code flows, uses the stored refresh_token.
 
-        Updates access_token and expires_at in-place and persists
-        the new token to the database.
+        Persists the new token to the database and updates expires_at
+        in-place. The refresh response does not expose the new access
+        token; fetch integration data again if the workflow needs the
+        rotated token in this process.
 
         Returns:
             self (for chaining)
@@ -169,10 +171,9 @@ class OAuthCredentials(BaseModel):
         Example:
             >>> integration = await integrations.get("Pax8")
             >>> await integration.oauth.refresh()
-            >>> # integration.oauth.access_token is now fresh
+            >>> # integration.oauth.expires_at now reflects the persisted refresh
         """
         from .client import get_client
-        from ._context import register_secret
 
         client = get_client()
         response = await client.post(
@@ -185,9 +186,7 @@ class OAuthCredentials(BaseModel):
             raise RuntimeError(f"Token refresh failed: {response.status_code} - {detail}")
 
         data = response.json()
-        self.access_token = data["access_token"]
         self.expires_at = data.get("expires_at")
-        register_secret(self.access_token)
         return self
 
 

--- a/api/src/core/system_agents.py
+++ b/api/src/core/system_agents.py
@@ -1,0 +1,18 @@
+"""Security policy helpers for built-in MCP agent tools."""
+
+from __future__ import annotations
+
+
+# Agent-management MCP tools can create, modify, or remove agents and their
+# tool grants. They are safe for direct admin-controlled MCP use, but not as
+# chat-agent callable tools.
+PRIVILEGED_AGENT_MANAGEMENT_TOOLS: frozenset[str] = frozenset({
+    "create_agent",
+    "update_agent",
+    "delete_agent",
+})
+
+
+def is_privileged_agent_management_tool(tool_name: str) -> bool:
+    """Return True when a built-in MCP tool manages agent privileges."""
+    return tool_name in PRIVILEGED_AGENT_MANAGEMENT_TOOLS

--- a/api/src/models/contracts/cli.py
+++ b/api/src/models/contracts/cli.py
@@ -329,7 +329,7 @@ class SDKIntegrationsRefreshTokenRequest(BaseModel):
 
 class SDKIntegrationsRefreshTokenResponse(BaseModel):
     """Response from refreshing an OAuth token."""
-    access_token: str = Field(..., description="New access token (decrypted)")
+    refreshed: bool = Field(default=True, description="True when the token refresh succeeded")
     expires_at: str | None = Field(None, description="Token expiration (ISO format)")
 
     model_config = ConfigDict(from_attributes=True)

--- a/api/src/routers/agent_tuning.py
+++ b/api/src/routers/agent_tuning.py
@@ -31,6 +31,7 @@ from src.models.contracts.agent_tuning import (
     ConsolidatedProposalResponse,
     DryRunPerRun,
 )
+from src.models.enums import AgentAccessLevel
 from src.models.orm.agents import Agent
 from src.services.execution.tuning_service import (
     apply_consolidated_tuning,
@@ -46,10 +47,12 @@ router = APIRouter(prefix="/api/agents", tags=["Agent Tuning"])
 async def _load_agent_with_access(
     agent_id: UUID, db: DbSession, user: CurrentActiveUser
 ) -> Agent:
-    """Fetch an agent and enforce org scoping for non-superusers.
+    """Fetch an agent and enforce tune authorization.
 
-    Org users can only tune agents in their own org (or global agents,
-    where ``organization_id is None``). Platform admins can tune any.
+    Tuning is a mutating prompt-management surface. Platform admins can tune
+    any agent; regular users can tune only their own private agents. Shared
+    org/global agents may be visible to regular users, but they are not
+    user-owned mutable resources.
     """
     is_admin = user.is_superuser or any(
         role in ["Platform Admin", "Platform Owner"] for role in user.roles
@@ -64,15 +67,14 @@ async def _load_agent_with_access(
             detail=f"Agent {agent_id} not found",
         )
 
-    if not is_admin:
-        if (
-            agent.organization_id is not None
-            and agent.organization_id != user.organization_id
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Agent {agent_id} not found",
-            )
+    if not is_admin and (
+        agent.access_level != AgentAccessLevel.PRIVATE
+        or agent.owner_user_id != user.user_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only tune your own private agents",
+        )
 
     return agent
 

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -306,8 +306,8 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         """Repoint an application's source directory.
 
         Validates uniqueness, nesting, and that the new prefix has source files
-        in file_index. Any of those checks may be bypassed with ``force=True``.
-        No file moves — updates DB only.
+        in file_index. ``force=True`` may bypass only the source-exists check;
+        app boundary checks are always enforced. No file moves — updates DB only.
 
         Returns the updated Application, or None if the app was not found.
         Raises ValueError on validation failure.
@@ -327,42 +327,41 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         if normalized == app.repo_path:
             return app
 
-        if not force:
-            # Uniqueness check (excluding the app itself).
-            existing_stmt = select(Application).where(
-                Application.repo_path == normalized,
-                Application.id != app_id,
+        # Uniqueness check (excluding the app itself).
+        existing_stmt = select(Application).where(
+            Application.repo_path == normalized,
+            Application.id != app_id,
+        )
+        conflict = (await self.session.execute(existing_stmt)).scalar_one_or_none()
+        if conflict is not None:
+            raise ValueError(
+                f"repo_path '{normalized}' already claimed by app "
+                f"{conflict.slug} ({conflict.id})."
             )
-            conflict = (await self.session.execute(existing_stmt)).scalar_one_or_none()
-            if conflict is not None:
+
+        # Nesting check: no other app's repo_path is a prefix of new (with /),
+        # and new (with /) is not a prefix of any other app's repo_path.
+        # Simple Python-side approach: fetch all other apps' repo_paths and check.
+        # This is fine because app count is small (tens, not millions).
+        new_prefix = f"{normalized}/"
+        others_stmt = select(Application).where(Application.id != app_id)
+        others = (await self.session.execute(others_stmt)).scalars().all()
+        for other in others:
+            other_prefix = f"{other.repo_path}/"
+            # new is nested inside other: new_prefix starts with other_prefix
+            if new_prefix.startswith(other_prefix):
                 raise ValueError(
-                    f"repo_path '{normalized}' already claimed by app "
-                    f"{conflict.slug} ({conflict.id}). Pass force=True to override."
+                    f"repo_path '{normalized}' is nested under app "
+                    f"{other.slug} ({other.repo_path})."
+                )
+            # other is nested inside new: other_prefix starts with new_prefix
+            if other_prefix.startswith(new_prefix):
+                raise ValueError(
+                    f"repo_path '{normalized}' would contain app "
+                    f"{other.slug} ({other.repo_path}) nested inside it."
                 )
 
-            # Nesting check: no other app's repo_path is a prefix of new (with /),
-            # and new (with /) is not a prefix of any other app's repo_path.
-            # Simple Python-side approach: fetch all other apps' repo_paths and check.
-            # This is fine because app count is small (tens, not millions).
-            new_prefix = f"{normalized}/"
-            others_stmt = select(Application).where(Application.id != app_id)
-            others = (await self.session.execute(others_stmt)).scalars().all()
-            for other in others:
-                other_prefix = f"{other.repo_path}/"
-                # new is nested inside other: new_prefix starts with other_prefix
-                if new_prefix.startswith(other_prefix):
-                    raise ValueError(
-                        f"repo_path '{normalized}' is nested under app "
-                        f"{other.slug} ({other.repo_path}). Pass force=True to override."
-                    )
-                # other is nested inside new: other_prefix starts with new_prefix
-                if other_prefix.startswith(new_prefix):
-                    raise ValueError(
-                        f"repo_path '{normalized}' would contain app "
-                        f"{other.slug} ({other.repo_path}) nested inside it. "
-                        "Pass force=True to override."
-                    )
-
+        if not force:
             # Source-exists check: at least one file_index row starts with new_prefix.
             file_stmt = select(FileIndex).where(
                 FileIndex.path.like(f"{new_prefix}%")
@@ -1041,7 +1040,7 @@ async def replace_application_endpoint(
     """Update ``repo_path`` after source files have been moved/renamed.
 
     Validates that the new path is unique, non-nested with other apps, and has
-    source files under it. ``force: true`` bypasses all three checks.
+    source files under it. ``force: true`` bypasses only the source-file check.
     """
     repo = ApplicationRepository(
         ctx.db,

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -1203,7 +1203,7 @@ async def sdk_integrations_refresh_token(
         )
 
         return SDKIntegrationsRefreshTokenResponse(
-            access_token=access_token,
+            refreshed=True,
             expires_at=expires_at,
         )
 

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -25,6 +25,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
+from src.core.system_agents import is_privileged_agent_management_tool
 from src.models.contracts.agents import (
     AgentSwitch,
     ChatStreamChunk,
@@ -1190,6 +1191,17 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
 
         # Check if this is a system tool call
         if agent and tool_call.name in (agent.system_tools or []):
+            if is_privileged_agent_management_tool(tool_call.name):
+                return ToolResult(
+                    tool_call_id=tool_call.id,
+                    tool_name=tool_call.name,
+                    result=None,
+                    error=(
+                        f"System tool '{tool_call.name}' cannot be executed "
+                        "from chat agents"
+                    ),
+                    duration_ms=int((time.time() - start_time) * 1000),
+                )
             return await self._execute_system_tool(tool_call, agent, conversation)
 
         # External MCP tools — namespaced ``mcp__<connection_id>__<tool>``.

--- a/api/src/services/app_bundler/__init__.py
+++ b/api/src/services/app_bundler/__init__.py
@@ -176,7 +176,7 @@ class BundlerService:
             #    arbitrary-value utilities (bg-[color:var(--x)],
             #    lg:grid-cols-[1fr_360px]) the host preload doesn't know
             #    about, AND processes user .css files so @apply / @layer /
-            #    @theme directives + per-app tailwind.config.* work.
+            #    @theme directives work.
             #    User CSS files that were consumed get filtered out of
             #    `sources` because they're now inlined into the unified
             #    __bifrost_tailwind.css; re-importing them through esbuild
@@ -312,9 +312,9 @@ class BundlerService:
 
         Scans .tsx/.ts/.jsx/.js for class candidates, concatenates user
         .css files into the Tailwind input so @apply / @layer / @theme
-        directives are processed, optionally honors a per-app
-        tailwind.config.{js,ts,mjs,cjs} via @config. Writes the unified
-        result to src_dir/__bifrost_tailwind.css.
+        directives are processed. App-authored tailwind.config.* files are not
+        loaded because Tailwind config files execute server-side JavaScript.
+        Writes the unified result to src_dir/__bifrost_tailwind.css.
 
         Returns:
             (wrote_css, consumed_css_files). When wrote_css is True, the
@@ -354,20 +354,10 @@ class BundlerService:
                     f"Bundler: skipping {log_safe(rel)} for tailwind input: {e}"
                 )
 
-        # Per-app tailwind.config.* — first match wins. Tailwind v4 honors
-        # @config from the input CSS regardless of extension; we just need
-        # to find the file.
-        config_path: str | None = None
-        for ext in ("ts", "js", "mjs", "cjs"):
-            candidate = src_dir / f"tailwind.config.{ext}"
-            if candidate.exists():
-                config_path = str(candidate.resolve())
-                break
-
         css = await AppTailwindService.generate_css_pipeline(
             code_sources=code_contents,
             user_css=user_css,
-            config_path=config_path,
+            config_path=None,
         )
         if not css:
             return (False, set())

--- a/api/src/services/app_compiler/__init__.py
+++ b/api/src/services/app_compiler/__init__.py
@@ -150,7 +150,7 @@ class AppTailwindService:
         Candidates-only mode: produces utility CSS for the class names
         found in `sources`. Does NOT process user CSS files — see
         `generate_css_pipeline` for the pipeline mode that supports
-        @apply / @layer / per-app tailwind.config.
+        @apply / @layer / @theme.
         """
         candidates = AppTailwindService.extract_candidates(sources)
         if not candidates:
@@ -173,8 +173,8 @@ class AppTailwindService:
                 .css files. Concatenated into the Tailwind input so
                 @apply / @layer / @theme directives in user CSS are
                 processed against the utility layer.
-            config_path: optional absolute path to a per-app
-                tailwind.config.js. Threaded through as @config.
+            config_path: ignored for compatibility. Per-app Tailwind config
+                files are not loaded because they execute server-side JavaScript.
 
         Returns the generated CSS string (utilities + processed user CSS),
         or None on failure.
@@ -186,9 +186,6 @@ class AppTailwindService:
                 {"path": p, "content": c} for p, c in user_css
             ],
         }
-        if config_path:
-            payload["config_path"] = config_path
-
         # Skip the subprocess only when there's literally nothing to do —
         # no candidates AND no user CSS. (User CSS alone with no candidates
         # is still a real input; e.g. a stylesheet declaring CSS variables.)

--- a/api/src/services/app_compiler/tailwind.js
+++ b/api/src/services/app_compiler/tailwind.js
@@ -14,12 +14,13 @@
  *       Input  (stdin): {
  *         "candidates": ["flex", ...],
  *         "user_css": [{"path": "styles.css", "content": "..."}, ...],
- *         "config_path": "/abs/path/to/tailwind.config.js" | null
+ *         "config_path": null
  *       }
  *       Output (stdout): {"css": "...", "error": null}
  *     Concatenates user CSS into the input, threads it through Tailwind so
- *     @apply / @layer / @theme directives are processed, optionally honors
- *     a per-app tailwind.config.js via @config.
+ *     @apply / @layer / @theme directives are processed. Per-app
+ *     tailwind.config.* files are intentionally not loaded because Tailwind
+ *     config evaluation executes server-side JavaScript.
  *
  * The mode is determined by presence of "user_css" in the input.
  */
@@ -37,17 +38,8 @@ process.stdin.on("end", async () => {
     const cfg = JSON.parse(input);
     const candidates = cfg.candidates || [];
     const userCss = cfg.user_css;
-    const configPath = cfg.config_path || null;
-
     // Build the entry CSS — what we hand to compile() as the input string.
-    // @config must come before user CSS so per-app theme tokens are
-    // available when user @apply pulls them in.
     let entryCss = BASELINE_IMPORTS;
-    if (configPath) {
-      // @tailwindcss/node accepts absolute paths in @config but expects
-      // them quoted. Forward-slash even on Linux for portability.
-      entryCss += `@config '${configPath.replace(/\\/g, "/")}';\n`;
-    }
     if (userCss && Array.isArray(userCss)) {
       for (const f of userCss) {
         // Inline user CSS rather than @import it, so @apply rules in user

--- a/api/src/services/mcp_server/tools/agents.py
+++ b/api/src/services/mcp_server/tools/agents.py
@@ -12,12 +12,45 @@ from uuid import uuid4
 
 from fastmcp.tools import ToolResult
 
+from src.core.system_agents import PRIVILEGED_AGENT_MANAGEMENT_TOOLS
 from src.services.mcp_server.tool_result import error_result, success_result
 from src.services.mcp_server.tools.db import get_tool_db
 
 # MCPContext is imported where needed to avoid circular imports
 
 logger = logging.getLogger(__name__)
+
+
+def _ensure_can_manage_agent_privileges(
+    context: Any,
+    *,
+    scope: str | None = None,
+    system_tools: list[str] | None = None,
+    delegated_agent_ids: list[str] | None = None,
+    knowledge_sources: list[str] | None = None,
+) -> ToolResult | None:
+    """Block non-admin MCP callers from granting sensitive agent capabilities."""
+    if getattr(context, "is_platform_admin", False):
+        return None
+
+    if scope == "global":
+        return error_result("Only platform admins can create global agents.")
+
+    if system_tools:
+        privileged = sorted(set(system_tools) & PRIVILEGED_AGENT_MANAGEMENT_TOOLS)
+        if privileged:
+            return error_result(
+                "Only platform admins can grant privileged agent management tools: "
+                + ", ".join(privileged)
+            )
+
+    if delegated_agent_ids:
+        return error_result("Only platform admins can configure agent delegation via MCP.")
+
+    if knowledge_sources:
+        return error_result("Only platform admins can configure agent knowledge sources via MCP.")
+
+    return None
 
 
 # ==================== SCHEMA TOOL ====================
@@ -282,6 +315,16 @@ async def create_agent(
     if scope not in ("global", "organization"):
         return error_result("scope must be 'global' or 'organization'")
 
+    privilege_error = _ensure_can_manage_agent_privileges(
+        context,
+        scope=scope,
+        system_tools=system_tools,
+        delegated_agent_ids=delegated_agent_ids,
+        knowledge_sources=knowledge_sources,
+    )
+    if privilege_error is not None:
+        return privilege_error
+
     # Validate channels if provided
     valid_channels = {"chat", "voice", "teams", "slack"}
     if channels:
@@ -467,6 +510,15 @@ async def update_agent(
         invalid_channels = set(channels) - valid_channels
         if invalid_channels:
             return error_result(f"Invalid channels: {list(invalid_channels)}. Valid options: {list(valid_channels)}")
+
+    privilege_error = _ensure_can_manage_agent_privileges(
+        context,
+        system_tools=system_tools,
+        delegated_agent_ids=delegated_agent_ids,
+        knowledge_sources=knowledge_sources,
+    )
+    if privilege_error is not None:
+        return privilege_error
 
     try:
         async with get_tool_db(context) as db:

--- a/api/src/services/mcp_server/tools/agents.py
+++ b/api/src/services/mcp_server/tools/agents.py
@@ -324,6 +324,13 @@ async def create_agent(
     )
     if privilege_error is not None:
         return privilege_error
+    if (
+        scope == "organization"
+        and not context.is_platform_admin
+        and organization_id is not None
+        and (context.org_id is None or str(organization_id) != str(context.org_id))
+    ):
+        return error_result("You don't have permission to create agents in another organization.")
 
     # Validate channels if provided
     valid_channels = {"chat", "voice", "teams", "slack"}
@@ -519,6 +526,8 @@ async def update_agent(
     )
     if privilege_error is not None:
         return privilege_error
+    if not context.is_platform_admin and context.org_id is None:
+        return error_result("Organization context is required to update agents.")
 
     try:
         async with get_tool_db(context) as db:

--- a/api/tests/integration/test_app_bundler_pipeline.py
+++ b/api/tests/integration/test_app_bundler_pipeline.py
@@ -1,9 +1,8 @@
 """Phase 2 integration tests — full Tailwind v4 pipeline against the real
-@tailwindcss/node compiler. Covers @apply / @layer in user CSS and per-app
-tailwind.config.{ts,js,mjs,cjs}.
+@tailwindcss/node compiler. Covers @apply / @layer / @theme in user CSS.
 
-If these pass, every reasonable Tailwind feature a developer expects from
-"a normal React app with Tailwind" works inside the v2 Bifrost bundler.
+If these pass, the CSS-native Tailwind features Bifrost supports work inside
+the v2 bundler without loading app-authored JavaScript config.
 """
 from __future__ import annotations
 
@@ -91,32 +90,21 @@ async def test_layer_components_with_apply_chain() -> None:
 
 
 @pytest.mark.asyncio
-async def test_per_app_tailwind_config_extends_theme() -> None:
-    """Per-app tailwind.config.ts can add custom theme tokens — those
-    tokens must be available to the app's class names."""
+async def test_per_app_tailwind_config_is_not_executed() -> None:
+    """Per-app tailwind.config.* must not execute server-side JavaScript."""
     bundler = BundlerService()
 
     with tempfile.TemporaryDirectory() as tmp:
         src_dir = pathlib.Path(tmp)
         (src_dir / "_layout.tsx").write_text(
-            'export default () => <div className="bg-brand-500" />;\n',
+            'export default () => <div className="flex" />;\n',
             encoding="utf-8",
         )
-        # Tailwind v4 config files use CommonJS or ESM. Use .js/CJS for the
-        # broadest compatibility in the test (no Node ESM loader hassle).
+        marker = src_dir / "tailwind-config-executed"
         (src_dir / "tailwind.config.js").write_text(
-            """
-            module.exports = {
-              theme: {
-                extend: {
-                  colors: {
-                    brand: {
-                      500: '#facc15',
-                    },
-                  },
-                },
-              },
-            };
+            f"""
+            require('node:fs').writeFileSync({str(marker)!r}, 'executed');
+            module.exports = {{}};
             """,
             encoding="utf-8",
         )
@@ -126,11 +114,9 @@ async def test_per_app_tailwind_config_extends_theme() -> None:
         )
         assert added is True
         css = (src_dir / TAILWIND_OUTPUT_CSS).read_text(encoding="utf-8")
+        assert not marker.exists()
 
-    assert "#facc15" in css.lower() or "facc15" in css.lower(), (
-        "custom brand-500 color from per-app config must compile to a rule"
-    )
-    assert ".bg-brand-500" in css
+    assert ".flex" in css
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/routers/test_cli_refresh_token.py
+++ b/api/tests/unit/routers/test_cli_refresh_token.py
@@ -77,8 +77,12 @@ class TestRefreshTokenClientCredentials:
 
             result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
 
-        assert result.access_token == "fresh-pax8-token"
+        assert result.refreshed is True
         assert result.expires_at is not None
+        response_payload = result.model_dump()
+        assert "access_token" not in response_payload
+        assert "refresh_token" not in response_payload
+        assert "client_secret" not in response_payload
         mock_instance.get_client_credentials_token.assert_called_once_with(
             token_url="https://login.pax8.com/oauth/token",
             client_id="pax8-client-id",
@@ -149,7 +153,11 @@ class TestRefreshTokenClientCredentials:
 
             result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
 
-        assert result.access_token == "new-token"
+        assert result.refreshed is True
+        response_payload = result.model_dump()
+        assert "access_token" not in response_payload
+        assert "refresh_token" not in response_payload
+        assert "client_secret" not in response_payload
         # Existing token should be updated, not a new one added
         mock_db.add.assert_not_called()
         assert mock_existing_token.expires_at == expires_at
@@ -226,7 +234,11 @@ class TestRefreshTokenAuthorizationCode:
 
             result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
 
-        assert result.access_token == "refreshed-ms-token"
+        assert result.refreshed is True
+        response_payload = result.model_dump()
+        assert "access_token" not in response_payload
+        assert "refresh_token" not in response_payload
+        assert "client_secret" not in response_payload
         mock_instance.refresh_access_token.assert_called_once()
 
     @pytest.mark.asyncio
@@ -440,8 +452,8 @@ class TestRefreshTokenSDKModel:
     """Test the OAuthCredentials.refresh() SDK method."""
 
     @pytest.mark.asyncio
-    async def test_refresh_updates_access_token(self):
-        """refresh() should update access_token and expires_at in place."""
+    async def test_refresh_updates_expires_at_without_token_material(self):
+        """refresh() should update expires_at without requiring returned tokens."""
         from bifrost.models import OAuthCredentials
 
         creds = OAuthCredentials(
@@ -459,7 +471,7 @@ class TestRefreshTokenSDKModel:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "access_token": "fresh-token",
+            "refreshed": True,
             "expires_at": "2026-03-02T00:00:00+00:00",
         }
 
@@ -473,7 +485,7 @@ class TestRefreshTokenSDKModel:
             result = await creds.refresh()
 
         assert result is creds  # returns self
-        assert creds.access_token == "fresh-token"
+        assert creds.access_token == "old-token"
         assert creds.expires_at == "2026-03-02T00:00:00+00:00"
         mock_client.post.assert_called_once_with(
             "/api/cli/integrations/refresh_token",
@@ -481,8 +493,8 @@ class TestRefreshTokenSDKModel:
         )
 
     @pytest.mark.asyncio
-    async def test_refresh_registers_secret(self):
-        """refresh() should register the new token as a secret."""
+    async def test_refresh_does_not_register_response_secrets(self):
+        """refresh() should not receive or register secret material."""
         from bifrost.models import OAuthCredentials
 
         creds = OAuthCredentials(
@@ -500,7 +512,7 @@ class TestRefreshTokenSDKModel:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "access_token": "secret-token",
+            "refreshed": True,
             "expires_at": None,
         }
 
@@ -513,7 +525,8 @@ class TestRefreshTokenSDKModel:
         ):
             await creds.refresh()
 
-        mock_register.assert_called_once_with("secret-token")
+        mock_register.assert_not_called()
+        assert creds.access_token == "old-token"
 
     @pytest.mark.asyncio
     async def test_refresh_raises_on_failure(self):

--- a/api/tests/unit/services/test_agent_executor_tools.py
+++ b/api/tests/unit/services/test_agent_executor_tools.py
@@ -331,6 +331,71 @@ class TestWorkflowToolIdResolution:
         assert "some_unknown_tool" in compiled
 
 
+class TestPrivilegedAgentManagementTools:
+    """Regression tests for privileged MCP agent-management tools in chat."""
+
+    @pytest.mark.asyncio
+    async def test_chat_agent_cannot_execute_privileged_agent_management_tool(
+        self, executor, mock_agent
+    ):
+        """Even if present on agent.system_tools, chat cannot execute create_agent."""
+        from src.services.llm.base import ToolCallRequest
+
+        mock_agent.system_tools = ["create_agent"]
+
+        with patch.object(
+            executor,
+            "_execute_system_tool",
+            new_callable=AsyncMock,
+        ) as mock_execute_system_tool:
+            result = await executor._execute_tool(
+                ToolCallRequest(
+                    id="call_privileged",
+                    name="create_agent",
+                    arguments={
+                        "name": "Escalated",
+                        "system_prompt": "Grant privileged tools",
+                    },
+                ),
+                agent=mock_agent,
+                conversation=MagicMock(),
+            )
+
+        mock_execute_system_tool.assert_not_awaited()
+        assert result.error is not None
+        assert "cannot be executed from chat agents" in result.error
+        assert result.tool_name == "create_agent"
+
+    @pytest.mark.asyncio
+    async def test_chat_agent_can_execute_non_privileged_system_tool(
+        self, executor, mock_agent
+    ):
+        """The chat denylist does not block ordinary assigned system tools."""
+        from src.services.llm.base import ToolCallRequest
+
+        mock_agent.system_tools = ["list_workflows"]
+        expected = MagicMock()
+
+        with patch.object(
+            executor,
+            "_execute_system_tool",
+            new_callable=AsyncMock,
+            return_value=expected,
+        ) as mock_execute_system_tool:
+            result = await executor._execute_tool(
+                ToolCallRequest(
+                    id="call_allowed",
+                    name="list_workflows",
+                    arguments={},
+                ),
+                agent=mock_agent,
+                conversation=MagicMock(),
+            )
+
+        mock_execute_system_tool.assert_awaited_once()
+        assert result is expected
+
+
 class TestSerializeForJson:
     """Test the _serialize_for_json helper function."""
 

--- a/api/tests/unit/services/test_app_repoint.py
+++ b/api/tests/unit/services/test_app_repoint.py
@@ -1,139 +1,214 @@
-"""Unit tests for ApplicationRepository.replace_application (repoint).
-
-These tests use the real ``db_session`` fixture backed by PostgreSQL to
-exercise the uniqueness/nesting/source-exists validation logic against
-actual ORM behavior. They're placed under ``tests/unit/`` because they
-target a single repository method in isolation, but they still require
-the Docker test stack to be up (``./test.sh``).
-"""
+"""Unit tests for ApplicationRepository.replace_application (repoint)."""
 from __future__ import annotations
 
 from uuid import uuid4
 
 import pytest
-import pytest_asyncio
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.orm.applications import Application
-from src.models.orm.file_index import FileIndex
 from src.routers.applications import ApplicationRepository
 
 
-@pytest_asyncio.fixture
-async def repo(db_session: AsyncSession) -> ApplicationRepository:
-    # org_id=None → global scope. is_superuser=True bypasses per-entity role
-    # checks so the tests focus on replace_application's own validation logic.
-    return ApplicationRepository(
-        session=db_session,
-        org_id=None,
-        is_superuser=True,
-    )
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
 
 
-async def _make_app(db: AsyncSession, *, slug: str, repo_path: str) -> Application:
-    app = Application(
+class _ScalarsResult:
+    def __init__(self, values):
+        self._values = values
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._values
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        *,
+        apps: list[Application],
+        source_paths: set[str] | None = None,
+    ):
+        self.apps = apps
+        self.source_paths = source_paths or set()
+        self.execute_calls = 0
+        self.flushed = False
+        self.refreshed: Application | None = None
+
+    async def execute(self, _stmt):
+        self.execute_calls += 1
+        target = getattr(self, "target_app", None)
+        target_path = getattr(self, "target_path", None)
+
+        if self.execute_calls == 1:
+            conflict = next(
+                (
+                    app
+                    for app in self.apps
+                    if app.repo_path == target_path and app.id != target.id
+                ),
+                None,
+            )
+            return _ScalarResult(conflict)
+
+        if self.execute_calls == 2:
+            return _ScalarsResult([app for app in self.apps if app.id != target.id])
+
+        if self.execute_calls == 3:
+            prefix = f"{target_path}/"
+            has_source = any(path.startswith(prefix) for path in self.source_paths)
+            return _ScalarResult(object() if has_source else None)
+
+        raise AssertionError(f"unexpected execute call {self.execute_calls}")
+
+    async def flush(self):
+        self.flushed = True
+
+    async def refresh(self, app: Application):
+        self.refreshed = app
+
+
+class _TestRepository(ApplicationRepository):
+    def __init__(self, session: _FakeSession, target: Application):
+        super().__init__(session=session, org_id=None, is_superuser=True)
+        self._target = target
+        session.target_app = target
+
+    async def get(self, id):
+        return self._target if id == self._target.id else None
+
+    async def replace_application(self, app_id, new_repo_path, *, force=False):
+        self.session.target_path = new_repo_path.rstrip("/")
+        return await super().replace_application(
+            app_id,
+            new_repo_path,
+            force=force,
+        )
+
+
+def _make_app(*, slug: str, repo_path: str) -> Application:
+    return Application(
         id=uuid4(),
         name=slug,
         slug=slug,
         repo_path=repo_path,
         access_level="authenticated",
     )
-    db.add(app)
-    await db.flush()
-    return app
 
 
-async def _seed_file(db: AsyncSession, path: str) -> None:
-    db.add(FileIndex(path=path, content="// stub", content_hash="x"))
-    await db.flush()
+def _repo(
+    app: Application,
+    *,
+    others: list[Application] | None = None,
+    source_paths: set[str] | None = None,
+) -> _TestRepository:
+    return _TestRepository(
+        _FakeSession(apps=[app, *(others or [])], source_paths=source_paths),
+        app,
+    )
 
 
 @pytest.mark.asyncio
-async def test_replace_repoints_when_all_checks_pass(repo, db_session):
-    app = await _make_app(db_session, slug="foo", repo_path="apps/foo")
-    await _seed_file(db_session, "apps/foo-v2/index.tsx")
+async def test_replace_repoints_when_all_checks_pass():
+    app = _make_app(slug="foo", repo_path="apps/foo")
+    repo = _repo(app, source_paths={"apps/foo-v2/index.tsx"})
 
     result = await repo.replace_application(app.id, "apps/foo-v2", force=False)
 
     assert result is not None
     assert result.repo_path == "apps/foo-v2"
+    assert repo.session.flushed is True
+    assert repo.session.refreshed is app
 
 
 @pytest.mark.asyncio
-async def test_replace_noop_when_path_unchanged(repo, db_session):
-    app = await _make_app(db_session, slug="foo", repo_path="apps/foo")
-    # No file seeded — no-op should not trigger source-exists check.
+async def test_replace_noop_when_path_unchanged():
+    app = _make_app(slug="foo", repo_path="apps/foo")
+    repo = _repo(app)
 
     result = await repo.replace_application(app.id, "apps/foo", force=False)
 
     assert result is not None
     assert result.repo_path == "apps/foo"
+    assert repo.session.execute_calls == 0
+    assert repo.session.flushed is False
 
 
 @pytest.mark.asyncio
-async def test_replace_rejects_duplicate_repo_path(repo, db_session):
-    app_a = await _make_app(db_session, slug="a", repo_path="apps/a")
-    await _make_app(db_session, slug="b", repo_path="apps/taken")
-    await _seed_file(db_session, "apps/taken/index.tsx")
+async def test_replace_rejects_duplicate_repo_path():
+    app_a = _make_app(slug="a", repo_path="apps/a")
+    app_b = _make_app(slug="b", repo_path="apps/taken")
+    repo = _repo(app_a, others=[app_b], source_paths={"apps/taken/index.tsx"})
 
     with pytest.raises(ValueError, match="already claimed"):
         await repo.replace_application(app_a.id, "apps/taken", force=False)
 
 
 @pytest.mark.asyncio
-async def test_replace_rejects_nested_under_existing(repo, db_session):
-    app_a = await _make_app(db_session, slug="a", repo_path="apps/a")
-    await _make_app(db_session, slug="outer", repo_path="apps/outer")
-    await _seed_file(db_session, "apps/outer/sub/index.tsx")
+async def test_replace_rejects_nested_under_existing():
+    app_a = _make_app(slug="a", repo_path="apps/a")
+    app_outer = _make_app(slug="outer", repo_path="apps/outer")
+    repo = _repo(
+        app_a,
+        others=[app_outer],
+        source_paths={"apps/outer/sub/index.tsx"},
+    )
 
     with pytest.raises(ValueError, match="nested"):
         await repo.replace_application(app_a.id, "apps/outer/sub", force=False)
 
 
 @pytest.mark.asyncio
-async def test_replace_rejects_existing_nested_under_target(repo, db_session):
-    app_a = await _make_app(db_session, slug="a", repo_path="apps/a")
-    await _make_app(db_session, slug="inner", repo_path="apps/outer/inner")
-    await _seed_file(db_session, "apps/outer/index.tsx")
+async def test_replace_rejects_existing_nested_under_target():
+    app_a = _make_app(slug="a", repo_path="apps/a")
+    app_inner = _make_app(slug="inner", repo_path="apps/outer/inner")
+    repo = _repo(app_a, others=[app_inner], source_paths={"apps/outer/index.tsx"})
 
     with pytest.raises(ValueError, match="nested"):
         await repo.replace_application(app_a.id, "apps/outer", force=False)
 
 
 @pytest.mark.asyncio
-async def test_replace_rejects_empty_prefix(repo, db_session):
-    app = await _make_app(db_session, slug="foo", repo_path="apps/foo")
+async def test_replace_rejects_empty_prefix():
+    app = _make_app(slug="foo", repo_path="apps/foo")
+    repo = _repo(app)
 
     with pytest.raises(ValueError, match="no files"):
         await repo.replace_application(app.id, "apps/does-not-exist", force=False)
 
 
 @pytest.mark.asyncio
-async def test_force_bypasses_uniqueness_then_db_integrity_catches_it(repo, db_session):
-    app_a = await _make_app(db_session, slug="a", repo_path="apps/a")
-    await _make_app(db_session, slug="b", repo_path="apps/taken")
-    await _seed_file(db_session, "apps/taken/index.tsx")
+async def test_force_does_not_bypass_uniqueness():
+    app_a = _make_app(slug="a", repo_path="apps/a")
+    app_b = _make_app(slug="b", repo_path="apps/taken")
+    repo = _repo(app_a, others=[app_b], source_paths={"apps/taken/index.tsx"})
 
-    # force bypass skips application-layer check. The DB unique constraint is
-    # the final guard — verify it fires on commit.
-    with pytest.raises(Exception):  # IntegrityError on commit
+    with pytest.raises(ValueError, match="already claimed"):
         await repo.replace_application(app_a.id, "apps/taken", force=True)
-        await db_session.commit()
 
 
 @pytest.mark.asyncio
-async def test_force_bypasses_nesting(repo, db_session):
-    app_a = await _make_app(db_session, slug="a", repo_path="apps/a")
-    await _make_app(db_session, slug="outer", repo_path="apps/outer")
-    await _seed_file(db_session, "apps/outer/index.tsx")
+async def test_force_does_not_bypass_nesting():
+    app_a = _make_app(slug="a", repo_path="apps/a")
+    app_outer = _make_app(slug="outer", repo_path="apps/outer")
+    repo = _repo(app_a, others=[app_outer], source_paths={"apps/outer/index.tsx"})
 
-    result = await repo.replace_application(app_a.id, "apps/outer/sub", force=True)
-    assert result.repo_path == "apps/outer/sub"
+    with pytest.raises(ValueError, match="nested"):
+        await repo.replace_application(app_a.id, "apps/outer/sub", force=True)
 
 
 @pytest.mark.asyncio
-async def test_force_bypasses_source_exists(repo, db_session):
-    app = await _make_app(db_session, slug="foo", repo_path="apps/foo")
+async def test_force_bypasses_source_exists():
+    app = _make_app(slug="foo", repo_path="apps/foo")
+    repo = _repo(app)
 
     result = await repo.replace_application(app.id, "apps/empty", force=True)
+
+    assert result is not None
     assert result.repo_path == "apps/empty"

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -22,6 +22,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from src.services.mcp_server.server import MCPContext
+from src.services.mcp_server.tools.agents import create_agent, update_agent
 from src.services.mcp_server.tools.forms import list_forms
 from src.services.mcp_server.tools.integrations import list_integrations
 from src.services.mcp_server.tools.knowledge import search_knowledge
@@ -1340,3 +1341,53 @@ class TestMCPContextInputCoercion:
     def test_none_org_id_remains_none(self):
         ctx = MCPContext(user_id=uuid4(), org_id=None)
         assert ctx.org_id is None
+
+
+class TestMCPAgentPrivilegeBoundary:
+    """Regression tests for privileged agent-management grants via MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_create_agent_with_privileged_system_tool(
+        self,
+        org_user_context,
+    ):
+        result = await create_agent(
+            org_user_context,
+            name="Escalated Agent",
+            system_prompt="Try to grant privileged MCP tools",
+            system_tools=["create_agent"],
+        )
+
+        assert result.structured_content is not None
+        assert "Only platform admins" in result.structured_content["error"]
+        assert "create_agent" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_update_agent_with_privileged_system_tool(
+        self,
+        org_user_context,
+    ):
+        result = await update_agent(
+            org_user_context,
+            agent_id=str(uuid4()),
+            system_tools=["update_agent"],
+        )
+
+        assert result.structured_content is not None
+        assert "Only platform admins" in result.structured_content["error"]
+        assert "update_agent" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_create_global_agent_via_mcp(
+        self,
+        org_user_context,
+    ):
+        result = await create_agent(
+            org_user_context,
+            name="Global Agent",
+            system_prompt="Try to create global agent",
+            scope="global",
+        )
+
+        assert result.structured_content is not None
+        assert "Only platform admins can create global agents" in result.structured_content["error"]

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -1363,6 +1363,53 @@ class TestMCPAgentPrivilegeBoundary:
         assert "create_agent" in result.structured_content["error"]
 
     @pytest.mark.asyncio
+    async def test_non_admin_cannot_create_agent_with_delegation(
+        self,
+        org_user_context,
+    ):
+        result = await create_agent(
+            org_user_context,
+            name="Delegating Agent",
+            system_prompt="Try to grant delegation",
+            delegated_agent_ids=[str(uuid4())],
+        )
+
+        assert result.structured_content is not None
+        assert "Only platform admins" in result.structured_content["error"]
+        assert "delegation" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_create_agent_with_knowledge_sources(
+        self,
+        org_user_context,
+    ):
+        result = await create_agent(
+            org_user_context,
+            name="Knowledge Agent",
+            system_prompt="Try to grant knowledge sources",
+            knowledge_sources=["sensitive-namespace"],
+        )
+
+        assert result.structured_content is not None
+        assert "Only platform admins" in result.structured_content["error"]
+        assert "knowledge sources" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_create_agent_in_foreign_org(
+        self,
+        org_user_context,
+    ):
+        result = await create_agent(
+            org_user_context,
+            name="Foreign Org Agent",
+            system_prompt="Try to create outside caller org",
+            organization_id=str(uuid4()),
+        )
+
+        assert result.structured_content is not None
+        assert "another organization" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
     async def test_non_admin_cannot_update_agent_with_privileged_system_tool(
         self,
         org_user_context,
@@ -1376,6 +1423,57 @@ class TestMCPAgentPrivilegeBoundary:
         assert result.structured_content is not None
         assert "Only platform admins" in result.structured_content["error"]
         assert "update_agent" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_update_agent_with_delegation(
+        self,
+        org_user_context,
+    ):
+        result = await update_agent(
+            org_user_context,
+            agent_id=str(uuid4()),
+            delegated_agent_ids=[str(uuid4())],
+        )
+
+        assert result.structured_content is not None
+        assert "Only platform admins" in result.structured_content["error"]
+        assert "delegation" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_update_agent_with_knowledge_sources(
+        self,
+        org_user_context,
+    ):
+        result = await update_agent(
+            org_user_context,
+            agent_id=str(uuid4()),
+            knowledge_sources=["sensitive-namespace"],
+        )
+
+        assert result.structured_content is not None
+        assert "Only platform admins" in result.structured_content["error"]
+        assert "knowledge sources" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_without_org_context_cannot_update_agent(
+        self,
+    ):
+        context = MCPContext(
+            user_id=uuid4(),
+            org_id=None,
+            is_platform_admin=False,
+            user_email="user@org.local",
+            user_name="Org User",
+        )
+
+        result = await update_agent(
+            context,
+            agent_id=str(uuid4()),
+            name="No Org Update",
+        )
+
+        assert result.structured_content is not None
+        assert "Organization context is required" in result.structured_content["error"]
 
     @pytest.mark.asyncio
     async def test_non_admin_cannot_create_global_agent_via_mcp(

--- a/api/tests/unit/test_agent_tuning_authorization.py
+++ b/api/tests/unit/test_agent_tuning_authorization.py
@@ -1,0 +1,148 @@
+"""Authorization checks for the consolidated agent tuning router."""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from src.core.auth import UserPrincipal
+from src.models.enums import AgentAccessLevel
+from src.models.orm.agents import Agent
+from src.routers.agent_tuning import _load_agent_with_access
+
+
+def _principal(
+    user_id: UUID,
+    org_id: UUID | None,
+    *,
+    is_superuser: bool = False,
+) -> UserPrincipal:
+    return UserPrincipal(
+        user_id=user_id,
+        email=f"{user_id}@example.test",
+        organization_id=org_id,
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+    )
+
+
+class _AgentResult:
+    def __init__(self, agent: Agent | None):
+        self._agent = agent
+
+    def scalar_one_or_none(self) -> Agent | None:
+        return self._agent
+
+
+def _db_returning(agent: Agent | None):
+    db = AsyncMock()
+    db.execute.return_value = _AgentResult(agent)
+    return db
+
+
+def _agent(
+    *,
+    access_level: AgentAccessLevel,
+    owner_user_id: UUID | None,
+    organization_id: UUID | None,
+) -> Agent:
+    return Agent(
+        id=uuid4(),
+        name=f"tuning-auth-agent-{uuid4().hex[:8]}",
+        description="agent tuning authorization regression fixture",
+        system_prompt="You are a test agent.",
+        channels=["chat"],
+        access_level=access_level,
+        organization_id=organization_id,
+        owner_user_id=owner_user_id,
+        is_active=True,
+        knowledge_sources=[],
+        system_tools=[],
+        created_by="test@example.com",
+    )
+
+
+@pytest.mark.asyncio
+async def test_regular_user_can_tune_own_private_agent():
+    org_id = uuid4()
+    user_id = uuid4()
+    agent = _agent(
+        access_level=AgentAccessLevel.PRIVATE,
+        owner_user_id=user_id,
+        organization_id=org_id,
+    )
+
+    loaded = await _load_agent_with_access(
+        agent.id,
+        _db_returning(agent),
+        _principal(user_id, org_id),
+    )
+
+    assert loaded.id == agent.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "access_level",
+    [AgentAccessLevel.AUTHENTICATED, AgentAccessLevel.ROLE_BASED],
+)
+async def test_regular_user_cannot_tune_shared_agent(access_level):
+    org_id = uuid4()
+    user_id = uuid4()
+    agent = _agent(
+        access_level=access_level,
+        owner_user_id=None,
+        organization_id=org_id,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _load_agent_with_access(
+            agent.id,
+            _db_returning(agent),
+            _principal(user_id, org_id),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_regular_user_cannot_tune_another_users_private_agent():
+    org_id = uuid4()
+    owner_user_id = uuid4()
+    caller_user_id = uuid4()
+    agent = _agent(
+        access_level=AgentAccessLevel.PRIVATE,
+        owner_user_id=owner_user_id,
+        organization_id=org_id,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _load_agent_with_access(
+            agent.id,
+            _db_returning(agent),
+            _principal(caller_user_id, org_id),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_platform_admin_can_tune_shared_agent():
+    org_id = uuid4()
+    admin_id = uuid4()
+    agent = _agent(
+        access_level=AgentAccessLevel.AUTHENTICATED,
+        owner_user_id=None,
+        organization_id=org_id,
+    )
+
+    loaded = await _load_agent_with_access(
+        agent.id,
+        _db_returning(agent),
+        _principal(admin_id, None, is_superuser=True),
+    )
+
+    assert loaded.id == agent.id

--- a/api/tests/unit/test_agent_tuning_authorization.py
+++ b/api/tests/unit/test_agent_tuning_authorization.py
@@ -91,7 +91,7 @@ async def test_regular_user_can_tune_own_private_agent():
     "access_level",
     [AgentAccessLevel.AUTHENTICATED, AgentAccessLevel.ROLE_BASED],
 )
-async def test_regular_user_cannot_tune_shared_agent(access_level):
+async def test_regular_user_cannot_tune_shared_agent(access_level: AgentAccessLevel):
     org_id = uuid4()
     user_id = uuid4()
     agent = _agent(

--- a/api/tests/unit/test_agent_tuning_authorization.py
+++ b/api/tests/unit/test_agent_tuning_authorization.py
@@ -18,6 +18,7 @@ def _principal(
     org_id: UUID | None,
     *,
     is_superuser: bool = False,
+    roles: list[str] | None = None,
 ) -> UserPrincipal:
     return UserPrincipal(
         user_id=user_id,
@@ -26,6 +27,7 @@ def _principal(
         is_active=True,
         is_superuser=is_superuser,
         is_verified=True,
+        roles=roles or [],
     )
 
 
@@ -146,3 +148,35 @@ async def test_platform_admin_can_tune_shared_agent():
     )
 
     assert loaded.id == agent.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["Platform Admin", "Platform Owner"])
+async def test_role_based_admin_can_tune_shared_agent(role: str):
+    org_id = uuid4()
+    admin_id = uuid4()
+    agent = _agent(
+        access_level=AgentAccessLevel.AUTHENTICATED,
+        owner_user_id=None,
+        organization_id=org_id,
+    )
+
+    loaded = await _load_agent_with_access(
+        agent.id,
+        _db_returning(agent),
+        _principal(admin_id, org_id, roles=[role]),
+    )
+
+    assert loaded.id == agent.id
+
+
+@pytest.mark.asyncio
+async def test_missing_agent_returns_404():
+    with pytest.raises(HTTPException) as exc_info:
+        await _load_agent_with_access(
+            uuid4(),
+            _db_returning(None),
+            _principal(uuid4(), uuid4()),
+        )
+
+    assert exc_info.value.status_code == 404

--- a/api/tests/unit/test_app_bundler.py
+++ b/api/tests/unit/test_app_bundler.py
@@ -388,11 +388,14 @@ async def test_generate_app_tailwind_consumes_user_css_files(
 
 
 @pytest.mark.asyncio
-async def test_generate_app_tailwind_threads_per_app_config(
+async def test_generate_app_tailwind_ignores_per_app_config(
     bundler: BundlerService, tmp_path: pathlib.Path
 ) -> None:
-    """When the app source includes a tailwind.config.{ts,js,mjs,cjs},
-    its absolute path must be forwarded to the compiler as @config."""
+    """App-authored tailwind.config.* must not be forwarded to Tailwind.
+
+    Tailwind config loading executes server-side JavaScript, so app themes
+    should use CSS-native @theme directives instead.
+    """
     src_dir = tmp_path / "src"
     src_dir.mkdir()
     (src_dir / "_layout.tsx").write_text(
@@ -416,7 +419,7 @@ async def test_generate_app_tailwind_threads_per_app_config(
         added, _ = await bundler._generate_app_tailwind(src_dir, sources)
 
     assert added is True
-    assert captured["config_path"] == str(config_file.resolve())
+    assert captured["config_path"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Packages the first critical Codex Security findings into scoped fixes tied to the draft GitHub Security Advisories:

- GHSA-m5r4-wp96-4vmh: harden app source replacement path boundaries
- GHSA-r6jj-c29m-m648: stop server-side Tailwind config evaluation from app source
- GHSA-g8wf-fpgx-m9rp / GHSA-vc48-23rj-6qxq: restrict agent tuning to platform admins or owner private agents
- GHSA-q276-xc3p-wv96: stop returning OAuth access tokens from CLI refresh
- GHSA-5pf3-54gh-85hj: block privileged agent-management tools from chat execution

## Verification

- `.\.venv\Scripts\python.exe -m pytest api\tests\unit\routers\test_cli_refresh_token.py api\tests\unit\services\test_agent_executor_tools.py::TestPrivilegedAgentManagementTools api\tests\unit\services\test_mcp_tools.py::TestMCPAgentPrivilegeBoundary api\tests\unit\test_agent_tuning_authorization.py api\tests\unit\test_app_bundler.py api\tests\integration\test_app_bundler_pipeline.py api\tests\unit\services\test_app_repoint.py -q`
- `48 passed in 22.00s`
- `git diff --check HEAD~4..HEAD`

## Notes

The corresponding repository security advisories are still draft/private. Keep detailed exploit discussion in the advisory records until disclosure is intentional.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MTG-Thomas/codesmith/bifrost/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Security**
  * Agent tuning now restricted to private agents owned by the requesting user.
  * Privileged agent management tools cannot be executed from chat contexts.
  * Sensitive MCP agent operations (global scope, privileged tools, delegation, knowledge sources) require platform admin privileges.

* **Breaking Changes**
  * OAuth token refresh no longer returns the rotated access token; clients must re-fetch integration data if needed.
  * Per-app Tailwind configuration files are no longer loaded during v4 compilation.
  * Application replacement `force` flag now only bypasses source-existence checks, not uniqueness or nesting validations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/172)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->