### PR TITLE
Honor worker warm-pool settings

### DIFF
--- a/api/src/config.py
+++ b/api/src/config.py
@@ -114,6 +114,10 @@ class Settings(BaseSettings):
         default=30,
         description="TTL in seconds for worker registration in Redis (refreshed by heartbeat)"
     )
+    worker_install_requirements_on_startup: bool = Field(
+        default=True,
+        description="Install workspace requirements.txt during worker template startup"
+    )
     memory_pressure_threshold: float = Field(
         default=0.85,
         description="Reject new forks when container memory usage exceeds this ratio (0.0-1.0)"

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -72,6 +72,17 @@ def _get_installed_packages() -> list[dict[str, str]]:
     return []
 
 
+def _requirement_name(line: str) -> str:
+    """Return the normalized package name from one requirements.txt line."""
+    stripped = line.split("#", 1)[0].strip()
+    if not stripped or stripped.startswith(("-", "git+")) or "://" in stripped:
+        return ""
+    name = stripped
+    for marker in ("===", "==", ">=", "<=", "~=", "!=", ">", "<", "["):
+        name = name.split(marker, 1)[0]
+    return name.strip().lower().replace("_", "-")
+
+
 class ProcessState(Enum):
     """
     State of a worker process in the pool.
@@ -364,7 +375,10 @@ class ProcessPoolManager:
         catch this — the worker process should crash-loop so Kubernetes
         restarts it and the failure is visible.
         """
-        new_template = TemplateProcess()
+        settings = get_settings()
+        new_template = TemplateProcess(
+            install_requirements_on_startup=settings.worker_install_requirements_on_startup
+        )
         await asyncio.to_thread(new_template.start)
         self._template = new_template
         logger.info(f"Template process started (PID={new_template.pid})")
@@ -493,14 +507,13 @@ class ProcessPoolManager:
         self._shutdown = False
         self._started_at = datetime.now(timezone.utc)
 
-        # Install requirements once (shared filesystem — all child processes inherit)
-        await asyncio.to_thread(install_requirements)
-
-        # Compute requirements status for heartbeat reporting
-        self._update_requirements_status()
-
         # Start template process (loads deps, ready to fork)
         await self._start_template()
+
+        # Compute requirements status for heartbeat reporting after the template
+        # has optionally installed workspace requirements into the shared image
+        # filesystem.
+        self._update_requirements_status()
 
         # Spawn initial pool
         for _ in range(self.min_workers):
@@ -1683,11 +1696,8 @@ class ProcessPoolManager:
                 self._requirements_installed = 0
                 return
 
-            required = {
-                line.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0].strip().lower()
-                for line in content.strip().split("\n")
-                if line.strip()
-            }
+            required = {_requirement_name(line) for line in content.strip().split("\n")}
+            required.discard("")
             self._requirements_total = len(required)
 
             installed = {p["name"].lower() for p in _get_installed_packages()}
