### PR TITLE
Fix Graph webhook subscription provisioning

### DIFF
--- a/api/src/jobs/schedulers/webhook_renewal.py
+++ b/api/src/jobs/schedulers/webhook_renewal.py
@@ -65,7 +65,7 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                     "external_id": webhook.external_id,
                     "state": webhook.state or {},
                     "integration": webhook.integration if webhook.integration_id else None,
-                    "callback_path": webhook.callback_path,
+                    "event_source_id": webhook.event_source_id,
                     "has_event_source": webhook.event_source is not None,
                 })
 
@@ -95,9 +95,10 @@ async def renew_expiring_webhooks() -> dict[str, Any]:
                     })
                     results["renewed_successfully"] += 1
                     logger.info(
-                        f"Renewed webhook subscription: {wh['callback_path']}",
+                        f"Renewed webhook subscription for event source {wh['event_source_id']}",
                         extra={
                             "webhook_id": str(wh["id"]),
+                            "event_source_id": str(wh["event_source_id"]),
                             "adapter": wh["adapter_name"],
                             "new_expires_at": renewal_result.expires_at.isoformat() if renewal_result.expires_at else None,
                         },

--- a/api/src/repositories/events.py
+++ b/api/src/repositories/events.py
@@ -23,6 +23,8 @@ from src.models.orm.events import (
     EventSubscription,
     WebhookSource,
 )
+from src.models.orm.integrations import Integration
+from src.models.orm.oauth import OAuthProvider
 from src.repositories.base import BaseRepository
 
 
@@ -186,7 +188,9 @@ class WebhookSourceRepository(BaseRepository[WebhookSource]):
                     ),
                     joinedload(EventSource.organization),
                 ),
-                joinedload(WebhookSource.integration),
+                joinedload(WebhookSource.integration)
+                .joinedload(Integration.oauth_provider)
+                .joinedload(OAuthProvider.tokens),
             )
             .where(WebhookSource.event_source_id == event_source_id)
         )
@@ -203,7 +207,9 @@ class WebhookSourceRepository(BaseRepository[WebhookSource]):
             select(WebhookSource)
             .options(
                 joinedload(WebhookSource.event_source),
-                joinedload(WebhookSource.integration),
+                joinedload(WebhookSource.integration)
+                .joinedload(Integration.oauth_provider)
+                .joinedload(OAuthProvider.tokens),
             )
             .where(WebhookSource.expires_at.isnot(None))
             .where(WebhookSource.expires_at <= expiry_threshold)

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import joinedload
 from src.core.auth import Context, CurrentSuperuser
 from src.core.database import DbSession
 from src.core.log_safety import log_safe
