### PR TITLE
Enforce agent access during chat routing

### DIFF
--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -184,7 +184,10 @@ class AgentExecutor:
         try:
             # 1. Check for @mention agent switching
             if enable_routing:
-                mentioned_agent = await router.parse_mention(user_message)
+                mentioned_agent = await router.parse_mention(
+                    user_message,
+                    conversation.user,
+                )
                 if mentioned_agent:
                     # Strip @mention from message for cleaner processing
                     user_message = router.strip_mention(user_message)
@@ -199,7 +202,8 @@ class AgentExecutor:
                 is_first_message = await self._is_first_user_message(conversation.id)
                 if is_first_message:
                     routed_agent = await router.route_message(
-                        user_message
+                        user_message,
+                        user=conversation.user,
                     )
                     if routed_agent:
                         # Switch to routed agent (handles events and persistence)

--- a/api/src/services/agent_router.py
+++ b/api/src/services/agent_router.py
@@ -15,7 +15,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from src.core.log_safety import log_safe
+from src.core.org_filter import OrgFilterType
 from src.models.orm import Agent
+from src.models.orm.users import User
+from src.repositories.agents import AgentRepository
 from src.services.llm import get_llm_client, LLMMessage
 
 logger = logging.getLogger(__name__)
@@ -46,7 +49,35 @@ class AgentRouter:
             yield session
             await session.commit()
 
-    async def parse_mention(self, message: str) -> Agent | None:
+    async def _load_accessible_agents(self, user: User) -> list[Agent]:
+        """Load active agents visible to ``user`` using the normal access model."""
+        async with self._db() as session:
+            repo = AgentRepository(
+                session=session,
+                org_id=user.organization_id,
+                user_id=user.id,
+                is_superuser=user.is_superuser,
+            )
+            if user.is_superuser:
+                return await repo.list_all_in_scope(
+                    OrgFilterType.ALL,
+                    active_only=True,
+                )
+            return await repo.list_agents(active_only=True)
+
+    async def _find_accessible_agent_by_name(
+        self,
+        agent_name: str,
+        user: User,
+    ) -> Agent | None:
+        """Resolve an agent mention by name after applying caller access checks."""
+        normalized_name = agent_name.lower()
+        for agent in await self._load_accessible_agents(user):
+            if agent.name.lower() == normalized_name:
+                return agent
+        return None
+
+    async def parse_mention(self, message: str, user: User | None = None) -> Agent | None:
         """
         Parse @mention from user message and find matching agent.
 
@@ -62,7 +93,15 @@ class AgentRouter:
 
         agent_name = match.group(1).strip()
 
-        # Find agent by name (case-insensitive), with tools and delegations loaded
+        if user is not None:
+            agent = await self._find_accessible_agent_by_name(agent_name, user)
+            if agent:
+                logger.info(f"@mention routing to agent: {agent.name}")
+            return agent
+
+        # Compatibility fallback for internal callers that predate user-scoped
+        # routing. Chat execution passes a user and gets access-controlled
+        # resolution.
         async with self._db() as session:
             result = await session.execute(
                 select(Agent)
@@ -105,6 +144,7 @@ class AgentRouter:
         self,
         message: str,
         available_agents: list[Agent] | None = None,
+        user: User | None = None,
     ) -> Agent | None:
         """
         Use AI to route a message to the most appropriate agent.
