### PR TITLE
Harden OAuth scanner findings

### DIFF
--- a/api/src/jobs/schedulers/oauth_token_refresh.py
+++ b/api/src/jobs/schedulers/oauth_token_refresh.py
@@ -39,7 +39,9 @@ async def refresh_expiring_tokens() -> dict[str, Any]:
         Summary of refresh results
     """
     threshold = OAUTH_REFRESH_INTERVAL_MINUTES + REFRESH_BUFFER_MINUTES
-    return await run_refresh_job(trigger_type="automatic", refresh_threshold_minutes=threshold)
+    return await run_refresh_job(
+        trigger_type="automatic", refresh_threshold_minutes=threshold
+    )
 
 
 async def run_refresh_job(
@@ -124,7 +126,8 @@ async def run_refresh_job(
             if refresh_threshold_minutes is not None:
                 refresh_threshold = now + timedelta(minutes=refresh_threshold_minutes)
                 tokens_to_refresh = [
-                    t for t in all_tokens
+                    t
+                    for t in all_tokens
                     if t.expires_at and t.expires_at <= refresh_threshold
                 ]
             else:
@@ -140,10 +143,12 @@ async def run_refresh_job(
             for token in tokens_to_refresh:
                 provider = token.provider
                 if not provider:
-                    results["errors"].append({
-                        "token_id": str(token.id),
-                        "error": "Provider not found",
-                    })
+                    results["errors"].append(
+                        {
+                            "token_id": str(token.id),
+                            "error": "Provider not found",
+                        }
+                    )
                     results["refresh_failed"] += 1
                     continue
 
@@ -166,19 +171,25 @@ async def run_refresh_job(
                     results["refreshed_successfully"] += 1
                 else:
                     results["refresh_failed"] += 1
-                    results["errors"].append({
-                        "token_id": str(td["token_id"]),
-                        "provider": td["provider_name"],
-                        "error": outcome.get("error", "Refresh failed"),
-                    })
+                    results["errors"].append(
+                        {
+                            "token_id": str(td["token_id"]),
+                            "provider": td["provider_name"],
+                            "error": outcome.get("error", "Refresh failed"),
+                        }
+                    )
 
             except Exception as e:
                 results["refresh_failed"] += 1
-                results["errors"].append({
-                    "token_id": str(td["token_id"]),
-                    "error": str(e),
-                })
-                logger.error(f"Error refreshing token {td['token_id']}: {e}", exc_info=True)
+                results["errors"].append(
+                    {
+                        "token_id": str(td["token_id"]),
+                        "error": e.__class__.__name__,
+                    }
+                )
+                logger.error(
+                    "Error refreshing OAuth connection: %s", e.__class__.__name__
+                )
 
         # Phase 3: Persist refresh results (short-lived session)
         if refresh_outcomes:
@@ -194,7 +205,9 @@ async def run_refresh_job(
                         token.encrypted_access_token = outcome["encrypted_access_token"]
                         token.expires_at = outcome["expires_at"]
                         if outcome.get("encrypted_refresh_token"):
-                            token.encrypted_refresh_token = outcome["encrypted_refresh_token"]
+                            token.encrypted_refresh_token = outcome[
+                                "encrypted_refresh_token"
+                            ]
                         if outcome.get("scopes"):
                             token.scopes = outcome["scopes"]
                         token.status = "completed"
@@ -202,7 +215,9 @@ async def run_refresh_job(
                         token.last_refresh_at = datetime.now(timezone.utc)
                     else:
                         token.status = "failed"
-                        token.status_message = (outcome.get("error", "Refresh failed"))[:200]
+                        token.status_message = (outcome.get("error", "Refresh failed"))[
+                            :200
+                        ]
                         token.last_refresh_at = datetime.now(timezone.utc)
 
                     # Provider status mirrors the integration-level (fallback) token only.
@@ -214,7 +229,9 @@ async def run_refresh_job(
                             provider.last_token_refresh = datetime.now(timezone.utc)
                         else:
                             provider.status = "failed"
-                            provider.status_message = (outcome.get("error", "Refresh failed"))[:200]
+                            provider.status_message = (
+                                outcome.get("error", "Refresh failed")
+                            )[:200]
 
                 await db.commit()
 
@@ -226,21 +243,14 @@ async def run_refresh_job(
         results["end_time"] = end_time.isoformat()
 
         # Log completion with visual marker
-        success = results["refreshed_successfully"]
         failed = results["refresh_failed"]
         if failed > 0:
-            logger.warning(
-                f"⚠ OAuth token refresh completed with errors: "
-                f"{success} refreshed, {failed} failed ({duration_seconds:.1f}s)"
-            )
+            logger.warning("OAuth credential refresh completed with errors")
         else:
-            logger.info(
-                f"✓ OAuth token refresh completed: "
-                f"{success} refreshed, {failed} failed ({duration_seconds:.1f}s)"
-            )
+            logger.info("OAuth credential refresh completed")
 
     except Exception as e:
-        logger.error(f"✗ OAuth token refresh failed: {e}", exc_info=True)
-        results["errors"].append({"error": str(e)})
+        logger.error("OAuth refresh job failed: %s", e.__class__.__name__)
+        results["errors"].append({"error": e.__class__.__name__})
 
     return results

--- a/api/src/services/oauth_config_service.py
+++ b/api/src/services/oauth_config_service.py
@@ -93,7 +93,10 @@ class OAuthConfigService:
             try:
                 return decrypt_secret(encrypted)
             except Exception as e:
-                logger.error(f"Failed to decrypt secret {key}: {e}")
+                logger.error(
+                    "Failed to decrypt OAuth config secret: %s",
+                    e.__class__.__name__,
+                )
                 return None
         return None
 
@@ -308,8 +311,12 @@ class OAuthConfigService:
                         client_id=config.client_id,
                         client_secret_set=bool(config.client_secret),
                         tenant_id=config.tenant_id if provider == "microsoft" else None,
-                        discovery_url=config.discovery_url if provider == "oidc" else None,
-                        display_name=config.display_name if provider == "oidc" else None,
+                        discovery_url=config.discovery_url
+                        if provider == "oidc"
+                        else None,
+                        display_name=config.display_name
+                        if provider == "oidc"
+                        else None,
                     )
                 )
             else:
@@ -369,7 +376,9 @@ class OAuthConfigService:
                         message=f"Successfully connected to Microsoft Entra ID (tenant: {tenant})",
                         details={
                             "issuer": data.get("issuer"),
-                            "authorization_endpoint": data.get("authorization_endpoint"),
+                            "authorization_endpoint": data.get(
+                                "authorization_endpoint"
+                            ),
                             "token_endpoint": data.get("token_endpoint"),
                         },
                     )
@@ -414,7 +423,9 @@ class OAuthConfigService:
                         message="Successfully connected to Google OAuth",
                         details={
                             "issuer": data.get("issuer"),
-                            "authorization_endpoint": data.get("authorization_endpoint"),
+                            "authorization_endpoint": data.get(
+                                "authorization_endpoint"
+                            ),
                             "token_endpoint": data.get("token_endpoint"),
                         },
                     )
@@ -478,7 +489,9 @@ class OAuthConfigService:
                         message=f"Successfully connected to OIDC provider: {data.get('issuer')}",
                         details={
                             "issuer": data.get("issuer"),
-                            "authorization_endpoint": data.get("authorization_endpoint"),
+                            "authorization_endpoint": data.get(
+                                "authorization_endpoint"
+                            ),
                             "token_endpoint": data.get("token_endpoint"),
                             "userinfo_endpoint": data.get("userinfo_endpoint"),
                             "scopes_supported": data.get("scopes_supported", [])[:10],

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -13,6 +13,7 @@ from uuid import UUID
 import aiohttp
 from sqlalchemy import select
 
+from src.core.log_safety import log_safe
 from src.core.security import decrypt_secret, encrypt_secret
 
 if TYPE_CHECKING:
@@ -24,9 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def resolve_url_template(
-    url: str,
-    entity_id: str | None = None,
-    defaults: dict[str, str] | None = None
+    url: str, entity_id: str | None = None, defaults: dict[str, str] | None = None
 ) -> str:
     """
     Replace {placeholders} in URL with values.
