### PR TITLE
chore(security): add Snyk rollout

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -123,6 +123,7 @@ jobs:
 
       - name: Test Kubernetes manifests
         if: env.SNYK_TOKEN != ''
+        continue-on-error: true
         run: snyk iac test k8s --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}
 
   containers:
@@ -153,8 +154,10 @@ jobs:
 
       - name: Test published API image
         if: env.SNYK_TOKEN != ''
+        continue-on-error: true
         run: snyk container test ghcr.io/mtg-thomas/bifrost-api:dev --file=api/Dockerfile --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}
 
       - name: Test published client image
         if: env.SNYK_TOKEN != ''
+        continue-on-error: true
         run: snyk container test ghcr.io/mtg-thomas/bifrost-client:dev --file=client/Dockerfile --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,158 @@
+# Snyk dependency, IaC, and container scans.
+#
+# This is intentionally non-blocking at first. Snyk is a second signal next to
+# Dependabot, CodeQL, and Scorecard; once the finding volume is tuned, selected
+# jobs can become required checks.
+
+name: Snyk
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 11 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  SNYK_ORG: ${{ vars.SNYK_ORG }}
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+jobs:
+  open-source:
+    name: Open Source
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Skip when Snyk token is not configured
+        if: env.SNYK_TOKEN == ''
+        run: echo "SNYK_TOKEN is not configured; skipping Snyk open-source scans."
+
+      - name: Checkout
+        if: env.SNYK_TOKEN != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        if: env.SNYK_TOKEN != ''
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Set up Python
+        if: env.SNYK_TOKEN != ''
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Snyk CLI
+        if: env.SNYK_TOKEN != ''
+        run: npm install --global snyk@1.1304.3
+
+      - name: Prepare Python dependency manifest for Snyk
+        id: python-requirements
+        if: env.SNYK_TOKEN != ''
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import os
+
+          source = Path("requirements.lock")
+          target = Path(os.environ["RUNNER_TEMP"]) / "bifrost-snyk-requirements.txt"
+          lines = []
+          for line in source.read_text(encoding="utf-8").splitlines():
+              stripped = line.strip()
+              if not stripped or stripped.startswith("#") or stripped.startswith("--hash="):
+                  continue
+              if "==" in stripped:
+                  lines.append(stripped.split(" \\")[0])
+          target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"requirements_file={target}", file=output)
+          PY
+
+      - name: Install Python dependencies
+        if: env.SNYK_TOKEN != ''
+        run: |
+          python -m venv .venv
+          ./.venv/bin/pip install --require-hashes -r requirements.lock
+
+      - name: Test Python dependencies
+        if: env.SNYK_TOKEN != ''
+        run: snyk test --file="${{ steps.python-requirements.outputs.requirements_file }}" --package-manager=pip --severity-threshold=high --skip-unresolved=true --command=./.venv/bin/python ${SNYK_ORG:+--org="$SNYK_ORG"}
+
+      - name: Test client dependencies
+        if: env.SNYK_TOKEN != ''
+        run: snyk test --file=client/package-lock.json --package-manager=npm --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}
+
+      - name: Monitor default branch snapshots
+        if: env.SNYK_TOKEN != '' && github.event_name != 'pull_request'
+        run: |
+          snyk monitor --file="${{ steps.python-requirements.outputs.requirements_file }}" --package-manager=pip --project-name=bifrost-api --skip-unresolved=true --command=./.venv/bin/python ${SNYK_ORG:+--org="$SNYK_ORG"}
+          snyk monitor --file=client/package-lock.json --package-manager=npm --project-name=bifrost-client ${SNYK_ORG:+--org="$SNYK_ORG"}
+
+  iac:
+    name: IaC
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Skip when Snyk token is not configured
+        if: env.SNYK_TOKEN == ''
+        run: echo "SNYK_TOKEN is not configured; skipping Snyk IaC scans."
+
+      - name: Checkout
+        if: env.SNYK_TOKEN != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        if: env.SNYK_TOKEN != ''
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Install Snyk CLI
+        if: env.SNYK_TOKEN != ''
+        run: npm install --global snyk@1.1304.3
+
+      - name: Test Kubernetes manifests
+        if: env.SNYK_TOKEN != ''
+        run: snyk iac test k8s --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}
+
+  containers:
+    name: Containers
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    continue-on-error: true
+    steps:
+      - name: Skip when Snyk token is not configured
+        if: env.SNYK_TOKEN == ''
+        run: echo "SNYK_TOKEN is not configured; skipping Snyk container scans."
+
+      - name: Checkout
+        if: env.SNYK_TOKEN != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        if: env.SNYK_TOKEN != ''
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Install Snyk CLI
+        if: env.SNYK_TOKEN != ''
+        run: npm install --global snyk@1.1304.3
+
+      - name: Test published API image
+        if: env.SNYK_TOKEN != ''
+        run: snyk container test ghcr.io/mtg-thomas/bifrost-api:dev --file=api/Dockerfile --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}
+
+      - name: Test published client image
+        if: env.SNYK_TOKEN != ''
+        run: snyk container test ghcr.io/mtg-thomas/bifrost-client:dev --file=client/Dockerfile --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -82,14 +82,16 @@ jobs:
 
       - name: Test Python dependencies
         if: env.SNYK_TOKEN != ''
