### PR TITLE
Block privileged agent system tools

### DIFF
--- a/api/src/services/execution/agent_helpers.py
+++ b/api/src/services/execution/agent_helpers.py
@@ -13,6 +13,7 @@ from src.models.orm.external_mcp import (
     MCPConnection,
     MCPServer,
 )
+from src.core.system_agents import is_privileged_agent_management_tool
 from src.services.llm import ToolDefinition
 from src.services.tool_registry import ToolRegistry
 
@@ -134,7 +135,12 @@ async def resolve_agent_tools(
     seen_names: dict[str, str] = {}
 
     # 1. System tools first (they always win conflicts)
-    system_tool_ids = list(agent.system_tools or [])
+    configured_system_tool_ids = list(agent.system_tools or [])
+    system_tool_ids = [
+        tool_id
+        for tool_id in configured_system_tool_ids
+        if not is_privileged_agent_management_tool(tool_id)
+    ]
 
     # Auto-add search_knowledge when agent has knowledge sources
     if agent.knowledge_sources and "search_knowledge" not in system_tool_ids:

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -27,6 +27,7 @@ from src.models.orm.agent_runs import AgentRun, AgentRunStep
 from src.core.constants import SYSTEM_USER_ID, SYSTEM_USER_EMAIL
 from src.core.cache.keys import agent_run_steps_stream_key
 from src.core.pubsub import publish_agent_run_step
+from src.core.system_agents import is_privileged_agent_management_tool
 from src.services.execution.agent_helpers import (
     build_agent_system_prompt,
     find_delegated_agent,
@@ -427,6 +428,10 @@ class AutonomousAgentExecutor:
 
         # System tools
         if tool_call.name in (agent.system_tools or []):
+            if is_privileged_agent_management_tool(tool_call.name):
+                raise ToolError(
+                    f"System tool '{tool_call.name}' cannot be executed from autonomous agents"
+                )
             return await self._execute_system_tool(tool_call, agent)
 
         # External MCP tools — namespaced ``mcp__<connection_id>__<tool>``.

--- a/api/tests/unit/services/test_agent_helpers.py
+++ b/api/tests/unit/services/test_agent_helpers.py
@@ -67,6 +67,50 @@ class TestResolveAgentTools:
         assert "search_knowledge" in tool_names
 
     @pytest.mark.asyncio
+    @patch("src.services.mcp_server.server.get_system_tools")
+    async def test_filters_privileged_agent_management_system_tools(self, mock_get_system_tools):
+        """Privileged agent-management tools are not exposed to agent planners."""
+        mock_get_system_tools.return_value = [
+            {
+                "id": "create_agent",
+                "description": "Create an agent",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            {
+                "id": "update_agent",
+                "description": "Update an agent",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            {
+                "id": "delete_agent",
+                "description": "Delete an agent",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            {
+                "id": "list_workflows",
+                "description": "List workflows",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ]
+        mock_session = MagicMock()
+        mock_agent = MagicMock()
+        mock_agent.id = uuid4()
+        mock_agent.organization_id = None
+        mock_agent.tools = []
+        mock_agent.system_tools = [
+            "create_agent",
+            "list_workflows",
+            "update_agent",
+            "delete_agent",
+        ]
+        mock_agent.knowledge_sources = []
+        mock_agent.delegated_agents = []
+
+        tools, _ = await resolve_agent_tools(mock_agent, mock_session)
+
+        assert [t.name for t in tools] == ["list_workflows"]
+
+    @pytest.mark.asyncio
     @patch("src.services.mcp_server.server.get_system_tools", return_value=[])
     async def test_no_tools_returns_empty(self, _mock_get_system_tools):
         """Agent with no tools returns empty lists."""

--- a/api/tests/unit/services/test_autonomous_agent_executor.py
+++ b/api/tests/unit/services/test_autonomous_agent_executor.py
@@ -9,6 +9,7 @@ from src.services.execution.agent_helpers import find_delegated_agent
 from src.services.execution.autonomous_agent_executor import (
     AutonomousAgentExecutor,
     MAX_DELEGATION_DEPTH,
+    ToolError,
 )
 from src.services.llm.base import LLMResponse, ToolCallRequest
 
@@ -728,6 +729,20 @@ class TestAutonomousAgentExecutor:
         # Verify a tool_error step was buffered (Redis-first pattern)
         error_steps = [s for s in executor._pending_steps if s["type"] == "tool_error"]
         assert len(error_steps) >= 1
+
+    @pytest.mark.asyncio
+    async def test_privileged_agent_management_tool_is_blocked(self, mock_session, mock_agent):
+        """Autonomous agents cannot execute privileged agent-management system tools."""
+        mock_agent.system_tools = ["create_agent"]
+
+        executor = AutonomousAgentExecutor(mock_session)
+        tool_call = ToolCallRequest(id="tc1", name="create_agent", arguments={})
+
+        with patch.object(executor, "_execute_system_tool", new_callable=AsyncMock) as mock_system_tool:
+            with pytest.raises(ToolError, match="cannot be executed from autonomous agents"):
+                await executor._execute_tool(tool_call, mock_agent)
+
+        mock_system_tool.assert_not_awaited()
 
     @pytest.mark.asyncio
     @patch("src.services.execution.autonomous_agent_executor.get_llm_client")


### PR DESCRIPTION
## Summary
- filter privileged agent-management system tools out of planner-visible agent tool definitions
- block autonomous agent execution of privileged agent-management system tools
- add regression coverage for resolver filtering and autonomous dispatch denial

## Verification
- uv run ruff check api/src/services/execution/agent_helpers.py api/src/services/execution/autonomous_agent_executor.py api/tests/unit/services/test_agent_helpers.py api/tests/unit/services/test_autonomous_agent_executor.py
- uv run python -m pytest api/tests/unit/services/test_agent_helpers.py api/tests/unit/services/test_agent_executor_tools.py api/tests/unit/services/test_autonomous_agent_executor.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autonomous agents are now restricted from executing privileged agent management operations. System tool resolution has been updated to filter out restricted administrative tools from agent access.

* **Tests**
  * Added test coverage to verify proper filtering of privileged agent management tools and confirm that autonomous agents cannot execute these restricted operations during execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->