### PR TITLE
Harden release tag version handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,8 +219,8 @@ jobs:
         id: version
         run: |
           VERSION=$(./scripts/compute-dev-version.sh)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       # Surface manifest drift to the job summary. The plugin manifest is
       # updated at tag time (see bifrost-release skill) — between tags the
@@ -343,7 +343,11 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Release tag '${GITHUB_REF#refs/tags/}' must be strict semver like v1.2.3 or v1.2.3-beta.1."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       # Hard guard: the plugin manifest version must match the tag, otherwise
       # Claude Code's plugin marketplace will keep serving stale skill content
@@ -354,7 +358,7 @@ jobs:
       - name: Verify plugin manifest matches tag
         run: |
           MANIFEST_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-          TAG_VERSION="${{ steps.version.outputs.version }}"
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           if [[ "$MANIFEST_VERSION" != "$TAG_VERSION" ]]; then
             echo "::error::.claude-plugin/plugin.json version ($MANIFEST_VERSION) does not match tag ($TAG_VERSION)."
             echo "::error::Run 'scripts/update-plugin-version.sh $TAG_VERSION' on main, commit, then re-tag."
@@ -441,7 +445,11 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Release tag '${GITHUB_REF#refs/tags/}' must be strict semver like v1.2.3 or v1.2.3-beta.1."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -524,13 +532,18 @@ jobs:
         id: get_version
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "image_tag=${VERSION#v}" >> $GITHUB_OUTPUT
+          IMAGE_TAG="${VERSION#v}"
+          if [[ ! "$IMAGE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Release tag '$VERSION' must be strict semver like v1.2.3 or v1.2.3-beta.1."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           # Check if this is a pre-release (contains hyphen like v1.0.0-beta)
           if [[ "$VERSION" == *-* ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Copy type stubs
@@ -547,7 +560,7 @@ jobs:
       - name: Build source tarball
         id: source_tarball
         run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
+          VERSION="${GITHUB_REF#refs/tags/}"
           TARBALL="bifrost-${VERSION}-source.tar.gz"
           git archive --format=tar.gz --prefix="bifrost-${VERSION}/" -o "${TARBALL}" HEAD
           sha256sum "${TARBALL}" | tee "${TARBALL}.sha256"


### PR DESCRIPTION
## Summary
- validate release tags as strict semver before writing tag-derived workflow outputs
- avoid reinjecting tag-derived Actions outputs into shell run blocks
- quote GitHub output writes caught by actionlint while touching the workflow

## Verification
- actionlint .github/workflows/ci.yml
- uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8')); print('ci.yml parses')"
- PowerShell regex sanity check for accepted/rejected release versions
- git diff --check