+        continue-on-error: true
         run: snyk test --file="${{ steps.python-requirements.outputs.requirements_file }}" --package-manager=pip --severity-threshold=high --skip-unresolved=true --command=./.venv/bin/python ${SNYK_ORG:+--org="$SNYK_ORG"}
 
       - name: Test client dependencies
         if: env.SNYK_TOKEN != ''
+        continue-on-error: true
         run: snyk test --file=client/package-lock.json --package-manager=npm --severity-threshold=high ${SNYK_ORG:+--org="$SNYK_ORG"}
 
       - name: Monitor default branch snapshots
-        if: env.SNYK_TOKEN != '' && github.event_name != 'pull_request'
+        if: always() && env.SNYK_TOKEN != '' && github.event_name != 'pull_request'
         run: |
           snyk monitor --file="${{ steps.python-requirements.outputs.requirements_file }}" --package-manager=pip --project-name=bifrost-api --skip-unresolved=true --command=./.venv/bin/python ${SNYK_ORG:+--org="$SNYK_ORG"}
           snyk monitor --file=client/package-lock.json --package-manager=npm --project-name=bifrost-client ${SNYK_ORG:+--org="$SNYK_ORG"}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,8 @@ The repo runs:
 - **Secret scanning + push protection** at the repo level
 - **OpenSSF Scorecard** weekly, results published to
   https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost
+- **Snyk** dependency, IaC, and container scanning as a non-blocking rollout
+  lane (see `.github/workflows/snyk.yml` and `docs/security/snyk.md`)
 
 ### Auto-Merge Policy for Dependency Updates
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,8 +5,8 @@
 # =============================================================================
 # Stage 1: Builder
 # =============================================================================
-# python:3.14-slim
-FROM python@sha256:511f025a0718f01b977d5ad572bc431745b31887ceccc538c85b87e82ad2956f AS builder
+# python:3.14.5-slim-trixie
+FROM python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856 AS builder
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 # =============================================================================
 # Keep npm and its Debian node-* dependency tree out of the runtime image.
 # The runtime services execute Node scripts directly with `node`.
-FROM python@sha256:511f025a0718f01b977d5ad572bc431745b31887ceccc538c85b87e82ad2956f AS node-deps
+FROM python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856 AS node-deps
 
 WORKDIR /app
 
@@ -55,14 +55,15 @@ RUN cd /app/src/services/app_bundler && \
 # =============================================================================
 # Stage 3: Runtime
 # =============================================================================
-# python:3.14-slim
-FROM python@sha256:511f025a0718f01b977d5ad572bc431745b31887ceccc538c85b87e82ad2956f
+# python:3.14.5-slim-trixie
+FROM python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856
 
 WORKDIR /app
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
+    libcap2 \
     curl \
     gosu \
     git \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -29,7 +29,31 @@ COPY pyproject.toml requirements.lock ./
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 
 # =============================================================================
-# Stage 2: Runtime
+# Stage 2: Node dependencies
+# =============================================================================
+# Keep npm and its Debian node-* dependency tree out of the runtime image.
+# The runtime services execute Node scripts directly with `node`.
+FROM python@sha256:511f025a0718f01b977d5ad572bc431745b31887ceccc538c85b87e82ad2956f AS node-deps
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install app compiler Node.js dependencies
+COPY api/src/services/app_compiler/package.json api/src/services/app_compiler/package-lock.json* /app/src/services/app_compiler/
+RUN cd /app/src/services/app_compiler && \
+    if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
+
+# Install app bundler Node.js dependencies (esbuild)
+COPY api/src/services/app_bundler/package.json api/src/services/app_bundler/package-lock.json* /app/src/services/app_bundler/
+RUN cd /app/src/services/app_bundler && \
+    if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
+
+# =============================================================================
+# Stage 3: Runtime
 # =============================================================================
 # python:3.14-slim
 FROM python@sha256:511f025a0718f01b977d5ad572bc431745b31887ceccc538c85b87e82ad2956f
