### PR TITLE
Restrict app source repointing to platform admins

### DIFF
--- a/api/src/models/contracts/applications.py
+++ b/api/src/models/contracts/applications.py
@@ -386,7 +386,7 @@ class ApplicationReplaceRequest(BaseModel):
     force: bool = Field(
         default=False,
         description=(
-            "Bypass the uniqueness, nesting, and source-exists checks. "
+            "Bypass the source-exists check only. "
             "Use when repointing before files are pushed."
         ),
     )

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -1042,6 +1042,12 @@ async def replace_application_endpoint(
     Validates that the new path is unique, non-nested with other apps, and has
     source files under it. ``force: true`` bypasses only the source-file check.
     """
+    if not user.is_platform_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Platform admin privileges required",
+        )
+
     repo = ApplicationRepository(
         ctx.db,
         ctx.org_id,

--- a/api/tests/e2e/api/test_applications.py
+++ b/api/tests/e2e/api/test_applications.py
@@ -549,6 +549,48 @@ class TestApplicationCrossOrgAdmin:
 
 
 @pytest.mark.e2e
+class TestApplicationReplaceAuthorization:
+    """Authorization coverage for the source-root repoint endpoint."""
+
+    def test_org_user_cannot_replace_accessible_app_repo_path(
+        self, e2e_client, platform_admin, org1_user, org1
+    ):
+        """Readable authenticated apps cannot be repointed by non-admin users."""
+        suffix = uuid.uuid4().hex[:8]
+        app = _create_app(
+            e2e_client,
+            platform_admin.headers,
+            f"replace-deny-{suffix}",
+            name="Replace Deny",
+            organization_id=org1["id"],
+        )
+
+        try:
+            get_response = e2e_client.get(
+                f"/api/applications/{app['slug']}",
+                headers=org1_user.headers,
+            )
+            assert get_response.status_code == 200, (
+                f"Fixture app should be readable by org user: {get_response.text}"
+            )
+
+            response = e2e_client.post(
+                f"/api/applications/{app['id']}/replace",
+                headers=org1_user.headers,
+                json={
+                    "repo_path": f"apps/replaced-by-user-{suffix}",
+                    "force": True,
+                },
+            )
+
+            assert response.status_code == 403, (
+                f"Non-admin should not repoint app source roots: {response.text}"
+            )
+        finally:
+            _delete_app(e2e_client, platform_admin.headers, app["id"])
+
+
+@pytest.mark.e2e
 class TestApplicationDBStorage:
     """Test that applications are stored in database, not S3."""
 


### PR DESCRIPTION
## Summary
- require platform-admin privileges for the app source-root replace endpoint
- add an E2E regression proving an org user who can read an authenticated app cannot repoint its repo_path
- correct the replace request contract description so force only documents the source-exists bypass

## Security
Closes the remaining externally reachable mutation path from GHSA-m5r4-wp96-4vmh: authenticated app access no longer grants permission to change the repo_path prefix trusted by app file read/write/delete paths.

## Verification
- pve-t340 VM 101: `bash ./test.sh tests/unit/services/test_app_repoint.py tests/e2e/api/test_applications.py::TestApplicationReplaceAuthorization` => 10 passed
- pve-t340 VM 101: `bash ./test.sh tests/e2e/platform/test_cli_apps_replace.py tests/e2e/api/test_applications.py` => 29 passed
- pve-t340 VM 101: `bash ./test.sh unit` => 3912 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application replacement endpoint now requires platform administrator privileges. Previously, other users could attempt this operation.
  * Updated force field documentation to clarify it only bypasses the source-exists validation check.

* **Tests**
  * Added authorization tests verifying that non-administrator users cannot perform application replacements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->