### PR TITLE
Add optional Sentry monitoring

### DIFF
--- a/api/src/config.py
+++ b/api/src/config.py
@@ -120,6 +120,33 @@ class Settings(BaseSettings):
     )
 
     # ==========================================================================
+    # Error Monitoring (Sentry)
+    # ==========================================================================
+    sentry_dsn: str | None = Field(
+        default=None,
+        description="Sentry DSN. When unset, Sentry is disabled."
+    )
+
+    sentry_traces_sample_rate: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Sentry performance trace sample rate. Defaults to errors only."
+    )
+
+    sentry_profiles_sample_rate: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Sentry profiling sample rate. Defaults to disabled."
+    )
+
+    sentry_send_default_pii: bool = Field(
+        default=False,
+        description="Allow Sentry to send default PII such as headers and user IPs."
+    )
+
+    # ==========================================================================
     # Redis
     # ==========================================================================
     redis_url: str = Field(

--- a/api/src/core/sentry.py
+++ b/api/src/core/sentry.py
@@ -1,0 +1,110 @@
+"""Optional Sentry integration with conservative privacy defaults."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+SENSITIVE_KEYS = {
+    "access_token",
+    "api_key",
+    "authorization",
+    "cookie",
+    "cookies",
+    "database_url",
+    "dsn",
+    "id_token",
+    "jwt",
+    "password",
+    "refresh_token",
+    "secret",
+    "secret_key",
+    "session",
+    "token",
+    "x-api-key",
+}
+
+FILTERED = "[Filtered]"
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = str(key).lower().replace("-", "_")
+    return any(sensitive.replace("-", "_") in normalized for sensitive in SENSITIVE_KEYS)
+
+
+def _scrub_url(value: str) -> str:
+    parts = urlsplit(value)
+    if not parts.query:
+        return value
+
+    query = []
+    changed = False
+    for key, query_value in parse_qsl(parts.query, keep_blank_values=True):
+        if _is_sensitive_key(key):
+            query.append((key, FILTERED))
+            changed = True
+        else:
+            query.append((key, query_value))
+
+    if not changed:
+        return value
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+
+def _scrub(value: Any) -> Any:
+    if isinstance(value, dict):
+        scrubbed: dict[Any, Any] = {}
+        for key, item in value.items():
+            scrubbed[key] = FILTERED if _is_sensitive_key(key) else _scrub(item)
+        return scrubbed
+    if isinstance(value, list):
+        return [_scrub(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub(item) for item in value)
+    return value
+
+
+def before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
+    """Scrub sensitive data from Sentry events before upload."""
+    scrubbed = _scrub(deepcopy(event))
+    request = scrubbed.get("request")
+    if isinstance(request, dict):
+        request["cookies"] = FILTERED if request.get("cookies") else request.get("cookies")
+        url = request.get("url")
+        if isinstance(url, str):
+            request["url"] = _scrub_url(url)
+    return scrubbed
+
+
+def configure_sentry(settings: Any | None = None, sentry_sdk_module: Any | None = None) -> bool:
+    """Initialize Sentry if BIFROST_SENTRY_DSN is configured.
+
+    Returns True when Sentry was initialized and False when it is intentionally
+    disabled or the optional SDK dependency is unavailable.
+    """
+    if settings is None:
+        from src.config import get_settings
+
+        settings = get_settings()
+
+    dsn = getattr(settings, "sentry_dsn", None)
+    if not dsn:
+        return False
+
+    if sentry_sdk_module is None:
+        try:
+            import sentry_sdk as sentry_sdk_module
+        except ImportError:
+            return False
+
+    sentry_sdk_module.init(
+        dsn=dsn,
+        environment=getattr(settings, "environment", None),
+        send_default_pii=getattr(settings, "sentry_send_default_pii", False),
+        enable_logs=False,
+        traces_sample_rate=getattr(settings, "sentry_traces_sample_rate", 0.0),
+        profile_session_sample_rate=getattr(settings, "sentry_profiles_sample_rate", 0.0),
+        before_send=before_send,
+    )
+    return True

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -267,7 +267,10 @@ def create_app() -> FastAPI:
     Returns:
         Configured FastAPI application instance
     """
+    from src.core.sentry import configure_sentry
     from shared.version import get_version
+
+    configure_sentry(get_settings())
 
     app = FastAPI(
         title="Bifrost API",

--- a/api/tests/unit/core/test_sentry.py
+++ b/api/tests/unit/core/test_sentry.py
@@ -1,0 +1,125 @@
+"""Tests for optional Sentry initialization."""
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from src.config import get_settings
+from src.core import sentry as sentry_core
+
+
+class FakeSentrySdk:
+    def __init__(self):
+        self.calls = []
+
+    def init(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def settings(**overrides):
+    values = {
+        "sentry_dsn": None,
+        "sentry_traces_sample_rate": 0.0,
+        "sentry_profiles_sample_rate": 0.0,
+        "sentry_send_default_pii": False,
+        "environment": "testing",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_configure_sentry_noops_without_dsn():
+    fake_sdk = FakeSentrySdk()
+
+    assert sentry_core.configure_sentry(settings(), sentry_sdk_module=fake_sdk) is False
+    assert fake_sdk.calls == []
+
+
+def test_configure_sentry_uses_privacy_first_defaults():
+    fake_sdk = FakeSentrySdk()
+
+    configured = sentry_core.configure_sentry(
+        settings(sentry_dsn="https://example@sentry.invalid/1"),
+        sentry_sdk_module=fake_sdk,
+    )
+
+    assert configured is True
+    init_kwargs = fake_sdk.calls[0]
+    assert init_kwargs["dsn"] == "https://example@sentry.invalid/1"
+    assert init_kwargs["environment"] == "testing"
+    assert init_kwargs["send_default_pii"] is False
+    assert init_kwargs["enable_logs"] is False
+    assert init_kwargs["traces_sample_rate"] == pytest.approx(0.0)
+    assert init_kwargs["profile_session_sample_rate"] == pytest.approx(0.0)
+    assert callable(init_kwargs["before_send"])
+
+
+def test_app_startup_configures_sentry_from_env(monkeypatch):
+    captured_settings = []
+
+    monkeypatch.setenv("BIFROST_SENTRY_DSN", "https://example@sentry.invalid/1")
+    monkeypatch.setenv("BIFROST_SENTRY_TRACES_SAMPLE_RATE", "0.25")
+    monkeypatch.setenv("BIFROST_SENTRY_PROFILES_SAMPLE_RATE", "0.10")
+
+    def fake_configure_sentry(settings):
+        captured_settings.append(settings)
+        return True
+
+    get_settings.cache_clear()
+    monkeypatch.setattr(sentry_core, "configure_sentry", fake_configure_sentry)
+    sys.modules.pop("src.main", None)
+
+    try:
+        main_module = importlib.import_module("src.main")
+        assert main_module.app.title == "Bifrost API"
+    finally:
+        sys.modules.pop("src.main", None)
+        get_settings.cache_clear()
+
+    assert len(captured_settings) == 1
+    settings = captured_settings[0]
+    assert settings.sentry_dsn == "https://example@sentry.invalid/1"
+    assert settings.sentry_traces_sample_rate == pytest.approx(0.25)
+    assert settings.sentry_profiles_sample_rate == pytest.approx(0.10)
+    assert settings.sentry_send_default_pii is False
+
+
+def test_before_send_scrubs_sensitive_request_data():
+    event = {
+        "request": {
+            "url": "https://bifrost.example/api?access_token=secret-token&ok=1",
+            "headers": {
+                "Authorization": "Bearer secret-token",
+                "Cookie": "access_token=secret-cookie",
+                "X-Api-Key": "secret-key",
+                "X-Request-ID": "req-123",
+            },
+            "cookies": {"session": "secret-session"},
+            "data": {
+                "password": "secret-password",
+                "nested": {"refresh_token": "secret-refresh"},
+                "safe": "value",
+            },
+        },
+        "extra": {
+            "database_url": "postgresql://user:pass@example/db",
+            "workflow": {"name": "safe"},
+        },
+    }
+
+    scrubbed = sentry_core.before_send(event, hint={})
+
+    request = scrubbed["request"]
+    assert "secret-token" not in request["url"]
+    assert request["headers"]["Authorization"] == "[Filtered]"
+    assert request["headers"]["Cookie"] == "[Filtered]"
+    assert request["headers"]["X-Api-Key"] == "[Filtered]"
+    assert request["headers"]["X-Request-ID"] == "req-123"
+    assert request["cookies"] == "[Filtered]"
+    assert request["data"]["password"] == "[Filtered]"
+    assert request["data"]["nested"]["refresh_token"] == "[Filtered]"
+    assert request["data"]["safe"] == "value"
+    assert scrubbed["extra"]["database_url"] == "[Filtered]"
+    assert scrubbed["extra"]["workflow"]["name"] == "safe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ dependencies = [
     # =========================================================================
     "python-json-logger",
     "structlog",
+    "sentry-sdk[fastapi]",
     "psutil",  # Process monitoring for worker heartbeats
 
     # =========================================================================

--- a/requirements.lock
+++ b/requirements.lock
@@ -421,6 +421,7 @@ certifi==2026.4.22 \
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 cffi==2.0.0 \
     --hash=sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb \
     --hash=sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b \
@@ -927,7 +928,9 @@ exceptiongroup==1.3.1 \
 fastapi==0.136.1 \
     --hash=sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f \
     --hash=sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f
-    # via bifrost-api (pyproject.toml)
+    # via
+    #   bifrost-api (pyproject.toml)
+    #   sentry-sdk
 fastmcp==3.2.4 \
     --hash=sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1 \
     --hash=sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9
@@ -2595,6 +2598,10 @@ secretstorage==3.5.0 \
     --hash=sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137 \
     --hash=sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be
     # via keyring
+sentry-sdk[fastapi]==2.60.0 \
+    --hash=sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978 \
+    --hash=sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803
+    # via bifrost-api (pyproject.toml)
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -2758,6 +2765,7 @@ urllib3==2.6.3 \
     #   dulwich
     #   pygithub
     #   requests
+    #   sentry-sdk
 uvicorn[standard]==0.46.0 \
     --hash=sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048 \
     --hash=sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d


### PR DESCRIPTION
## Summary
- add optional Sentry SDK initialization before FastAPI app creation
- keep privacy/volume defaults conservative: no DSN means disabled, PII/logs/tracing/profiling off by default
- scrub sensitive request, auth, token, DSN, and database URL fields before events leave the API

## Verification
- VM over Netbird: ./test.sh tests/unit/core/test_sentry.py -v -> 4 passed in 4.23s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Integrated Sentry error monitoring to capture and track application errors
* Privacy-focused automatic scrubbing of sensitive data in monitored events
* Configurable monitoring parameters (sampling rates, PII handling) via environment variables with privacy-first defaults

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->