+from src.config import get_settings
 from src.models.contracts.events import (
     CreateDeliveryRequest,
     DynamicValuesRequest,
@@ -48,6 +49,8 @@ from src.models.orm.events import (
     ScheduleSource,
     WebhookSource,
 )
+from src.models.orm.integrations import Integration
+from src.models.orm.oauth import OAuthProvider
 from src.repositories.events import (
     EventDeliveryRepository,
     EventRepository,
@@ -63,8 +66,8 @@ router = APIRouter(prefix="/api/events", tags=["Events"])
 
 
 def _build_callback_url(source_id: UUID) -> str:
-    """Build callback URL path from event source ID."""
-    return f"/api/hooks/{source_id}"
+    """Build public callback URL from event source ID."""
+    return f"{get_settings().public_url.rstrip('/')}/api/hooks/{source_id}"
 
 
 async def _get_rate_limited_count(source_id: str) -> int:
@@ -413,8 +416,17 @@ async def create_source(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Adapter '{adapter_name}' requires integration",
                 )
-            # TODO: Load integration from database
-            # integration = await get_integration(request.webhook.integration_id)
+            integration_result = await db.execute(
+                select(Integration)
+                .options(joinedload(Integration.oauth_provider).joinedload(OAuthProvider.tokens))
+                .where(Integration.id == request.webhook.integration_id)
+            )
+            integration = integration_result.unique().scalar_one_or_none()
+            if not integration:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Integration not found",
+                )
 
         # Create webhook source record
         webhook_source = WebhookSource(
@@ -430,7 +442,6 @@ async def create_source(
         )
 
         # Call adapter subscribe (for external subscriptions)
-        # Note: callback_url is a path - client will combine with origin
         callback_url = _build_callback_url(source.id)
         try:
             result = await adapter.subscribe(

--- a/api/src/services/webhooks/adapters/microsoft_graph.py
+++ b/api/src/services/webhooks/adapters/microsoft_graph.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 
+from src.core.security import decrypt_secret
 from src.services.webhooks.protocol import (
     Deliver,
     HandleResult,
@@ -26,6 +27,31 @@ from src.services.webhooks.protocol import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _get_access_token(integration: Any | None) -> str:
+    """Read a Graph access token from SDK-style or ORM-style integration data."""
+    if not integration:
+        raise ValueError("Microsoft integration with OAuth is required")
+
+    oauth = getattr(integration, "oauth", None)
+    access_token = getattr(oauth, "access_token", None)
+    if access_token:
+        return access_token
+
+    provider = getattr(integration, "oauth_provider", None)
+    tokens = getattr(provider, "tokens", None) if provider else None
+    token = next(iter(tokens or []), None)
+    encrypted_access_token = getattr(token, "encrypted_access_token", None)
+    if encrypted_access_token:
+        raw_token = (
+            encrypted_access_token.decode()
+            if isinstance(encrypted_access_token, bytes)
+            else encrypted_access_token
+        )
+        return decrypt_secret(raw_token)
+
+    raise ValueError("OAuth access token is required")
 
 
 class MicrosoftGraphAdapter(WebhookAdapter):
@@ -120,12 +146,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
 
     async def _list_users(self, integration: Any | None) -> list[dict[str, Any]]:
         """Fetch users from Microsoft Graph API."""
-        if not integration or not integration.oauth:
-            raise ValueError("Microsoft integration with OAuth is required")
-
-        access_token = integration.oauth.access_token
-        if not access_token:
-            raise ValueError("OAuth access token is required")
+        access_token = _get_access_token(integration)
 
         async with httpx.AsyncClient() as client:
             response = await client.get(
@@ -209,12 +230,7 @@ class MicrosoftGraphAdapter(WebhookAdapter):
 
         Calls POST /subscriptions to register the webhook with Graph API.
         """
-        if not integration or not integration.oauth:
-            raise ValueError("Microsoft integration with OAuth is required")
-
-        access_token = integration.oauth.access_token
-        if not access_token:
-            raise ValueError("OAuth access token is required")
+        access_token = _get_access_token(integration)
 
         # Generate client state for validation
         client_state = self.generate_secret(32)
@@ -279,11 +295,9 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         if not external_id:
             return
 
-        if not integration or not integration.oauth:
-            return
-
-        access_token = integration.oauth.access_token
-        if not access_token:
+        try:
+            access_token = _get_access_token(integration)
+        except ValueError:
             return
 
         try:
@@ -311,11 +325,9 @@ class MicrosoftGraphAdapter(WebhookAdapter):
         if not external_id:
             return None
 
-        if not integration or not integration.oauth:
-            return None
-
-        access_token = integration.oauth.access_token
-        if not access_token:
+        try:
+            access_token = _get_access_token(integration)
+        except ValueError:
             return None
 
         # Extend for another 3 days

--- a/api/tests/unit/routers/test_events_webhook_callbacks.py
+++ b/api/tests/unit/routers/test_events_webhook_callbacks.py
@@ -1,0 +1,20 @@
+"""Tests for event webhook callback URL construction."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from src.routers import events
+
+
+def test_build_callback_url_uses_public_url(monkeypatch):
+    source_id = uuid4()
+    monkeypatch.setattr(
+        events,
+        "get_settings",
+        lambda: SimpleNamespace(public_url="https://bifrost.example.com/"),
+    )
+
+    assert (
+        events._build_callback_url(source_id)
+        == f"https://bifrost.example.com/api/hooks/{source_id}"
+    )

--- a/api/tests/unit/services/test_webhook_adapters.py
+++ b/api/tests/unit/services/test_webhook_adapters.py
@@ -7,11 +7,13 @@ request handling logic.
 
 import hashlib
 import hmac
+from types import SimpleNamespace
 
 import pytest
 
 from src.services.webhooks.adapters.generic import GenericWebhookAdapter
-from src.services.webhooks.protocol import Deliver, Rejected, WebhookAdapter, WebhookRequest
+from src.services.webhooks.adapters.microsoft_graph import MicrosoftGraphAdapter
+from src.services.webhooks.protocol import Deliver, Rejected, ValidationResponse, WebhookAdapter, WebhookRequest
 
 
 def _sign(body: bytes, secret: str, prefix: str = "sha256=") -> str:
@@ -263,3 +265,93 @@ class TestGenericWebhookAdapterSubscribe:
         )
 
         assert result.state == {}
+
+
+# =============================================================================
+# TestMicrosoftGraphAdapter
+# =============================================================================
+
+
+class TestMicrosoftGraphAdapter:
+    """Tests for MicrosoftGraphAdapter Graph-specific behavior."""
+
+    @pytest.fixture
+    def adapter(self):
+        return MicrosoftGraphAdapter()
+
+    @pytest.mark.asyncio
+    async def test_validation_token_returns_plain_text_response(self, adapter):
+        request = WebhookRequest(
+            method="GET",
+            path="/api/hooks/source-id",
+            headers={},
+            query_params={"validationToken": "probe-token"},
+            body=b"",
+        )
+
+        result = await adapter.handle_request(request, config={}, state={})
+
+        assert isinstance(result, ValidationResponse)
+        assert result.status_code == 200
+        assert result.body == "probe-token"
+        assert result.content_type == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_subscribe_reads_orm_oauth_token(self, adapter, monkeypatch):
+        calls = []
+
+        class FakeResponse:
+            status_code = 201
+
+            def json(self):
+                return {
+                    "id": "graph-subscription-id",
+                    "expirationDateTime": "2026-05-16T12:00:00Z",
+                }
+
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, headers, json, timeout):
+                calls.append({
+                    "url": url,
+                    "headers": headers,
+                    "json": json,
+                    "timeout": timeout,
+                })
+                return FakeResponse()
+
+        monkeypatch.setattr(
+            "src.services.webhooks.adapters.microsoft_graph.decrypt_secret",
+            lambda encrypted: "decrypted-access-token",
+        )
+        monkeypatch.setattr(
+            "src.services.webhooks.adapters.microsoft_graph.httpx.AsyncClient",
+            FakeClient,
+        )
+
+        integration = SimpleNamespace(
+            oauth_provider=SimpleNamespace(
+                tokens=[
+                    SimpleNamespace(encrypted_access_token=b"encrypted-token"),
+                ]
+            )
+        )
+
+        result = await adapter.subscribe(
+            callback_url="https://bifrost.example.com/api/hooks/source-id",
+            config={
+                "resource": "/users/midbot@midtowntg.com/messages",
+                "change_types": ["created"],
+            },
+            integration=integration,
+        )
+
+        assert result.external_id == "graph-subscription-id"
+        assert result.state["client_state"]
+        assert calls[0]["headers"]["Authorization"] == "Bearer decrypted-access-token"
+        assert calls[0]["json"]["notificationUrl"] == "https://bifrost.example.com/api/hooks/source-id"


### PR DESCRIPTION
## Summary
- load the selected Microsoft integration before Graph webhook subscription creation
- build external webhook callback URLs from `BIFROST_PUBLIC_URL`
- allow the Graph adapter to read Bifrost's ORM OAuth token shape
- eager-load Graph OAuth tokens for webhook dispatch and renewal, and fix renewal logging state

## Validation
- `python -m pytest api\tests\unit\services\test_webhook_adapters.py api\tests\unit\routers\test_events_webhook_callbacks.py -q`
- `python -m ruff check api\src\routers\events.py api\src\services\webhooks\adapters\microsoft_graph.py api\src\repositories\events.py api\src\jobs\schedulers\webhook_renewal.py api\tests\unit\services\test_webhook_adapters.py api\tests\unit\routers\test_events_webhook_callbacks.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Webhook callback URLs now utilize the configured public base URL for proper external accessibility
  * Enhanced webhook renewal logging with improved context tracking
  * Optimized OAuth token handling in webhook adapters for better integration support
  * More efficient eager-loading of OAuth provider data when fetching webhook sources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/181)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->