@@ -59,7 +58,7 @@ def resolve_url_template(
 
     # Check if URL contains any placeholders
     if "{" not in url:
-        logger.debug(f"URL has no placeholders: {url}")
+        logger.debug("OAuth URL has no placeholders")
         return url
 
     result = url
@@ -74,18 +73,12 @@ def resolve_url_template(
 
         if placeholder == "entity_id" and entity_id:
             replacement = entity_id
-            logger.debug(
-                f"Resolving {{entity_id}} in URL with provided entity_id: {entity_id}"
-            )
+            logger.debug("Resolving {entity_id} in OAuth URL with provided entity ID")
         elif placeholder in defaults:
             replacement = defaults[placeholder]
-            logger.debug(
-                f"Resolving {{{placeholder}}} in URL with default value: {replacement}"
-            )
+            logger.debug("Resolving OAuth URL placeholder with configured default")
         else:
-            logger.warning(
-                f"URL placeholder {{{placeholder}}} has no value or default, leaving unresolved"
-            )
+            logger.warning("OAuth URL placeholder has no value or default")
             continue
 
         # Replace the placeholder
@@ -116,7 +109,9 @@ class OAuthProviderClient:
         """
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.max_retries = max_retries
-        logger.debug(f"OAuthProviderClient initialized (timeout={timeout}s, max_retries={max_retries})")
+        logger.debug(
+            f"OAuthProviderClient initialized (timeout={timeout}s, max_retries={max_retries})"
+        )
 
     async def exchange_code_for_token(
         self,
@@ -147,15 +142,15 @@ class OAuthProviderClient:
             "grant_type": "authorization_code",
             "code": code,
             "client_id": client_id,
-            "redirect_uri": redirect_uri
+            "redirect_uri": redirect_uri,
         }
 
         # Only include client_secret if provided (PKCE flow omits this)
         if client_secret:
             payload["client_secret"] = client_secret
-            logger.info(f"Exchanging authorization code for token at {token_url} (with client_secret)")
+            logger.info("Exchanging authorization code (confidential client)")
         else:
-            logger.info(f"Exchanging authorization code for token at {token_url} (PKCE flow - no client_secret)")
+            logger.info("Exchanging authorization code (PKCE flow)")
 
         if audience:
             payload["audience"] = audience
@@ -189,15 +184,15 @@ class OAuthProviderClient:
         payload = {
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
-            "client_id": client_id
+            "client_id": client_id,
         }
 
         # Only include client_secret if provided (PKCE flow omits this)
         if client_secret:
             payload["client_secret"] = client_secret
-            logger.info(f"Refreshing access token at {token_url} (with client_secret)")
+            logger.info("Refreshing OAuth access token (confidential client)")
         else:
-            logger.info(f"Refreshing access token at {token_url} (PKCE flow - no client_secret)")
+            logger.info("Refreshing OAuth access token (PKCE flow)")
 
         if audience:
             payload["audience"] = audience
@@ -230,7 +225,7 @@ class OAuthProviderClient:
         payload = {
             "grant_type": "client_credentials",
             "client_id": client_id,
-            "client_secret": client_secret
+            "client_secret": client_secret,
         }
 
         if scopes:
@@ -240,14 +235,12 @@ class OAuthProviderClient:
         if audience:
             payload["audience"] = audience
 
-        logger.info(f"Requesting client credentials token at {token_url}")
+        logger.info("Requesting client credentials token")
 
         return await self._make_token_request(token_url, payload)
 
     async def _make_token_request(
-        self,
-        token_url: str,
-        payload: dict
+        self, token_url: str, payload: dict
     ) -> tuple[bool, dict]:
         """
         Make token request with retry logic
@@ -265,18 +258,24 @@ class OAuthProviderClient:
             try:
                 # Create connector with proper cleanup settings
                 connector = aiohttp.TCPConnector(force_close=True)
-                async with aiohttp.ClientSession(timeout=self.timeout, connector=connector) as session:
+                async with aiohttp.ClientSession(
+                    timeout=self.timeout, connector=connector
+                ) as session:
                     async with session.post(
                         token_url,
                         data=payload,
-                        headers={"Content-Type": "application/x-www-form-urlencoded"}
+                        headers={"Content-Type": "application/x-www-form-urlencoded"},
                     ) as response:
                         response_data = await response.json()
 
                         # Success (2xx status codes)
                         if 200 <= response.status < 300:
-                            logger.info(f"Token request successful (status={response.status})")
-                            logger.debug(f"Raw OAuth response keys: {list(response_data.keys())}")
+                            logger.info(
+                                f"Token request successful (status={response.status})"
+                            )
+                            logger.debug(
+                                f"Raw OAuth response keys: {list(response_data.keys())}"
+                            )
 
                             # Parse token response
                             result = self._parse_token_response(response_data)
@@ -284,57 +283,88 @@ class OAuthProviderClient:
 
                         # Client errors (4xx) - don't retry
                         elif 400 <= response.status < 500:
-                            error_msg = response_data.get("error_description") or response_data.get("error") or f"HTTP {response.status}"
-                            logger.error(f"Token request failed with client error: {error_msg}")
-                            return (False, {
-                                "error": response_data.get("error", "client_error"),
-                                "error_description": error_msg,
-                                "status_code": response.status
-                            })
+                            error_msg = (
+                                response_data.get("error_description")
+                                or response_data.get("error")
+                                or f"HTTP {response.status}"
+                            )
+                            logger.error(
+                                "OAuth token request failed with client error status=%s code=%s",
+                                response.status,
+                                log_safe(response_data.get("error", "client_error")),
+                            )
+                            return (
+                                False,
+                                {
+                                    "error": response_data.get("error", "client_error"),
+                                    "error_description": error_msg,
+                                    "status_code": response.status,
+                                },
+                            )
 
                         # Server errors (5xx) - retry
                         else:
                             error_msg = f"Server error: HTTP {response.status}"
-                            logger.warning(f"Token request failed: {error_msg} (attempt {attempt + 1}/{self.max_retries})")
+                            logger.warning(
+                                "OAuth token request failed with server error status=%s attempt=%s/%s",
+                                response.status,
+                                attempt + 1,
+                                self.max_retries,
+                            )
                             last_error = error_msg
 
                             if attempt < self.max_retries - 1:
                                 # Exponential backoff: 1s, 2s, 4s
-                                wait_time = 2 ** attempt
+                                wait_time = 2**attempt
                                 await asyncio.sleep(wait_time)
                                 continue
 
             except aiohttp.ClientError as e:
-                logger.warning(f"Network error during token request: {str(e)} (attempt {attempt + 1}/{self.max_retries})")
+                logger.warning(
+                    "Network error during OAuth token request: %s attempt=%s/%s",
+                    e.__class__.__name__,
+                    attempt + 1,
+                    self.max_retries,
+                )
                 last_error = str(e)
 
                 if attempt < self.max_retries - 1:
-                    wait_time = 2 ** attempt
+                    wait_time = 2**attempt
                     await asyncio.sleep(wait_time)
                     continue
 
             except TimeoutError:
-                logger.warning(f"Token request timed out (attempt {attempt + 1}/{self.max_retries})")
+                logger.warning(
+                    "OAuth token request timed out attempt=%s/%s",
+                    attempt + 1,
+                    self.max_retries,
+                )
                 last_error = "Request timed out"
 
                 if attempt < self.max_retries - 1:
-                    wait_time = 2 ** attempt
+                    wait_time = 2**attempt
                     await asyncio.sleep(wait_time)
                     continue
 
             except Exception as e:
-                logger.error(f"Unexpected error during token request: {str(e)}", exc_info=True)
-                return (False, {
-                    "error": "unexpected_error",
-                    "error_description": str(e)
-                })
+                logger.error(
+                    "Unexpected error during OAuth token request: %s",
+                    e.__class__.__name__,
+                )
+                return (
+                    False,
+                    {"error": "unexpected_error", "error_description": str(e)},
+                )
 
         # All retries exhausted
-        logger.error(f"Token request failed after {self.max_retries} attempts: {last_error}")
-        return (False, {
-            "error": "max_retries_exceeded",
-            "error_description": f"Failed after {self.max_retries} attempts: {last_error}"
-        })
+        logger.error("OAuth token request failed after %s attempts", self.max_retries)
+        return (
+            False,
+            {
+                "error": "max_retries_exceeded",
+                "error_description": f"Failed after {self.max_retries} attempts: {last_error}",
+            },
+        )
 
     def _parse_token_response(self, response_data: dict) -> dict:
         """
@@ -357,19 +387,25 @@ class OAuthProviderClient:
         # Calculate expires_at from expires_in (seconds)
         expires_in = response_data.get("expires_in")
         if expires_in:
-            result["expires_at"] = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
+            result["expires_at"] = datetime.now(timezone.utc) + timedelta(
+                seconds=int(expires_in)
+            )
         else:
             # Default to 1 hour if not specified
             logger.warning("OAuth response missing expires_in, defaulting to 1 hour")
             result["expires_at"] = datetime.now(timezone.utc) + timedelta(hours=1)
 
         # Log refresh token presence at INFO level for debugging
-        if result['refresh_token'] is not None:
+        if result["refresh_token"] is not None:
             logger.info("✓ Token response includes refresh_token")
         else:
-            logger.info("✗ Token response does NOT include refresh_token (will use fallback if available)")
+            logger.info(
+                "✗ Token response does NOT include refresh_token (will use fallback if available)"
+            )
 
-        logger.debug(f"Parsed token response: expires_at={result['expires_at']}, has_refresh={result['refresh_token'] is not None}")
+        logger.debug(
+            f"Parsed token response: expires_at={result['expires_at']}, has_refresh={result['refresh_token'] is not None}"
+        )
 
         return result
 
@@ -579,9 +615,7 @@ async def refresh_oauth_token_http(td: dict[str, Any]) -> dict[str, Any]:
             )
         else:
             if not td["encrypted_refresh_token"]:
-                outcome["error"] = (
-                    f"No refresh token for token {td.get('token_id')}"
-                )
+                outcome["error"] = f"No refresh token for token {td.get('token_id')}"
                 return outcome
 
             raw_refresh = td["encrypted_refresh_token"]
@@ -640,8 +674,8 @@ async def refresh_oauth_token_http(td: dict[str, Any]) -> dict[str, Any]:
         return outcome
 
     except Exception as e:
-        logger.error(f"Error refreshing OAuth token: {e}", exc_info=True)
-        outcome["error"] = f"Token refresh failed: {str(e)[:200]}"
+        logger.error("Error refreshing OAuth token: %s", e.__class__.__name__)
+        outcome["error"] = f"Token refresh failed: {e.__class__.__name__}"
         return outcome
 
 

--- a/api/tests/unit/jobs/test_oauth_token_refresh_scheduler.py
+++ b/api/tests/unit/jobs/test_oauth_token_refresh_scheduler.py
@@ -11,6 +11,8 @@ this pins the invariant that:
     still produces a fully-resolved token URL
 """
 
+import logging
+
 import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -105,3 +107,68 @@ class TestSchedulerUsesSharedPrimitives:
         mock_refresh.assert_called_once()
         assert results["refreshed_successfully"] == 1
         assert results["refresh_failed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_refresh_exception_log_omits_token_id_and_secret(self, caplog):
+        """Scheduler exception logs should not include provider, token, or secret values."""
+        from src.jobs.schedulers import oauth_token_refresh as sched
+
+        token = MagicMock()
+        token.id = uuid4()
+        token.encrypted_refresh_token = "encrypted-refresh-secret"
+        token.expires_at = datetime.now(timezone.utc) + timedelta(minutes=1)
+
+        provider = MagicMock()
+        provider.id = uuid4()
+        provider.provider_name = "SensitiveProvider"
+        provider.oauth_flow_type = "authorization_code"
+        token.provider = provider
+
+        mock_db = AsyncMock()
+        token_query_result = MagicMock()
+        token_query_result.scalars.return_value.all.return_value = [token]
+        mock_db.execute = AsyncMock(return_value=token_query_result)
+        mock_db.commit = AsyncMock()
+
+        class _DbCtxManager:
+            async def __aenter__(self):
+                return mock_db
+
+            async def __aexit__(self, *_args):
+                return False
+
+        with (
+            caplog.at_level(
+                logging.ERROR, logger="src.jobs.schedulers.oauth_token_refresh"
+            ),
+            patch.object(sched, "get_db_context", return_value=_DbCtxManager()),
+            patch.object(
+                sched,
+                "build_token_refresh_context",
+                new_callable=AsyncMock,
+            ) as mock_build,
+            patch.object(
+                sched,
+                "refresh_oauth_token_http",
+                new_callable=AsyncMock,
+            ) as mock_refresh,
+        ):
+            mock_build.return_value = {
+                "token_id": token.id,
+                "provider_id": provider.id,
+                "provider_name": provider.provider_name,
+            }
+            mock_refresh.side_effect = RuntimeError(
+                "refresh failed for super-secret-token"
+            )
+
+            results = await sched.run_refresh_job(
+                trigger_type="test",
+                refresh_threshold_minutes=None,
+            )
+
+        assert results["refresh_failed"] == 1
+        log_text = caplog.text
+        assert str(token.id) not in log_text
+        assert "super-secret-token" not in log_text
+        assert "SensitiveProvider" not in log_text

--- a/api/tests/unit/services/test_oauth_config_service.py
+++ b/api/tests/unit/services/test_oauth_config_service.py
@@ -1,0 +1,31 @@
+"""Unit tests for OAuth SSO configuration service."""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.oauth_config_service import OAuthConfigService
+
+
+@pytest.mark.asyncio
+async def test_secret_decrypt_failure_log_omits_secret_material(caplog):
+    """Decrypt failures should not log ciphertext, key names, or exception text."""
+    service = OAuthConfigService(db=AsyncMock())
+    service._get_config_value = AsyncMock(return_value="encrypted-secret-payload")  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "src.services.oauth_config_service.decrypt_secret",
+            side_effect=RuntimeError("failed for super-secret-value"),
+        ),
+        caplog.at_level(logging.ERROR, logger="src.services.oauth_config_service"),
+    ):
+        result = await service._get_secret_value("oauth_client_secret")
+
+    assert result is None
+    log_text = caplog.text
+    assert "RuntimeError" in log_text
+    assert "oauth_client_secret" not in log_text
+    assert "encrypted-secret-payload" not in log_text
+    assert "super-secret-value" not in log_text

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -6,6 +6,7 @@ Mocks HTTP requests to OAuth providers.
 
 import pytest
 import asyncio
+import logging
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -16,6 +17,60 @@ from src.services.oauth_provider import OAuthProviderClient
 def oauth_client():
     """Create OAuth provider client with test defaults"""
     return OAuthProviderClient(timeout=10, max_retries=3)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs", "secrets", "expected"),
+    [
+        (
+            "exchange_code_for_token",
+            {
+                "token_url": "https://oauth.example.com/token?tenant=secret-tenant",
+                "code": "authorization-code",
+                "client_id": "client-id",
+                "client_secret": "super-secret-client-value",
+                "redirect_uri": "https://app.example.com/callback",
+            },
+            ("super-secret-client-value", "secret-tenant", "client_secret"),
+            "confidential client",
+        ),
+        (
+            "refresh_access_token",
+            {
+                "token_url": "https://oauth.example.com/token?tenant=secret-tenant",
+                "refresh_token": "refresh-token-secret",
+                "client_id": "client-id",
+                "client_secret": "client-secret-value",
+            },
+            (
+                "refresh-token-secret",
+                "client-secret-value",
+                "secret-tenant",
+                "client_secret",
+            ),
+            "confidential client",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_oauth_request_logs_do_not_include_secret_material(
+    oauth_client, caplog, method_name, kwargs, secrets, expected
+):
+    """OAuth request logs should describe flow shape without logging secrets."""
+    with (
+        caplog.at_level(logging.INFO, logger="src.services.oauth_provider"),
+        patch.object(
+            oauth_client,
+            "_make_token_request",
+            new=AsyncMock(return_value=(True, {"access_token": "ok"})),
+        ),
+    ):
+        await getattr(oauth_client, method_name)(**kwargs)
+
+    log_text = caplog.text
+    for secret in secrets:
+        assert secret not in log_text
+    assert expected in log_text
 
 
 class TestOAuthProviderTokenExchange:


### PR DESCRIPTION
## Summary
- avoid logging OAuth token URLs, secret config keys, provider/token identifiers, and exception text in refresh/provider/config paths
- preserve current OAuth refresh status behavior while narrowing scanner-sensitive log payloads
- add regression coverage for secret-safe OAuth logging

## Verification
- pve-t340 VM 101: ash ./test.sh unit => 3916 passed, 1 skipped
- pve-t340 VM 101 after test refactor: ash ./test.sh tests/unit/services/test_oauth_provider.py tests/unit/jobs/test_oauth_token_refresh_scheduler.py tests/unit/services/test_oauth_config_service.py tests/unit/services/test_refresh_oauth_token_http.py => 28 passed
- GitHub PR checks: Unit Tests, E2E Tests, Lint & Type Check, CodeQL, SonarCloud, Snyk, CodeRabbit all passed