@@ -116,18 +156,23 @@ class AgentRouter:
         Returns:
             Agent if a good match was found, None to handle directly
         """
-        # Get available agents if not provided (with tools and delegations eager-loaded)
+        # Get available agents if not provided.
         if available_agents is None:
-            async with self._db() as session:
-                result = await session.execute(
-                    select(Agent)
-                    .options(
-                        selectinload(Agent.tools),
-                        selectinload(Agent.delegated_agents),
+            if user is not None:
+                available_agents = await self._load_accessible_agents(user)
+            else:
+                # Compatibility fallback for internal callers. Chat execution
+                # passes a user and gets access-controlled routing candidates.
+                async with self._db() as session:
+                    result = await session.execute(
+                        select(Agent)
+                        .options(
+                            selectinload(Agent.tools),
+                            selectinload(Agent.delegated_agents),
+                        )
+                        .where(Agent.is_active.is_(True))
                     )
-                    .where(Agent.is_active.is_(True))
-                )
-                available_agents = list(result.scalars().all())
+                    available_agents = list(result.scalars().all())
 
         # If no agents available, return None
         if not available_agents:

--- a/api/tests/unit/services/test_agent_router_access.py
+++ b/api/tests/unit/services/test_agent_router_access.py
@@ -1,0 +1,110 @@
+"""Access-control regression tests for chat agent routing."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from src.models.enums import AgentAccessLevel
+from src.models.orm.agents import Agent
+from src.models.orm.organizations import Organization
+from src.models.orm.users import User
+from src.services.agent_router import AgentRouter
+
+
+@pytest_asyncio.fixture
+async def seeded_router_data(db_session):
+    now = datetime.now(timezone.utc)
+    org = Organization(
+        id=uuid4(),
+        name=f"Org {uuid4().hex[:8]}",
+        created_by="test@example.com",
+        created_at=now,
+        updated_at=now,
+    )
+    user = User(
+        id=uuid4(),
+        email=f"user_{uuid4().hex[:8]}@example.com",
+        name="Org User",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        is_registered=True,
+        organization_id=org.id,
+        created_at=now,
+        updated_at=now,
+    )
+    restricted = Agent(
+        id=uuid4(),
+        name="Platform Assistant",
+        description="Privileged helper",
+        system_prompt="You can manage the platform.",
+        channels=["chat"],
+        access_level=AgentAccessLevel.ROLE_BASED,
+        organization_id=None,
+        is_active=True,
+        knowledge_sources=[],
+        system_tools=["create_agent"],
+        created_by="admin@example.com",
+        created_at=now,
+        updated_at=now,
+    )
+    allowed = Agent(
+        id=uuid4(),
+        name="Help Desk",
+        description="General support",
+        system_prompt="You help users.",
+        channels=["chat"],
+        access_level=AgentAccessLevel.AUTHENTICATED,
+        organization_id=None,
+        is_active=True,
+        knowledge_sources=[],
+        system_tools=[],
+        created_by="admin@example.com",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add_all([org, user, restricted, allowed])
+    await db_session.commit()
+
+    yield user, restricted, allowed
+
+    await db_session.delete(restricted)
+    await db_session.delete(allowed)
+    await db_session.delete(user)
+    await db_session.delete(org)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_parse_mention_ignores_inaccessible_role_based_agent(
+    seeded_router_data, async_session_factory
+):
+    user, _restricted, allowed = seeded_router_data
+    router = AgentRouter(async_session_factory)
+
+    assert await router.parse_mention("@[Platform Assistant] help", user) is None
+
+    mentioned = await router.parse_mention("@[Help Desk] help", user)
+    assert mentioned is not None
+    assert mentioned.id == allowed.id
+
+
+@pytest.mark.asyncio
+async def test_auto_routing_cannot_select_inaccessible_agent(
+    seeded_router_data, async_session_factory, monkeypatch
+):
+    user, _restricted, _allowed = seeded_router_data
+    router = AgentRouter(async_session_factory)
+
+    class _RouterLLM:
+        async def complete(self, messages):
+            return type("Response", (), {"content": "Platform Assistant"})()
+
+    async def _get_router_llm(_session):
+        return _RouterLLM()
+
+    monkeypatch.setattr("src.services.agent_router.get_llm_client", _get_router_llm)
+
+    assert await router.route_message("manage platform agents", user=user) is None


### PR DESCRIPTION
## Summary
- scope @mention and automatic chat routing candidates to agents the conversation user can access
- keep existing internal fallback behavior for callers that do not pass a user
- add regression coverage for inaccessible role-based agents being ignored by mention and AI routing

## Security
Closes a residual path from GHSA-5pf3-54gh-85hj where a low-privileged user could route chat to an inaccessible privileged agent by name.

## Verification
- pve-t340 VM 101: ash ./test.sh tests/unit/services/test_agent_router_access.py => 2 passed
- pve-t340 VM 101: ash ./test.sh tests/unit/services/test_agent_router_access.py tests/unit/services/test_agent_executor_tools.py tests/unit/services/test_agent_executor_context.py tests/unit/services/test_mcp_agent_scope.py tests/unit/test_agent_tuning_authorization.py => 91 passed, 1 warning
- pve-t340 VM 101: ash ./test.sh unit => 3914 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent routing and mention resolution now respect user access levels, ensuring only accessible agents are suggested or routed to during conversations.

* **Tests**
  * Added access control regression tests for agent routing to verify proper permission enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->