### PR TITLE
Speed up PR E2E feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # =============================================================================
-  # E2E Tests - Slow, only gates tag releases
+  # E2E Tests - PR smoke lane, full suite on merge queue/tags/manual dispatch
   # =============================================================================
   test-e2e:
     # Skip on push: main — covered by the merge_group run.
@@ -166,11 +166,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Run E2E tests
+      - name: Run PR E2E smoke tests
+        if: github.event_name == 'pull_request'
+        run: |
+          chmod +x test.sh
+          ./test.sh stack up
+          ./test.sh e2e-smoke
+
+      - name: Run full E2E tests
+        if: github.event_name != 'pull_request'
         run: |
           chmod +x test.sh
           ./test.sh stack up
           ./test.sh e2e
+
+      - name: Upload E2E timing and JUnit artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-test-artifacts
+          path: |
+            /tmp/bifrost-*/test-results.xml
+            /tmp/bifrost-*/test-runner.log
+          if-no-files-found: ignore
 
   # =============================================================================
   # Dev Build - Every push to main, gated by unit tests only

--- a/test.sh
+++ b/test.sh
@@ -233,7 +233,7 @@ run_pytest() {
     require_stack_up
     reset_state
     docker compose -f "$COMPOSE_FILE" --profile test run --rm test-runner \
-        pytest "$@" --durations=25 --junitxml="/tmp/bifrost/test-results.xml" 2>&1 | tee "$LOG_DIR/test-runner.log"
+        pytest "$@" --durations=25 --junitxml="$LOG_DIR/test-results.xml" 2>&1 | tee "$LOG_DIR/test-runner.log"
     return "${PIPESTATUS[0]}"
 }
 

--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,7 @@
 # Backend tests (stack must be up):
 #   ./test.sh                           Unit tests only (fast default).
 #   ./test.sh unit                      Same as above.
+#   ./test.sh e2e-smoke                 PR-gating backend e2e smoke tests.
 #   ./test.sh e2e                       Backend e2e tests.
 #   ./test.sh all                       Unit + e2e (mirrors CI).
 #   ./test.sh tests/path/... [args]     Pass through to pytest.
@@ -232,11 +233,20 @@ run_pytest() {
     require_stack_up
     reset_state
     docker compose -f "$COMPOSE_FILE" --profile test run --rm test-runner \
-        pytest "$@" --junitxml="/tmp/bifrost/test-results.xml" 2>&1 | tee "$LOG_DIR/test-runner.log"
+        pytest "$@" --durations=25 --junitxml="/tmp/bifrost/test-results.xml" 2>&1 | tee "$LOG_DIR/test-runner.log"
     return "${PIPESTATUS[0]}"
 }
 
 cmd_unit() { run_pytest tests/ --ignore=tests/e2e/ -v "$@"; }
+cmd_e2e_smoke() {
+    run_pytest \
+        tests/e2e/api/test_auth.py::TestHealthCheck \
+        tests/e2e/api/test_auth.py::TestRegistrationFlow::test_platform_admin_can_access_protected_endpoints \
+        tests/e2e/api/test_workflows.py::TestWorkflowListing \
+        tests/e2e/api/test_workflows.py::TestWorkflowValidation::test_validate_valid_workflow \
+        tests/e2e/platform/test_cli_ephemeral_login.py::test_ephemeral_env_vars_authenticate_bifrost_api_subprocess \
+        -v "$@"
+}
 cmd_e2e()  { run_pytest tests/e2e/ -v "$@"; }
 cmd_all()  { run_pytest tests/ -v "$@"; }
 
@@ -342,6 +352,7 @@ fi
 case "$1" in
     stack) shift; cmd_stack "$@" ;;
     unit) shift; cmd_unit "$@" ;;
+    e2e-smoke) shift; cmd_e2e_smoke "$@" ;;
     e2e) shift; cmd_e2e "$@" ;;
     all) shift; cmd_all "$@" ;;
     client) shift; cmd_client "$@" ;;


### PR DESCRIPTION
## Summary
- add an e2e-smoke test runner command for PR feedback
- run smoke E2E on pull_request and full E2E on merge queue/tags/manual dispatch
- upload E2E JUnit and timing logs as workflow artifacts

## Verification
- git diff --check -- .github/workflows/ci.yml test.sh
- python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8')); print('yaml ok')"
- bash -n test.sh
- python -m pytest tests/e2e/api/test_auth.py::TestHealthCheck tests/e2e/api/test_auth.py::TestRegistrationFlow::test_platform_admin_can_access_protected_endpoints tests/e2e/api/test_workflows.py::TestWorkflowListing tests/e2e/api/test_workflows.py::TestWorkflowValidation::test_validate_valid_workflow tests/e2e/platform/test_cli_ephemeral_login.py::test_ephemeral_env_vars_authenticate_bifrost_api_subprocess --collect-only -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with optimized E2E testing: smoke tests for pull requests, full suite for merges and releases.
  * Added `e2e-smoke` command for faster test feedback.
  * Automated collection and upload of test timing and junit artifacts after each test run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->