@@ -43,7 +67,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gosu \
     git \
     awscli \
-    nodejs npm \
+    nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages from builder
@@ -59,15 +83,13 @@ COPY api/bifrost.py /app/
 COPY api/scripts/ /app/scripts/
 COPY api/shared/ /app/shared/
 
-# Install app compiler Node.js dependencies
-COPY api/src/services/app_compiler/package.json api/src/services/app_compiler/package-lock.json* /app/src/services/app_compiler/
+# Copy app compiler Node.js runtime
 COPY api/src/services/app_compiler/compile.js /app/src/services/app_compiler/
 COPY api/src/services/app_compiler/tailwind.js /app/src/services/app_compiler/
-RUN cd /app/src/services/app_compiler && npm install --production
+COPY --from=node-deps /app/src/services/app_compiler/node_modules /app/src/services/app_compiler/node_modules
 
-# Install app bundler Node.js dependencies (esbuild)
-COPY api/src/services/app_bundler/package.json api/src/services/app_bundler/package-lock.json* /app/src/services/app_bundler/
-RUN cd /app/src/services/app_bundler && npm install --production
+# Copy app bundler Node.js runtime (esbuild)
+COPY --from=node-deps /app/src/services/app_bundler/node_modules /app/src/services/app_bundler/node_modules
 
 # Create non-root user
 RUN useradd -m -u 1000 bifrost && \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -104,8 +104,9 @@ RUN mkdir -p /workspace /tmp/bifrost && \
 COPY api/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Don't switch to bifrost here - entrypoint handles user switching
-# This allows the entrypoint to fix volume permissions when needed
+# Run non-root by default. Compose/test harnesses that need startup ownership
+# repair can still override this to root; entrypoint drops back to bifrost.
+USER bifrost
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Environment variables

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -45,12 +45,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install app compiler Node.js dependencies
 COPY api/src/services/app_compiler/package.json api/src/services/app_compiler/package-lock.json* /app/src/services/app_compiler/
 RUN cd /app/src/services/app_compiler && \
-    if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
+    test -f package-lock.json || { echo "package-lock.json is required for app_compiler"; exit 1; } && \
+    npm ci --omit=dev
 
 # Install app bundler Node.js dependencies (esbuild)
 COPY api/src/services/app_bundler/package.json api/src/services/app_bundler/package-lock.json* /app/src/services/app_bundler/
 RUN cd /app/src/services/app_bundler && \
-    if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
+    test -f package-lock.json || { echo "package-lock.json is required for app_bundler"; exit 1; } && \
+    npm ci --omit=dev
 
 # =============================================================================
 # Stage 3: Runtime

--- a/api/src/services/app_bundler/package-lock.json
+++ b/api/src/services/app_bundler/package-lock.json
@@ -1,0 +1,453 @@
+{
+  "name": "bifrost-app-bundler",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bifrost-app-bundler",
+      "dependencies": {
+        "esbuild": "^0.24.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    }
+  }
+}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -35,7 +35,7 @@ RUN npm run build
 # Stage 3: Production with nginx
 # =============================================================================
 # nginx:alpine
-FROM nginx@sha256:1881968aff6f7cdcc4b888c00a11f4ce241ad7ec957e0cb4a9e19e93a3ff87ea AS production
+FROM nginx:alpine@sha256:dc48b7a872a79fb541ba5081d320b11b549231bc63ba465a7495afaa7d2ebcb8 AS production
 
 RUN if command -v apk >/dev/null 2>&1; then \
         apk add --no-cache libcap; \

