### PR TITLE
Escape MCP OAuth callback errors

### DIFF
--- a/api/src/routers/mcp_oauth_callback.py
+++ b/api/src/routers/mcp_oauth_callback.py
@@ -24,6 +24,8 @@ Behavior:
 
 from __future__ import annotations
 
+import html
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -64,6 +66,16 @@ router = APIRouter(prefix="/api/mcp/oauth", tags=["MCP Connections"])
 # =============================================================================
 
 
+def _json_for_inline_script(payload: dict[str, str]) -> str:
+    """Serialize JSON so it is safe inside an inline script element."""
+    return (
+        json.dumps(payload)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
 def _popup_response(*, success: bool, connection_id: str, error: str | None = None) -> HTMLResponse:
     """Render the popup-closing page that posts back to the opener.
 
@@ -77,26 +89,25 @@ def _popup_response(*, success: bool, connection_id: str, error: str | None = No
     on slow browsers. Inline JS sidesteps it.
     """
     if success:
-        message = (
-            "{type: 'mcp_oauth_success', connection_id: '"
-            + connection_id
-            + "'}"
+        message = _json_for_inline_script(
+            {
+                "type": "mcp_oauth_success",
+                "connection_id": connection_id,
+            }
         )
         body_text = "Connected. You can close this window."
     else:
-        # Escape any quotes the error string might carry; the simple
-        # repr->slice trick works because error is server-controlled.
-        safe_error = (error or "Unknown error").replace("'", "\\'")
-        message = (
-            "{type: 'mcp_oauth_error', connection_id: '"
-            + connection_id
-            + "', error: '"
-            + safe_error
-            + "'}"
+        error_text = error or "Unknown error"
+        message = _json_for_inline_script(
+            {
+                "type": "mcp_oauth_error",
+                "connection_id": connection_id,
+                "error": error_text,
+            }
         )
-        body_text = f"Connection failed: {error or 'Unknown error'}"
+        body_text = f"Connection failed: {html.escape(error_text)}"
 
-    html = f"""<!doctype html>
+    html_doc = f"""<!doctype html>
 <html><head><title>MCP OAuth</title></head>
 <body>
 <p>{body_text}</p>
@@ -113,7 +124,7 @@ def _popup_response(*, success: bool, connection_id: str, error: str | None = No
 }})();
 </script>
 </body></html>"""
-    return HTMLResponse(content=html, status_code=200 if success else 400)
+    return HTMLResponse(content=html_doc, status_code=200 if success else 400)
 
 
 # =============================================================================
@@ -307,11 +318,15 @@ async def mcp_oauth_callback(
     """Handle the vendor's redirect after the user consents (or refuses)."""
     # Vendor-side error: surface immediately without any state work.
     if error:
-        logger.info("MCP OAuth callback received vendor error: %s", log_safe(error))
+        logger.info(
+            "MCP OAuth callback received vendor error: %s (%s)",
+            log_safe(error),
+            log_safe(error_description or ""),
+        )
         return _popup_response(
             success=False,
             connection_id="",
-            error=f"{error}: {error_description}" if error_description else error,
+            error="OAuth provider rejected the connection request.",
         )
 
     # 1. Decode + verify state

--- a/api/tests/e2e/api/test_mcp_oauth_callback.py
+++ b/api/tests/e2e/api/test_mcp_oauth_callback.py
@@ -30,12 +30,13 @@ class TestMCPOAuthCallbackErrors:
                 "code": "",
                 "state": "ignored",
                 "error": "access_denied",
-                "error_description": "user clicked cancel",
+                "error_description": "</script><img src=x onerror=alert(1)>",
             },
         )
         assert resp.status_code == 400
-        assert "access_denied" in resp.text
-        assert "user clicked cancel" in resp.text
+        assert "OAuth provider rejected the connection request." in resp.text
+        assert "access_denied" not in resp.text
+        assert "onerror=alert" not in resp.text
 
     def test_callback_renders_popup_html(self, e2e_client):
         """The callback always renders an HTML page (window.opener

--- a/api/tests/unit/routers/test_mcp_oauth_callback.py
+++ b/api/tests/unit/routers/test_mcp_oauth_callback.py
@@ -49,8 +49,19 @@ class TestPopupResponse:
             success=False, connection_id="x", error="user's denied"
         )
         body = response.body.decode()
-        # JS-escaped single quote
-        assert "\\'" in body
+        assert '"error": "user\'s denied"' in body
+
+    def test_error_html_escapes_markup_and_script_breakout(self):
+        response = _popup_response(
+            success=False,
+            connection_id="conn-1",
+            error="</script><img src=x onerror=alert(1)>",
+        )
+        body = response.body.decode()
+
+        assert "<p>Connection failed: &lt;/script&gt;&lt;img src=x onerror=alert(1)&gt;</p>" in body
+        assert '"error": "</script><img src=x onerror=alert(1)>"' not in body
+        assert '"error": "\\u003c/script\\u003e\\u003cimg src=x onerror=alert(1)\\u003e"' in body
 
 
 class TestExchangeCodeForToken:
@@ -240,12 +251,13 @@ class TestCallbackHandler:
             code="",
             state="ignored",
             error="access_denied",
-            error_description="user clicked cancel",
+            error_description="</script><img src=x onerror=alert(1)>",
         )
         assert response.status_code == 400
         body = response.body.decode()
-        assert "access_denied" in body
-        assert "user clicked cancel" in body
+        assert "OAuth provider rejected the connection request." in body
+        assert "access_denied" not in body
+        assert "onerror=alert" not in body
 
     @pytest.mark.asyncio
     async def test_invalid_state_returns_error_without_db_io(self):


### PR DESCRIPTION
## Summary
- escape MCP OAuth callback error text before rendering it in the popup HTML
- JSON-encode postMessage payloads and escape inline-script breakouts such as `</script>`
- add regression coverage for markup/script-breakout payloads

## Security Finding
- Codex Cloud Security: Reflected XSS in MCP OAuth callback error page

## Verification
- `.\.venv\Scripts\python.exe -m pytest api/tests/unit/routers/test_mcp_oauth_callback.py -q`
- `python -m ruff check api/src/routers/mcp_oauth_callback.py api/tests/unit/routers/test_mcp_oauth_callback.py`
- `git diff --check`

Note: `bash ./test.sh tests/unit/routers/test_mcp_oauth_callback.py -q` failed before test execution in the local Docker harness because `minio-init` could not resolve the `minio` service. The repo virtualenv focused unit run passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MTG-Thomas/codesmith/bifrost/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth callback security with proper HTML and JSON escaping to prevent injection attacks.
  * Updated error responses to use generic messages instead of reflecting vendor-specific error details.

* **Tests**
  * Added tests to verify secure rendering of error messages and prevention of content injection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->