### PR TITLE
Scope MCP agent knowledge access by org

### DIFF
--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -9,7 +9,7 @@ import logging
 from dataclasses import dataclass
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -96,6 +96,7 @@ class MCPToolAccessService:
         accessible_agents = await self._get_accessible_agents(
             user_roles=user_roles,
             is_superuser=is_superuser,
+            org_id=org_id,
         )
 
         # Step 2: Collect tools from accessible agents, enforcing per-workflow
@@ -189,6 +190,7 @@ class MCPToolAccessService:
             .where(Agent.id == str(agent_id))
             .where(Agent.is_active.is_(True))
         )
+        query = self._apply_agent_org_scope(query, org_id=org_id, is_superuser=is_superuser)
 
         result = await self.session.execute(query)
         agent = result.scalars().unique().first()
@@ -198,6 +200,10 @@ class MCPToolAccessService:
             return None
 
         # Check access using same rules as _get_accessible_agents
+        if not self._agent_in_org_scope(agent, org_id=org_id, is_superuser=is_superuser):
+            logger.warning(f"User denied org-scoped access to agent {agent_id}")
+            return None
+
         if not self._check_agent_access(agent, user_roles, is_superuser):
             logger.warning(f"User denied access to agent {agent_id}")
             return None
@@ -354,6 +360,7 @@ class MCPToolAccessService:
         self,
         user_roles: list[str],
         is_superuser: bool,