@@ -1834,7 +1844,7 @@ def get_process_pool() -> ProcessPoolManager:
     if _pool is None:
         settings = get_settings()
         _pool = ProcessPoolManager(
-            min_workers=0,  # On-demand (JIT) mode — no warm pool
+            min_workers=settings.min_workers,
             max_workers=settings.max_workers,
             execution_timeout_seconds=settings.execution_timeout_seconds,
             graceful_shutdown_seconds=settings.graceful_shutdown_seconds,

--- a/api/src/services/execution/template_process.py
+++ b/api/src/services/execution/template_process.py
@@ -90,9 +90,30 @@ CMD_FORK = "fork"
 CMD_SHUTDOWN = "shutdown"
 
 
+def _load_execution_infrastructure(install_requirements_on_startup: bool) -> None:
+    """Load execution helpers and optionally install workspace requirements."""
+    from src.services.execution.virtual_import import install_virtual_import_hook
+    from src.services.execution.simple_worker import install_requirements
+
+    if install_requirements_on_startup:
+        install_requirements()
+    else:
+        logger.info("Skipping requirements install in template process")
+
+    # Ensure user site-packages is in sys.path
+    import site
+    user_site = site.getusersitepackages()
+    if site.ENABLE_USER_SITE and os.path.exists(user_site) and user_site not in sys.path:
+        sys.path.insert(0, user_site)
+        logger.info(f"Added user site-packages to sys.path: {user_site}")
+
+    install_virtual_import_hook()
+
+
 def _template_main(
     pipe: Connection,
     preload_modules: list[str] | None = None,
+    install_requirements_on_startup: bool = True,
 ) -> None:
     """
     Entry point for the template process.
@@ -145,21 +166,7 @@ def _template_main(
 
         # Execution infrastructure
         try:
-            from src.services.execution.virtual_import import install_virtual_import_hook
-            from src.services.execution.simple_worker import install_requirements
-
-            # Install user packages (pip install from requirements.txt)
-            install_requirements()
-
-            # Ensure user site-packages is in sys.path
-            import site
-            user_site = site.getusersitepackages()
-            if site.ENABLE_USER_SITE and os.path.exists(user_site) and user_site not in sys.path:
-                sys.path.insert(0, user_site)
-                logger.info(f"Added user site-packages to sys.path: {user_site}")
-
-            # Install virtual import hook for workspace modules
-            install_virtual_import_hook()
+            _load_execution_infrastructure(install_requirements_on_startup)
         except ImportError as e:
             logger.warning(f"Execution infrastructure not available: {e} — continuing without it")
 
@@ -425,10 +432,11 @@ class TemplateProcess:
     holds all heavy dependencies in memory and forks children on request.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, install_requirements_on_startup: bool = True) -> None:
         self._process: Any = None  # multiprocessing.Process or SpawnProcess
         self._pipe: Connection | None = None
         self.pid: int | None = None
+        self.install_requirements_on_startup = install_requirements_on_startup
 
     def start(self) -> None:
         """
@@ -445,7 +453,7 @@ class TemplateProcess:
 
         self._process = ctx.Process(
             target=_template_main,
-            args=(child_conn,),
+            args=(child_conn, None, self.install_requirements_on_startup),
             name="template-process",
         )
         self._process.start()

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -15,12 +15,14 @@ NOTE: These tests use mocks to avoid spawning real processes.
 """
 
 import asyncio
+from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from queue import Empty
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import src.services.execution.process_pool as process_pool_module
 from src.services.execution.process_pool import (
     ExecutionInfo,
     ProcessHandle,
@@ -212,6 +214,35 @@ class TestProcessPoolManagerStart:
     """Tests for pool startup."""
 
     @pytest.mark.asyncio
+    async def test_start_delegates_requirements_install_to_template_process(self):
+        """Pool startup should not install requirements before template startup."""
+        pool = ProcessPoolManager(min_workers=0, max_workers=5)
+
+        with patch("src.services.execution.process_pool.install_requirements") as install:
+            with patch.object(pool, "_start_template", new_callable=AsyncMock):
+                with patch.object(pool, "_update_requirements_status"):
+                    with patch.object(pool, "_register_worker", new_callable=AsyncMock):
+                        with patch.object(pool, "_monitor_loop", new_callable=AsyncMock):
+                            with patch.object(pool, "_result_loop", new_callable=AsyncMock):
+                                with patch.object(pool, "_heartbeat_loop", new_callable=AsyncMock):
+                                    await pool.start()
+
+        install.assert_not_called()
+
+        pool._shutdown = True
+        for task in [
+            pool._monitor_task,
+            pool._result_task,
+            pool._heartbeat_task,
+            pool._cancel_task,
+            pool._command_task,
+        ]:
+            if task:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+
+    @pytest.mark.asyncio
     async def test_pool_starts_with_min_workers(self):
         """Should spawn min_workers processes on start."""
         pool = ProcessPoolManager(min_workers=3, max_workers=10)
@@ -261,11 +292,8 @@ class TestProcessPoolManagerStart:
         for task in [pool._monitor_task, pool._result_task, pool._heartbeat_task]:
             if task:
                 task.cancel()
-                try:
+                with suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    # Expected — we just cancelled the task during cleanup
-                    pass
 
 
 class TestProcessPoolManagerRouting:
@@ -640,6 +668,34 @@ class TestProcessPoolManagerRecycle:
 
 class TestProcessPoolManagerHeartbeat:
     """Tests for heartbeat functionality."""
+
+    def test_update_requirements_status_ignores_comments_and_inline_comments(self):
+        """Requirements status should count real package names, not comments."""
+        pool = ProcessPoolManager()
+        content = """
+# Bifrost API requirements
+aio-pika  # async rabbitmq client
+sqlalchemy[asyncio]>=2.0
+
+# Developer tools
+pytest-timeout==2.3.1
+"""
+
+        with patch(
+            "src.core.requirements_cache.get_requirements_sync",
+            return_value=content,
+        ):
+            with patch(
+                "src.services.execution.process_pool._get_installed_packages",
+                return_value=[
+                    {"name": "aio-pika", "version": "1.0"},
+                    {"name": "SQLAlchemy", "version": "2.0"},
+                ],
+            ):
+                pool._update_requirements_status()
+
+        assert pool._requirements_total == 3
+        assert pool._requirements_installed == 2
 
     def test_build_heartbeat(self):
         """Should build heartbeat with process state."""
@@ -1238,10 +1294,33 @@ class TestOrphanedKilledHandleSweep:
 
 
 class TestOnDemandMode:
-    """Tests for on-demand mode (min_workers is always 0 now)."""
+    """Tests for on-demand mode and configured warm pools."""
+
+    def test_get_process_pool_uses_settings_min_workers(self):
+        """Global pool construction should honor configured warm pool size."""
+        previous_pool = process_pool_module._pool
+        process_pool_module._pool = None
+        settings = MagicMock()
+        settings.min_workers = 3
+        settings.max_workers = 8
+        settings.execution_timeout_seconds = 300
+        settings.graceful_shutdown_seconds = 5
+        settings.recycle_after_executions = 100
+        settings.recycle_memory_mb = 768
+        settings.worker_heartbeat_interval_seconds = 10
+        settings.worker_registration_ttl_seconds = 30
+
+        try:
+            with patch("src.services.execution.process_pool.get_settings", return_value=settings):
+                pool = process_pool_module.get_process_pool()
+
+            assert pool.min_workers == 3
+            assert pool.max_workers == 8
+        finally:
+            process_pool_module._pool = previous_pool
 
     def test_pool_starts_with_zero_min_workers(self):
-        """Pool should always have min_workers=0 for on-demand mode."""
+        """Pool should still allow min_workers=0 for on-demand mode."""
         pool = ProcessPoolManager(min_workers=0, max_workers=5)
         assert pool.min_workers == 0
 

--- a/api/tests/unit/execution/test_template_process.py
+++ b/api/tests/unit/execution/test_template_process.py
@@ -9,10 +9,14 @@ import logging
 import os
 import signal
 import time
+from unittest.mock import Mock, patch
 
 import pytest
 
-from src.services.execution.template_process import TemplateProcess
+from src.services.execution.template_process import (
+    TemplateProcess,
+    _load_execution_infrastructure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +41,21 @@ def _wait_for_pid_to_die(pid: int, timeout: float = 5.0) -> None:
 
 class TestTemplateProcessLifecycle:
     """Tests for template process startup and shutdown."""
+
+    def test_load_execution_infrastructure_can_skip_requirements_install(self):
+        """Baked worker images should be able to skip startup requirements install."""
+        install = Mock()
+        hook = Mock()
+
+        with patch("src.services.execution.simple_worker.install_requirements", install):
+            with patch(
+                "src.services.execution.virtual_import.install_virtual_import_hook",
+                hook,
+            ):
+                _load_execution_infrastructure(install_requirements_on_startup=False)
+
+        install.assert_not_called()
+        hook.assert_called_once()
 
     def test_start_and_ready(self):
         """Template process should start and signal ready."""


### PR DESCRIPTION
Target: platform worker runtime used by PoC/dev published images.\n\nChanges:\n- Move requirements installation to the template-process startup path only.\n- Add BIFROST_WORKER_INSTALL_REQUIREMENTS_ON_STARTUP so baked worker images can skip runtime install.\n- Honor BIFROST_MIN_WORKERS when constructing the process pool.\n- Tighten requirements status parsing so comments/inline comments are not counted as packages.\n\nVerification:\n- docker compose -f docker-compose.test.yml --profile test run --rm test-runner pytest tests/unit/execution/test_process_pool.py tests/unit/execution/test_template_process.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control whether workspace requirements are installed during worker startup, providing flexibility in worker initialization. Feature defaults to enabled for backward compatibility.

* **Chores**
  * Enhanced worker startup process and requirements management logic for improved robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->