--- a/docs/security/snyk.md
+++ b/docs/security/snyk.md
@@ -52,8 +52,14 @@ and an isolated virtual environment:
 ```powershell
 $tmpReq = Join-Path $env:TEMP 'bifrost-snyk-requirements.txt'
 Get-Content requirements.lock |
-  Where-Object { $_ -match '^[A-Za-z0-9_.-]+==' } |
-  ForEach-Object { ($_ -split '\s+\\')[0] } |
+  ForEach-Object { $_.Trim() } |
+  Where-Object {
+    $_ -and
+    $_ -notmatch '^#' -and
+    $_ -notmatch '^--hash=' -and
+    $_ -match '=='
+  } |
+  ForEach-Object { ($_ -replace '\s+\\$','') } |
   Set-Content -Encoding ascii $tmpReq
 
 python -m venv .venv

--- a/docs/security/snyk.md
+++ b/docs/security/snyk.md
@@ -77,9 +77,61 @@ Start with this policy:
 - License findings warn during rollout and should not block merges until the
   policy is explicitly tuned.
 
+## Debian Container Findings
+
+Debian stable packages often keep an older upstream version and backport
+security fixes into the Debian package revision. Do not treat an upstream
+version comparison as sufficient evidence that a Debian package is exploitable.
+
+For Debian container findings:
+
+1. Record the Snyk ID, CVE, package, installed version, introducing package,
+   and runtime path.
+2. Check the installed version and candidate version in the built image:
+
+   ```sh
+   apt-get update
+   apt-cache policy <package>
+   ```
+
+3. Check Debian Security Tracker for the CVE and source package:
+   - https://security-tracker.debian.org/tracker/<CVE>
+   - https://security-tracker.debian.org/tracker/source-package/<source-package>
+4. Classify the finding:
+   - **Fix now** when Debian has a fixed candidate available in stable or
+     stable-security.
+   - **Track upstream/distro** when Debian still marks the stable package
+     vulnerable and no fixed stable candidate exists.
+   - **Accept with evidence** when Debian marks the issue ignored, postponed,
+     no-DSA, or not applicable to our runtime path.
+   - **Refactor later** when the finding only disappears by removing a runtime
+     tool such as `awscli`, `git`, or `curl`.
+5. Add Snyk ignores only for reviewed findings with a dated comment that names
+   the Debian tracker status and the Bifrost follow-up decision. Do not add
+   broad package-level ignores.
+
+### Current API Image Snapshot
+
+As of 2026-05-19, the API image is based on
+`python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856`.
+The container scan reports 8 high/critical Debian findings after the initial
+base-image cleanup. The image already has the current Debian candidate versions:
+
+| Source package | Installed version | Snyk CVEs | Debian status | Bifrost disposition |
+| --- | --- | --- | --- | --- |
+| `gnutls28` | `3.8.9-3+deb13u3` | `CVE-2026-33845`, `CVE-2026-33846`, `CVE-2026-3833`, `CVE-2026-42009`, `CVE-2026-42010`, `CVE-2026-42011` | Debian Security Tracker marks trixie vulnerable; fixed in sid/forky at `3.8.13-1`. | Track until Debian ships a trixie security fix or we can remove the `git`/`curl` runtime dependency chain. |
+| `expat` | `2.7.1-2` | `CVE-2026-45186` | Debian Security Tracker marks trixie vulnerable; fixed in sid at `2.8.0-2`. | Track until Debian ships a trixie security fix or we can remove the `git`/`awscli` runtime dependency chain. |
+| `python-urllib3` | `2.3.0-3+deb13u1` | `CVE-2025-66471` | Debian marks trixie vulnerable but ignored because the effective fix is intrusive and requires a newer `brotli`. | Accept as distro-reviewed residual for now; revisit if Debian publishes a stable fix or if `awscli` is removed. |
+
+The remaining findings are not a reason to vendor newer Debian packages from
+testing/unstable into the production image. Prefer either the supported Debian
+stable security update, or a separate runtime-slimming change that removes the
+introducing tool.
+
 ## Promotion Criteria
 
 Make Snyk blocking only after at least one scheduled run and one representative
 pull-request run have completed with acceptable noise. A reasonable first
 blocking gate is high and critical open-source findings on production
-dependencies only.
+dependencies only. Do not make Debian container findings blocking until the
+triage process above has a low-noise suppress/track workflow.

--- a/docs/security/snyk.md
+++ b/docs/security/snyk.md
@@ -1,0 +1,85 @@
+# Snyk Rollout
+
+Bifrost uses Snyk as an additional dependency, IaC, and container signal next
+to GitHub-native security controls. It does not replace Dependabot, CodeQL,
+secret scanning, or OpenSSF Scorecard.
+
+## Local Setup
+
+The local CLI is installed from npm:
+
+```powershell
+snyk --version
+npm view snyk version
+npm install --global snyk@<version>
+```
+
+Authenticate once per workstation and set the default organization:
+
+```powershell
+snyk auth
+snyk config set org=<snyk-org-id-or-slug>
+```
+
+## Repository Setup
+
+Add these repository settings before expecting the GitHub workflow to report
+useful results:
+
+- `SNYK_TOKEN` as a repository or organization secret.
+- `SNYK_ORG` as a repository or organization variable when the default token
+  organization is not the desired Bifrost organization.
+- Import the GitHub repositories into Snyk so scheduled Snyk monitoring and
+  dashboard triage work outside CI.
+
+## Scan Surfaces
+
+The initial workflow scans:
+
+- Python dependencies from a temporary Snyk-compatible requirements file
+  generated from `requirements.lock`.
+- Client dependencies from `client/package-lock.json`.
+- Kubernetes manifests under `k8s/`.
+- Published `ghcr.io/mtg-thomas/bifrost-api:dev` and
+  `ghcr.io/mtg-thomas/bifrost-client:dev` images on scheduled/manual runs.
+
+The workflow is non-blocking during rollout. Treat it as tuning evidence until
+the false-positive and duplicate-finding volume is understood.
+
+For local open-source scans, use the lock-derived temporary Python manifest
+and an isolated virtual environment:
+
+```powershell
+$tmpReq = Join-Path $env:TEMP 'bifrost-snyk-requirements.txt'
+Get-Content requirements.lock |
+  Where-Object { $_ -match '^[A-Za-z0-9_.-]+==' } |
+  ForEach-Object { ($_ -split '\s+\\')[0] } |
+  Set-Content -Encoding ascii $tmpReq
+
+python -m venv .venv
+.\.venv\Scripts\pip install --require-hashes -r requirements.lock
+
+snyk test --file=$tmpReq --package-manager=pip --severity-threshold=high --skip-unresolved=true --command=.\.venv\Scripts\python.exe
+snyk test --file=client/package-lock.json --package-manager=npm --severity-threshold=high
+```
+
+## Triage Policy
+
+Start with this policy:
+
+- Critical and high findings get reviewed first.
+- Dependency findings that already have a Dependabot PR should be routed to
+  that PR instead of creating duplicate work.
+- Confirm whether a finding affects production dependencies before opening a
+  security advisory or public issue.
+- Container base-image findings need human review; do not auto-merge base image
+  updates solely because Snyk reports a fix.
+- License findings warn during rollout and should not block merges until the
+  policy is explicitly tuned.
+
+## Promotion Criteria
+
+Make Snyk blocking only after at least one scheduled run and one representative
+pull-request run have completed with acceptable noise. A reasonable first
+blocking gate is high and critical open-source findings on production
+dependencies only.

--- a/docs/security/snyk.md
+++ b/docs/security/snyk.md
@@ -121,13 +121,15 @@ For Debian container findings:
 As of 2026-05-19, the API image is based on
 `python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856`.
 The container scan reports 8 high/critical Debian findings after the initial
-base-image cleanup. The image already has the current Debian candidate versions:
+base-image cleanup. The image already has the current Debian candidate versions.
+Track the Snyk finding IDs in our backlog; use Debian Security Tracker for the
+public CVE/source-package status during each review.
 
-| Source package | Installed version | Snyk CVEs | Debian status | Bifrost disposition |
+| Source package | Installed version | Snyk finding IDs | Debian status | Bifrost disposition |
 | --- | --- | --- | --- | --- |
-| `gnutls28` | `3.8.9-3+deb13u3` | `CVE-2026-33845`, `CVE-2026-33846`, `CVE-2026-3833`, `CVE-2026-42009`, `CVE-2026-42010`, `CVE-2026-42011` | Debian Security Tracker marks trixie vulnerable; fixed in sid/forky at `3.8.13-1`. | Track until Debian ships a trixie security fix or we can remove the `git`/`curl` runtime dependency chain. |
-| `expat` | `2.7.1-2` | `CVE-2026-45186` | Debian Security Tracker marks trixie vulnerable; fixed in sid at `2.8.0-2`. | Track until Debian ships a trixie security fix or we can remove the `git`/`awscli` runtime dependency chain. |
-| `python-urllib3` | `2.3.0-3+deb13u1` | `CVE-2025-66471` | Debian marks trixie vulnerable but ignored because the effective fix is intrusive and requires a newer `brotli`. | Accept as distro-reviewed residual for now; revisit if Debian publishes a stable fix or if `awscli` is removed. |
+| `gnutls28` | `3.8.9-3+deb13u3` | `SNYK-DEBIAN13-GNUTLS28-16344302`, `SNYK-DEBIAN13-GNUTLS28-16344305`, `SNYK-DEBIAN13-GNUTLS28-16344314`, `SNYK-DEBIAN13-GNUTLS28-16344321`, `SNYK-DEBIAN13-GNUTLS28-16344352`, `SNYK-DEBIAN13-GNUTLS28-16344357` | Debian Security Tracker marks trixie vulnerable; fixed in sid/forky at `3.8.13-1`. | Track until Debian ships a trixie security fix or we can remove the `git`/`curl` runtime dependency chain. |
+| `expat` | `2.7.1-2` | `SNYK-DEBIAN13-EXPAT-16650098` | Debian Security Tracker marks trixie vulnerable; fixed in sid at `2.8.0-2`. | Track until Debian ships a trixie security fix or we can remove the `git`/`awscli` runtime dependency chain. |
+| `python-urllib3` | `2.3.0-3+deb13u1` | `SNYK-DEBIAN13-PYTHONURLLIB3-14193375` | Debian marks trixie vulnerable but ignored because the effective fix is intrusive and requires a newer `brotli`. | Accept as distro-reviewed residual for now; revisit if Debian publishes a stable fix or if `awscli` is removed. |
 
 The remaining findings are not a reason to vendor newer Debian packages from
 testing/unstable into the production image. Prefer either the supported Debian

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,8 @@ dependencies = [
     # as a lockfile and infers the lowest possible version. Explicit floors
     # close the gap.
     # =========================================================================
-    "Mako>=1.3.11",  # transitive (alembic) — 1.3.9 has CVE-2025-XXXX
+    "Mako>=1.3.12",  # transitive (alembic) - Snyk finding through 1.3.11
+    "urllib3>=2.7.0",  # transitive (requests, dulwich, PyGithub) - Snyk finding through 2.6.3
     "setuptools>=78.1.1",  # transitive (build) — multiple CVEs in older versions
     "tqdm>=4.66.3",  # transitive (anthropic, openai, etc.)
 ]

--- a/requirements.lock
+++ b/requirements.lock
@@ -1468,9 +1468,9 @@ linkify-it-py==2.1.0 \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via markdown-it-py
-mako==1.3.11 \
-    --hash=sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069 \
-    --hash=sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77
+mako==1.3.12 \
+    --hash=sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9 \
+    --hash=sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a
     # via
     #   alembic
     #   bifrost-api (pyproject.toml)
@@ -2757,10 +2757,11 @@ uncalled-for==0.3.1 \
     --hash=sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200 \
     --hash=sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca
     # via fastmcp
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
+    #   bifrost-api (pyproject.toml)
     #   botocore
     #   dulwich
     #   pygithub


### PR DESCRIPTION
## Summary
- add a non-blocking Snyk workflow for Open Source, IaC, and container scan lanes
- document local/CI Snyk usage and add Snyk to the repo security posture notes
- apply first-pass Snyk fixes: Python dependency floors/lock refresh, client nginx base refresh, and moving npm out of the API runtime image

## Verification
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/snyk.yml').read_text()); print('yaml ok')"`
- `actionlint .github\workflows\snyk.yml`
- `git diff --check`
- `snyk test --file=client/package-lock.json --package-manager=npm --severity-threshold=high`
- `snyk iac test k8s --severity-threshold=high`
- `docker buildx build --platform linux/amd64 -f client/Dockerfile -t bifrost-client-snyk-pr --load client`
- `snyk container test bifrost-client-snyk-pr --file=client/Dockerfile --severity-threshold=high`
- `docker build -f api/Dockerfile -t bifrost-api-snyk-pr:dev .`

## Notes
- The API container still has OS package findings from the current Debian/Python base and runtime package set (`awscli`, `git`, `curl`, ImageMagick/OpenEXR/LibRaw/GnuTLS chains). This PR leaves the Snyk workflow non-blocking so that follow-up can slim or refresh the API image without blocking rollout.
- Local Windows Python dependency install is blocked by `uvloop`; the API Docker build verifies the locked Python set in Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking automated Snyk scans for dependencies, IaC, and container images on PRs, scheduled runs, and manual triggers.

* **Documentation**
  * Added Snyk rollout and triage guidance; updated supply-chain/security practices.

* **Security**
  * Raised transitive dependency bounds (Mako, urllib3) to patched versions.

* **Chores**
  * Updated container build/runtime images to pinned base images, prebuild Node assets, and default to a non-root runtime user.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->