+        org_id: UUID | str | None = None,
     ) -> list[Agent]:
         """
         Get agents accessible to the user based on access_level and roles.
@@ -374,9 +381,15 @@ class MCPToolAccessService:
             )
             .where(Agent.is_active.is_(True))
         )
+        query = self._apply_agent_org_scope(query, org_id=org_id, is_superuser=is_superuser)
 
         result = await self.session.execute(query)
         all_agents = result.scalars().unique().all()
+        all_agents = [
+            agent
+            for agent in all_agents
+            if self._agent_in_org_scope(agent, org_id=org_id, is_superuser=is_superuser)
+        ]
 
         # Filter by access level
         accessible_agents: list[Agent] = []
@@ -404,6 +417,39 @@ class MCPToolAccessService:
             # as MCP requires authentication
 
         return accessible_agents
+
+    @staticmethod
+    def _apply_agent_org_scope(query, org_id: UUID | str | None, is_superuser: bool):
+        """Apply AgentRepository-style cascade scoping to MCP-visible agents."""
+        if org_id is None:
+            if is_superuser:
+                return query
+            return query.where(Agent.organization_id.is_(None))
+
+        return query.where(
+            or_(
+                Agent.organization_id == org_id,
+                Agent.organization_id.is_(None),
+            )
+        )
+
+    @staticmethod
+    def _agent_in_org_scope(
+        agent: Agent,
+        org_id: UUID | str | None,
+        is_superuser: bool,
+    ) -> bool:
+        """Return whether an already-loaded agent is in the caller's org scope."""
+        agent_org_id = (
+            getattr(agent, "organization_id", None)
+            if "organization_id" in getattr(agent, "__dict__", {})
+            else None
+        )
+
+        if org_id is None:
+            return is_superuser or agent_org_id is None
+
+        return agent_org_id is None or str(agent_org_id) == str(org_id)
 
     def _apply_config_filters(
         self,

--- a/api/tests/unit/services/mcp_server/test_tool_access.py
+++ b/api/tests/unit/services/mcp_server/test_tool_access.py
@@ -59,6 +59,7 @@ def mock_agent(mock_role, mock_workflow):
     def _create_agent(
         name: str = "Test Agent",
         access_level: AgentAccessLevel = AgentAccessLevel.AUTHENTICATED,
+        organization_id=None,
         system_tools: list[str] | None = None,
         knowledge_sources: list[str] | None = None,
         roles: list[str] | None = None,
@@ -68,6 +69,7 @@ def mock_agent(mock_role, mock_workflow):
         agent.id = uuid4()
         agent.name = name
         agent.access_level = access_level
+        agent.organization_id = organization_id
         agent.is_active = True
         agent.system_tools = system_tools or []
         agent.knowledge_sources = knowledge_sources or []
@@ -161,6 +163,41 @@ class TestGetAccessibleAgents:
 
         assert len(result) == 1
         assert result[0].id == agent.id
+
+    @pytest.mark.asyncio
+    async def test_org_user_only_sees_global_and_own_org_agents(
+        self, service, mock_session, mock_agent
+    ):
+        """Org-scoped MCP callers cannot collect tools from another org's agents."""
+        caller_org_id = uuid4()
+        other_org_id = uuid4()
+        global_agent = mock_agent(
+            name="Global Agent",
+            organization_id=None,
+            knowledge_sources=["global-docs"],
+        )
+        own_org_agent = mock_agent(
+            name="Own Org Agent",
+            organization_id=caller_org_id,
+            knowledge_sources=["own-docs"],
+        )
+        other_org_agent = mock_agent(
+            name="Other Org Agent",
+            organization_id=other_org_id,
+            knowledge_sources=["other-docs"],
+        )
+
+        mock_session.execute = AsyncMock(
+            return_value=mock_query_result([global_agent, own_org_agent, other_org_agent])
+        )
+
+        result = await service._get_accessible_agents(
+            user_roles=[],
+            is_superuser=False,
+            org_id=caller_org_id,
+        )
+
+        assert {agent.id for agent in result} == {global_agent.id, own_org_agent.id}
 
     @pytest.mark.asyncio
     async def test_role_based_agent_with_matching_role(self, service, mock_session, mock_agent):
@@ -820,6 +857,46 @@ class TestSearchKnowledgeAutoInjection:
         assert "search_knowledge" in tool_ids
 
     @pytest.mark.asyncio
+    async def test_get_accessible_tools_excludes_cross_org_knowledge_namespaces(
+        self, service, mock_session, mock_agent
+    ):
+        """Namespace grants come only from agents in the caller's org cascade."""
+        caller_org_id = uuid4()
+        other_org_id = uuid4()
+        own_org_agent = mock_agent(
+            access_level=AgentAccessLevel.AUTHENTICATED,
+            organization_id=caller_org_id,
+            system_tools=[],
+            knowledge_sources=["own-docs"],
+        )
+        other_org_agent = mock_agent(
+            access_level=AgentAccessLevel.AUTHENTICATED,
+            organization_id=other_org_id,
+            system_tools=[],
+            knowledge_sources=["other-docs"],
+        )
+
+        mock_session.execute = AsyncMock(
+            return_value=mock_query_result([own_org_agent, other_org_agent])
+        )
+
+        with patch("src.services.mcp_server.tool_access.MCPConfigService") as MockConfig:
+            mock_config = MagicMock()
+            mock_config.allowed_tool_ids = None
+            mock_config.blocked_tool_ids = None
+            MockConfig.return_value.get_config = AsyncMock(return_value=mock_config)
+
+            result = await service.get_accessible_tools(
+                user_roles=[],
+                is_superuser=False,
+                org_id=caller_org_id,
+            )
+
+        assert result.accessible_agent_ids == [own_org_agent.id]
+        assert result.accessible_namespaces == ["own-docs"]
+        assert "other-docs" not in result.accessible_namespaces
+
+    @pytest.mark.asyncio
     async def test_get_accessible_tools_does_not_inject_without_namespaces(
         self, service, mock_session, mock_agent
     ):
@@ -907,6 +984,34 @@ class TestSearchKnowledgeAutoInjection:
         assert result is not None
         tool_ids = {t.id for t in result.tools}
         assert "search_knowledge" in tool_ids
+
+    @pytest.mark.asyncio
+    async def test_get_tools_for_agent_denies_cross_org_agent(
+        self, service, mock_session, mock_agent
+    ):
+        """Agent-scoped MCP path cannot bind to another org's authenticated agent."""
+        caller_org_id = uuid4()
+        other_org_id = uuid4()
+        agent = mock_agent(
+            access_level=AgentAccessLevel.AUTHENTICATED,
+            organization_id=other_org_id,
+            system_tools=[],
+            knowledge_sources=["other-docs"],
+        )
+        agent.system_prompt = "Other org docs"
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.unique.return_value.first.return_value = agent
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await service.get_tools_for_agent(
+            agent_id=agent.id,
+            user_roles=[],
+            is_superuser=False,
+            org_id=caller_org_id,
+        )
+
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_get_tools_for_agent_no_inject_without_namespaces(


### PR DESCRIPTION
## Summary
- apply org-plus-global agent scoping before MCP tool and namespace collection
- deny `/mcp/{agent_id}` binding to cross-org agents even when access level or roles otherwise match
- add regressions for aggregate MCP knowledge namespace leakage and agent-scoped cross-org denial

## Verification
- uv run python -m pytest api/tests/unit/services/mcp_server/test_tool_access.py api/tests/unit/services/test_mcp_agent_scope.py -q
- uv run ruff check api/src/services/mcp_server/tool_access.py api/tests/unit/services/mcp_server/test_tool_access.py api/tests/unit/services/test_mcp_agent_scope.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added organization-level access controls for agents and tools
  * Users can now only access resources within their organization scope
  * Cross-organization access restrictions for agents and tools enforced

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->