### PR TITLE
Scope agent tuning runs to caller org

### DIFF
--- a/api/src/routers/agent_tuning.py
+++ b/api/src/routers/agent_tuning.py
@@ -44,6 +44,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/agents", tags=["Agent Tuning"])
 
 
+def _is_tuning_admin(user: CurrentActiveUser) -> bool:
+    return user.is_superuser or any(
+        role in ["Platform Admin", "Platform Owner"] for role in user.roles
+    )
+
+
 async def _load_agent_with_access(
     agent_id: UUID, db: DbSession, user: CurrentActiveUser
 ) -> Agent:
@@ -54,9 +60,7 @@ async def _load_agent_with_access(
     org/global agents may be visible to regular users, but they are not
     user-owned mutable resources.
     """
-    is_admin = user.is_superuser or any(
-        role in ["Platform Admin", "Platform Owner"] for role in user.roles
-    )
+    is_admin = _is_tuning_admin(user)
 
     agent = (
         await db.execute(select(Agent).where(Agent.id == agent_id))
@@ -90,9 +94,15 @@ async def create_tuning_session(
 ) -> ConsolidatedProposalResponse:
     """Generate a consolidated prompt proposal from this agent's flagged runs."""
     await _load_agent_with_access(agent_id, db, user)
+    is_admin = _is_tuning_admin(user)
 
     try:
-        proposal = await propose_consolidated_tuning(agent_id, db)
+        proposal = await propose_consolidated_tuning(
+            agent_id,
+            db,
+            org_id=user.organization_id,
+            restrict_to_org=not is_admin,
+        )
     except LookupError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
@@ -120,6 +130,7 @@ async def dry_run_tuning_session(
     Capped at 10 runs by the service layer to bound cost.
     """
     await _load_agent_with_access(agent_id, db, user)
+    is_admin = _is_tuning_admin(user)
 
     session_factory = get_session_factory()
     raw = await dry_run_consolidated(
@@ -127,6 +138,8 @@ async def dry_run_tuning_session(
         proposed_prompt=request.proposed_prompt,
         db=db,
         session_factory=session_factory,
+        org_id=user.organization_id,
+        restrict_to_org=not is_admin,
     )
     return ConsolidatedDryRunResponse(
         results=[
@@ -153,6 +166,7 @@ async def apply_tuning_session(
 ) -> ApplyTuningResponse:
     """Apply a consolidated tuning proposal: update prompt, write history, clear verdicts."""
     await _load_agent_with_access(agent_id, db, user)
+    is_admin = _is_tuning_admin(user)
 
     try:
         applied = await apply_consolidated_tuning(
@@ -161,6 +175,8 @@ async def apply_tuning_session(
             reason=request.reason,
             user_id=user.user_id,
             db=db,
+            org_id=user.organization_id,
+            restrict_to_org=not is_admin,
         )
     except LookupError as exc:
         raise HTTPException(

--- a/api/src/services/execution/tuning_service.py
+++ b/api/src/services/execution/tuning_service.py
@@ -210,18 +210,29 @@ class AppliedTuning:
 
 
 async def _load_flagged_runs_with_conversations(
-    agent_id: UUID, db: AsyncSession
+    agent_id: UUID,
+    db: AsyncSession,
+    *,
+    org_id: UUID | None = None,
+    restrict_to_org: bool = False,
 ) -> list[tuple[AgentRun, AgentRunFlagConversation | None]]:
     """Load all completed thumbs-down runs for ``agent_id`` and their conversations."""
+    stmt = (
+        select(AgentRun)
+        .where(AgentRun.agent_id == agent_id)
+        .where(AgentRun.verdict == "down")
+        .where(AgentRun.status == "completed")
+        .order_by(AgentRun.created_at)
+    )
+    if restrict_to_org:
+        if org_id is None:
+            stmt = stmt.where(AgentRun.org_id.is_(None))
+        else:
+            stmt = stmt.where(AgentRun.org_id == org_id)
+
     runs = (
         (
-            await db.execute(
-                select(AgentRun)
-                .where(AgentRun.agent_id == agent_id)
-                .where(AgentRun.verdict == "down")
-                .where(AgentRun.status == "completed")
-                .order_by(AgentRun.created_at)
-            )
+            await db.execute(stmt)
         )
         .scalars()
         .all()
@@ -246,7 +257,11 @@ async def _load_flagged_runs_with_conversations(
 
 
 async def propose_consolidated_tuning(
-    agent_id: UUID, db: AsyncSession
+    agent_id: UUID,
+    db: AsyncSession,
+    *,
+    org_id: UUID | None = None,
+    restrict_to_org: bool = False,
 ) -> ConsolidatedProposal:
     """Single LLM call across all flagged runs; returns one consolidated proposal.
 
@@ -258,7 +273,12 @@ async def propose_consolidated_tuning(
     if agent is None:
         raise LookupError(f"Agent {agent_id} not found")
 
-    pairs = await _load_flagged_runs_with_conversations(agent_id, db)
+    pairs = await _load_flagged_runs_with_conversations(
+        agent_id,
+        db,
+        org_id=org_id,
+        restrict_to_org=restrict_to_org,
+    )
     if not pairs:
         raise LookupError(
             f"Agent {agent_id} has no flagged (thumbs-down) runs to tune"
@@ -324,13 +344,21 @@ async def dry_run_consolidated(
     proposed_prompt: str,
     db: AsyncSession,
     session_factory: async_sessionmaker[AsyncSession],
+    *,
+    org_id: UUID | None = None,
+    restrict_to_org: bool = False,
 ) -> list[tuple[UUID, bool, str, float]]:
     """Run :func:`evaluate_against_prompt` for each flagged run (capped).
 
     Returns a list of ``(run_id, would_still_decide_same, reasoning, confidence)``
     tuples, capped at :data:`CONSOLIDATED_DRY_RUN_LIMIT` runs to bound cost.
     """
-    pairs = await _load_flagged_runs_with_conversations(agent_id, db)
+    pairs = await _load_flagged_runs_with_conversations(
+        agent_id,
+        db,
+        org_id=org_id,
+        restrict_to_org=restrict_to_org,
+    )
     capped = pairs[:CONSOLIDATED_DRY_RUN_LIMIT]
     results: list[tuple[UUID, bool, str, float]] = []
     for run, _conv in capped:
@@ -356,6 +384,9 @@ async def apply_consolidated_tuning(
     reason: str | None,
     user_id: UUID | None,
     db: AsyncSession,
+    *,
+    org_id: UUID | None = None,
+    restrict_to_org: bool = False,
 ) -> AppliedTuning:
     """Apply a consolidated tuning proposal.
 
@@ -369,7 +400,12 @@ async def apply_consolidated_tuning(
     if agent is None:
         raise LookupError(f"Agent {agent_id} not found")
 
-    pairs = await _load_flagged_runs_with_conversations(agent_id, db)
+    pairs = await _load_flagged_runs_with_conversations(
+        agent_id,
+        db,
+        org_id=org_id,
+        restrict_to_org=restrict_to_org,
+    )
     affected_ids = [r.id for r, _ in pairs]
 
     previous_prompt = agent.system_prompt

--- a/api/tests/unit/test_consolidated_tuning.py
+++ b/api/tests/unit/test_consolidated_tuning.py
@@ -10,6 +10,7 @@ Validates the Task 17 implementation:
 - ``dry_run_consolidated`` calls the per-run dry-run for at most
   ``CONSOLIDATED_DRY_RUN_LIMIT`` runs even when more are flagged.
 """
+import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -22,6 +23,7 @@ from src.models.orm.agent_prompt_history import AgentPromptHistory
 from src.models.orm.agent_run_flag_conversations import AgentRunFlagConversation
 from src.models.orm.agent_runs import AgentRun
 from src.models.orm.ai_usage import AIUsage
+from src.models.orm.organizations import Organization
 from src.services.execution.tuning_service import (
     CONSOLIDATED_DRY_RUN_LIMIT,
     apply_consolidated_tuning,
@@ -46,6 +48,10 @@ def _build_mock_client(response):
     client.complete = AsyncMock(return_value=response)
     client.provider_name = "anthropic"
     return client
+
+
+def _build_org(name: str) -> Organization:
+    return Organization(id=uuid4(), name=name, created_by="test")
 
 
 @pytest_asyncio.fixture
@@ -119,6 +125,85 @@ async def test_propose_returns_proposal_with_flagged_runs(
 
 
 @pytest.mark.asyncio
+async def test_propose_can_scope_global_agent_runs_to_caller_org(
+    db_session, seed_agent
+):
+    """Tenant-scoped tuning excludes other orgs' runs for global agents."""
+    from src.services.execution import tuning_service as mod
+
+    caller_org = _build_org("Caller Org")
+    other_org = _build_org("Other Org")
+    caller_org_id = caller_org.id
+    other_org_id = other_org.id
+    caller_run = AgentRun(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        trigger_type="test",
+        status="completed",
+        iterations_used=1,
+        tokens_used=100,
+        input={"message": "caller org question"},
+        output={"text": "caller org answer"},
+        verdict="down",
+        org_id=caller_org_id,
+    )
+    other_run = AgentRun(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        trigger_type="test",
+        status="completed",
+        iterations_used=1,
+        tokens_used=100,
+        input={"message": "other org secret question"},
+        output={"text": "other org secret answer"},
+        verdict="down",
+        org_id=other_org_id,
+    )
+    db_session.add_all([caller_org, other_org])
+    await db_session.flush()
+    db_session.add_all([caller_run, other_run])
+    await db_session.commit()
+
+    mock_client = _build_mock_client(
+        _build_mock_llm_response(
+            '{"summary": "Caller org only.", '
+            '"proposed_prompt": "Stay tenant scoped."}'
+        )
+    )
+
+    try:
+        with patch.object(
+            mod,
+            "get_tuning_client",
+            new=AsyncMock(return_value=(mock_client, "claude-sonnet-4-6")),
+        ):
+            proposal = await propose_consolidated_tuning(
+                seed_agent.id,
+                db_session,
+                org_id=caller_org_id,
+                restrict_to_org=True,
+            )
+
+        assert proposal.affected_run_ids == [caller_run.id]
+        payload = json.loads(
+            mock_client.complete.await_args.kwargs["messages"][1].content
+        )
+        serialized = json.dumps(payload)
+        assert "caller org question" in serialized
+        assert "other org secret question" not in serialized
+    finally:
+        await db_session.execute(
+            delete(AgentRun).where(AgentRun.id.in_([caller_run.id, other_run.id]))
+        )
+        await db_session.execute(
+            delete(Organization).where(
+                Organization.id.in_([caller_org_id, other_org_id])
+            )
+        )
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
 async def test_propose_no_flagged_runs_raises(db_session, seed_agent):
     """No flagged runs -> LookupError (router maps to 404)."""
     with pytest.raises(LookupError):
@@ -182,6 +267,91 @@ async def test_apply_updates_prompt_creates_history_resets_verdicts(
         ).scalar_one()
         assert refreshed_run.verdict is None
         assert refreshed_run.verdict_note is None
+
+
+@pytest.mark.asyncio
+async def test_apply_only_clears_caller_org_flagged_runs_for_global_agent(
+    db_session, seed_agent, seed_user
+):
+    """Tenant-scoped apply must not clear verdicts from other orgs."""
+    caller_org = _build_org("Apply Caller Org")
+    other_org = _build_org("Apply Other Org")
+    caller_org_id = caller_org.id
+    other_org_id = other_org.id
+    caller_run = AgentRun(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        trigger_type="test",
+        status="completed",
+        iterations_used=1,
+        tokens_used=100,
+        input={"message": "caller"},
+        output={"text": "caller"},
+        verdict="down",
+        verdict_note="caller wrong",
+        org_id=caller_org_id,
+    )
+    other_run = AgentRun(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        trigger_type="test",
+        status="completed",
+        iterations_used=1,
+        tokens_used=100,
+        input={"message": "other"},
+        output={"text": "other"},
+        verdict="down",
+        verdict_note="other wrong",
+        org_id=other_org_id,
+    )
+    db_session.add_all([caller_org, other_org])
+    await db_session.flush()
+    db_session.add_all([caller_run, other_run])
+    await db_session.commit()
+
+    try:
+        applied = await apply_consolidated_tuning(
+            agent_id=seed_agent.id,
+            new_prompt="Tenant-scoped prompt.",
+            reason="Only caller org.",
+            user_id=seed_user.id,
+            db=db_session,
+            org_id=caller_org_id,
+            restrict_to_org=True,
+        )
+        await db_session.commit()
+
+        assert applied.affected_run_ids == [caller_run.id]
+
+        refreshed_caller = (
+            await db_session.execute(
+                select(AgentRun).where(AgentRun.id == caller_run.id)
+            )
+        ).scalar_one()
+        refreshed_other = (
+            await db_session.execute(
+                select(AgentRun).where(AgentRun.id == other_run.id)
+            )
+        ).scalar_one()
+        assert refreshed_caller.verdict is None
+        assert refreshed_caller.verdict_note is None
+        assert refreshed_other.verdict == "down"
+        assert refreshed_other.verdict_note == "other wrong"
+    finally:
+        await db_session.execute(
+            delete(AgentRun).where(AgentRun.id.in_([caller_run.id, other_run.id]))
+        )
+        await db_session.execute(
+            delete(AgentPromptHistory).where(
+                AgentPromptHistory.agent_id == seed_agent.id
+            )
+        )
+        await db_session.execute(
+            delete(Organization).where(
+                Organization.id.in_([caller_org_id, other_org_id])
+            )
+        )
+        await db_session.commit()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass caller org scope into consolidated agent tuning propose, dry-run, and apply flows for non-admin users
- keep platform-admin tuning behavior unchanged
- add regression coverage proving global-agent tuning excludes other tenants' flagged runs and does not clear their verdicts

## Security
Closes a residual path from GHSA-g8wf-fpgx-m9rp where consolidated tuning for a global/shared agent could include or mutate flagged runs from other organizations.

## Verification
- pve-t340 VM 101: \ash ./test.sh tests/unit/test_agent_tuning_authorization.py tests/unit/test_consolidated_tuning.py tests/unit/test_tuning_service.py tests/unit/test_dry_run.py\ => 20 passed
- pve-t340 VM 101: \ash ./test.sh unit\ => 3914 passed, 1 skipped