### PR TITLE
Sanitize backend OAuth and LLM logs

### DIFF
--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -749,8 +749,8 @@ async def _build_oauth_data(
 
     # Check if we should auto-fetch a fresh token
     if should_auto_refresh_token(provider, entity_id, oauth_scope):
-        scope_info = f"oauth_scope={log_safe(oauth_scope)}" if oauth_scope else f"entity_id={entity_id}"
-        logger.info(f"Auto-refreshing token ({scope_info})")
+        refresh_mode = "oauth_scope" if oauth_scope else "entity_id"
+        logger.info("Auto-refreshing token using %s selector", refresh_mode)
 
         if client_secret and resolved_token_url:
             from src.services.oauth_provider import OAuthProviderClient

--- a/api/src/services/llm_config_service.py
+++ b/api/src/services/llm_config_service.py
@@ -367,7 +367,11 @@ class LLMConfigService:
                         message=f"Authentication failed at {endpoint_label}: {e}",
                     )
                 # Listing not supported — that's OK, key still seems live.
-                logger.info(f"Model listing not supported at {endpoint_label}: {e}")
+                logger.info(
+                    "Model listing not supported at %s: %s",
+                    log_safe(endpoint_label),
+                    log_safe(e),
+                )
                 return LLMTestResult(
                     success=True,
                     message=f"Connected to {endpoint_label}. Model listing not available — enter the model id manually.",
@@ -411,7 +415,11 @@ class LLMConfigService:
                         success=False,
                         message=f"Authentication failed at {endpoint_label}: {e}",
                     )
-                logger.info(f"Model listing not supported at {endpoint_label}: {e}")
+                logger.info(
+                    "Model listing not supported at %s: %s",
+                    log_safe(endpoint_label),
+                    log_safe(e),
+                )
                 return LLMTestResult(
                     success=True,
                     message=f"Connected to {endpoint_label}. Model listing not available — enter the model id manually.",


### PR DESCRIPTION
## Summary
- sanitize LLM model-listing endpoint/error values before logging
- sanitize CLI OAuth auto-refresh entity identifiers before logging
- switch the touched log calls to structured logger arguments

## Security
Addresses open CodeQL log-injection alerts in \pi/src/services/llm_config_service.py\ and \pi/src/routers/cli.py\.

## Verification
- pve-t340 VM 101: \ash ./test.sh tests/unit/services/test_llm_config_service.py tests/unit/routers/test_cli_auto_refresh.py\ => 36 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging security by implementing safer parameter formatting practices in internal logging calls across authentication and model configuration services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->