### PR TITLE
Scope system tool context to caller org

### DIFF
--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -1663,12 +1663,17 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
             # Get user from conversation (same pattern as workflow tool execution)
             user = conversation.user if conversation else None
 
+            # Create context from the caller first. Agent organization controls
+            # visibility of the agent, not the tenant scope for tool effects.
+            user_org_id = getattr(user, "organization_id", None) if user else None
+            context_org_id = user_org_id or agent.organization_id
+
             # Create context from agent/conversation/user
             # session=None: system tools create their own short-lived sessions
             # via get_tool_db() fallback, avoiding long-lived connection holds
             context = MCPContext(
                 user_id=str(user.id) if user else "",
-                org_id=str(agent.organization_id) if agent.organization_id else None,
+                org_id=str(context_org_id) if context_org_id else None,
                 is_platform_admin=user.is_superuser if user else False,
                 user_email=user.email if user else "",
                 user_name=user.name if user else "",

--- a/api/tests/unit/services/test_agent_executor_tools.py
+++ b/api/tests/unit/services/test_agent_executor_tools.py
@@ -395,6 +395,51 @@ class TestPrivilegedAgentManagementTools:
         mock_execute_system_tool.assert_awaited_once()
         assert result is expected
 
+    @pytest.mark.asyncio
+    async def test_system_tool_context_uses_caller_org_not_agent_org(self, executor):
+        """System tools inherit caller tenant scope even when the agent is global/foreign."""
+        from src.services.llm.base import ToolCallRequest
+        from src.services.mcp_server.tool_result import success_result
+
+        caller_org_id = uuid4()
+        agent_org_id = uuid4()
+        seen_context = None
+
+        async def fake_tool(context, **_kwargs):
+            nonlocal seen_context
+            seen_context = context
+            return success_result("ok", {"ok": True})
+
+        conversation = MagicMock()
+        conversation.user = MagicMock()
+        conversation.user.id = uuid4()
+        conversation.user.organization_id = caller_org_id
+        conversation.user.is_superuser = False
+        conversation.user.email = "user@example.com"
+        conversation.user.name = "User"
+
+        agent = MagicMock()
+        agent.organization_id = agent_org_id
+
+        with patch(
+            "src.services.mcp_server.server.get_system_tool_function",
+            return_value=fake_tool,
+        ):
+            result = await executor._execute_system_tool(
+                ToolCallRequest(
+                    id="call_allowed",
+                    name="list_workflows",
+                    arguments={},
+                ),
+                agent=agent,
+                conversation=conversation,
+            )
+
+        assert result.error is None
+        assert seen_context is not None
+        assert seen_context.org_id == caller_org_id
+        assert seen_context.org_id != agent_org_id
+
 
 class TestSerializeForJson:
     """Test the _serialize_for_json helper function."""


### PR DESCRIPTION
## Summary
- build chat system-tool MCPContext from the conversation user's org before falling back to the agent org
- add regression coverage proving system tools use caller tenant scope, not selected agent scope

## Security
Closes another residual path from GHSA-5pf3-54gh-85hj where a chat-selected/global agent could cause system tools to run with agent-derived org context instead of caller-derived tenant scope.

## Verification
- pve-t340 VM 101: `bash ./test.sh tests/unit/services/test_agent_executor_tools.py tests/unit/services/test_mcp_agent_scope.py` => 46 passed, 1 warning
- pve-t340 VM 101: `bash ./test.sh unit` => 3913 passed, 1 skipped