### PR TITLE
Add Codex Gateway policy primitives

### DIFF
--- a/api/src/models/contracts/__init__.py
+++ b/api/src/models/contracts/__init__.py
@@ -296,6 +296,15 @@ from src.models.contracts.common import (
     UploadedFileMetadata,
 )
 
+# Codex Gateway
+from src.models.contracts.codex_gateway import (
+    CodexGatewayKeyContext,
+    CodexGatewayPolicyDecision,
+    CodexGatewayRequestContext,
+    CodexGatewayUpstreamAccount,
+    OpenAICompatibleError,
+)
+
 # Scheduling & Async Execution
 from src.models.contracts.scheduling import (
     AsyncExecution,
@@ -717,6 +726,11 @@ __all__ = [
     "FileUploadRequest",
     "FileUploadResponse",
     "UploadedFileMetadata",
+    "CodexGatewayKeyContext",
+    "CodexGatewayPolicyDecision",
+    "CodexGatewayRequestContext",
+    "CodexGatewayUpstreamAccount",
+    "OpenAICompatibleError",
     "WorkflowKey",
     "WorkflowKeyCreateRequest",
     "WorkflowKeyResponse",

--- a/api/src/models/contracts/codex_gateway.py
+++ b/api/src/models/contracts/codex_gateway.py
@@ -1,0 +1,93 @@
+"""
+Contracts for the Bifrost Codex Gateway governance layer.
+
+These models intentionally describe Bifrost-side identity and policy context,
+not upstream ChatGPT/Codex token material. Upstream OAuth tokens stay in the
+vault layer and must never be serialized through these contracts.
+"""
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+CodexGatewayKeyStatus = Literal["active", "revoked"]
+
+
+class CodexGatewayKeyContext(BaseModel):
+    """Downstream gateway key/session context resolved by Bifrost auth."""
+
+    id: UUID
+    user_id: UUID
+    project_id: UUID | None = None
+    name: str
+    allowed_models: list[str] = Field(default_factory=list)
+    denied_models: list[str] = Field(default_factory=list)
+    daily_limit: int | None = None
+    monthly_limit: int | None = None
+    status: CodexGatewayKeyStatus = "active"
+
+
+class CodexGatewayUpstreamAccount(BaseModel):
+    """Metadata for a user's connected ChatGPT/Codex identity."""
+
+    id: UUID
+    user_id: UUID
+    upstream_subject: str
+    upstream_email: str | None = None
+    upstream_workspace_id: str | None = None
+    access_token_expires_at: datetime | None = None
+    last_refresh_at: datetime | None = None
+    last_used_at: datetime | None = None
+    revoked_at: datetime | None = None
+
+
+class CodexGatewayRequestContext(BaseModel):
+    """Metadata extracted from an OpenAI-compatible gateway request."""
+
+    request_id: str
+    endpoint: str
+    model: str
+    streaming: bool = False
+    client_type: str | None = None
+    source_ip: str | None = None
+    client_user_agent: str | None = None
+    input_token_count: int | None = None
+    output_token_count: int | None = None
+    requested_max_output_tokens: int | None = None
+    prompt_capture_enabled: bool = False
+    response_capture_enabled: bool = False
+    sensitive_input_preview: str | None = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description="Testing hook for proving prompts are not logged by default.",
+    )
+    sensitive_output_preview: str | None = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description="Testing hook for proving responses are not logged by default.",
+    )
+
+
+class OpenAICompatibleError(BaseModel):
+    """OpenAI-compatible error object returned by gateway denials."""
+
+    message: str
+    type: str = "invalid_request_error"
+    code: str
+    param: str | None = None
+
+
+class CodexGatewayPolicyDecision(BaseModel):
+    """Policy result plus metadata safe to persist in audit/request logs."""
+
+    allowed: bool
+    code: str
+    message: str
+    status_code: int
+    audit_metadata: dict[str, Any]
+    openai_error: OpenAICompatibleError

--- a/api/src/services/codex_gateway/__init__.py
+++ b/api/src/services/codex_gateway/__init__.py
@@ -1,0 +1,2 @@
+"""Bifrost Codex Gateway service primitives."""
+

--- a/api/src/services/codex_gateway/policy.py
+++ b/api/src/services/codex_gateway/policy.py
@@ -1,0 +1,218 @@
+"""
+Policy and identity resolution for the Bifrost Codex Gateway.
+
+The gateway's core invariant is same-user attribution:
+the Bifrost user represented by a downstream gateway key must be the same
+Bifrost user whose upstream ChatGPT/Codex account is selected. This module is
+pure business logic so routers and future app/admin surfaces can share it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.models.contracts.codex_gateway import (
+    CodexGatewayKeyContext,
+    CodexGatewayPolicyDecision,
+    CodexGatewayRequestContext,
+    CodexGatewayUpstreamAccount,
+    OpenAICompatibleError,
+)
+
+
+class CodexGatewayPolicyError(Exception):
+    """Structured policy failure that can be mapped to OpenAI-style errors."""
+
+    def __init__(self, code: str, message: str, *, status_code: int = 403) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+class CodexGatewayPolicyEngine:
+    """Evaluate Bifrost-native gateway policy before upstream dispatch."""
+
+    def resolve_upstream_account(
+        self,
+        key: CodexGatewayKeyContext,
+        accounts: Iterable[CodexGatewayUpstreamAccount],
+    ) -> CodexGatewayUpstreamAccount:
+        """
+        Select the active upstream account for the downstream key's user.
+
+        Cross-user fallback is deliberately absent. If the matching account is
+        missing, revoked, or ambiguous, callers must fail closed.
+        """
+        if key.status != "active":
+            raise CodexGatewayPolicyError(
+                "gateway_key_revoked",
+                "The Bifrost Codex Gateway key is not active.",
+                status_code=401,
+            )
+
+        matching = [account for account in accounts if account.user_id == key.user_id]
+        if not matching:
+            raise CodexGatewayPolicyError(
+                "upstream_identity_not_connected",
+                "No active ChatGPT/Codex account is connected for this Bifrost user.",
+            )
+
+        active = [account for account in matching if account.revoked_at is None]
+        if not active:
+            raise CodexGatewayPolicyError(
+                "upstream_identity_revoked",
+                "The connected ChatGPT/Codex account has been revoked.",
+            )
+
+        if len(active) > 1:
+            raise CodexGatewayPolicyError(
+                "upstream_identity_ambiguous",
+                "Multiple active ChatGPT/Codex accounts are connected for this Bifrost user.",
+            )
+
+        return active[0]
+
+    def evaluate(
+        self,
+        key: CodexGatewayKeyContext,
+        account: CodexGatewayUpstreamAccount,
+        request: CodexGatewayRequestContext,
+    ) -> CodexGatewayPolicyDecision:
+        """Return an allow/deny decision with metadata safe for audit logs."""
+        if account.user_id != key.user_id:
+            return self._deny(
+                key,
+                account,
+                request,
+                code="upstream_identity_mismatch",
+                message="The downstream gateway identity does not match the upstream ChatGPT/Codex identity.",
+            )
+
+        if key.status != "active":
+            return self._deny(
+                key,
+                account,
+                request,
+                code="gateway_key_revoked",
+                message="The Bifrost Codex Gateway key is not active.",
+                status_code=401,
+            )
+
+        if account.revoked_at is not None:
+            return self._deny(
+                key,
+                account,
+                request,
+                code="upstream_identity_revoked",
+                message="The connected ChatGPT/Codex account has been revoked.",
+            )
+
+        if request.model in key.denied_models:
+            return self._deny(
+                key,
+                account,
+                request,
+                code="model_denied",
+                message=f"Model '{request.model}' is denied by Bifrost Codex Gateway policy.",
+                param="model",
+            )
+
+        if key.allowed_models and request.model not in key.allowed_models:
+            return self._deny(
+                key,
+                account,
+                request,
+                code="model_not_allowed",
+                message=f"Model '{request.model}' is not allowed by Bifrost Codex Gateway policy.",
+                param="model",
+            )
+
+        return CodexGatewayPolicyDecision(
+            allowed=True,
+            code="allowed",
+            message="Request allowed by Bifrost Codex Gateway policy.",
+            status_code=200,
+            audit_metadata=self._audit_metadata(key, account, request, "allow"),
+            openai_error=OpenAICompatibleError(
+                message="",
+                code="allowed",
+            ),
+        )
+
+    def filter_visible_models(
+        self,
+        key: CodexGatewayKeyContext,
+        upstream_model_ids: Iterable[str],
+    ) -> list[str]:
+        """Apply downstream allow/deny policy to the upstream-visible model list."""
+        allowed = set(key.allowed_models)
+        denied = set(key.denied_models)
+        visible: list[str] = []
+        for model_id in upstream_model_ids:
+            if model_id in denied:
+                continue
+            if allowed and model_id not in allowed:
+                continue
+            visible.append(model_id)
+        return visible
+
+    def _deny(
+        self,
+        key: CodexGatewayKeyContext,
+        account: CodexGatewayUpstreamAccount,
+        request: CodexGatewayRequestContext,
+        *,
+        code: str,
+        message: str,
+        status_code: int = 403,
+        param: str | None = None,
+    ) -> CodexGatewayPolicyDecision:
+        return CodexGatewayPolicyDecision(
+            allowed=False,
+            code=code,
+            message=message,
+            status_code=status_code,
+            audit_metadata=self._audit_metadata(key, account, request, "deny", code),
+            openai_error=OpenAICompatibleError(
+                message=message,
+                code=code,
+                param=param,
+            ),
+        )
+
+    def _audit_metadata(
+        self,
+        key: CodexGatewayKeyContext,
+        account: CodexGatewayUpstreamAccount,
+        request: CodexGatewayRequestContext,
+        policy_decision: str,
+        denied_reason: str | None = None,
+    ) -> dict[str, object]:
+        metadata: dict[str, object] = {
+            "request_id": request.request_id,
+            "user_id": str(key.user_id),
+            "gateway_key_id": str(key.id),
+            "project_id": str(key.project_id) if key.project_id else None,
+            "oauth_account_id": str(account.id),
+            "upstream_subject": account.upstream_subject,
+            "upstream_email": account.upstream_email,
+            "upstream_workspace_id": account.upstream_workspace_id,
+            "endpoint": request.endpoint,
+            "model": request.model,
+            "streaming": request.streaming,
+            "client_type": request.client_type,
+            "source_ip": request.source_ip,
+            "client_user_agent": request.client_user_agent,
+            "input_token_count": request.input_token_count,
+            "output_token_count": request.output_token_count,
+            "policy_decision": policy_decision,
+            "denied_reason": denied_reason,
+        }
+
+        if request.prompt_capture_enabled:
+            metadata["sensitive_input_preview"] = request.sensitive_input_preview
+        if request.response_capture_enabled:
+            metadata["sensitive_output_preview"] = request.sensitive_output_preview
+
+        return metadata

--- a/api/tests/unit/services/test_codex_gateway_policy.py
+++ b/api/tests/unit/services/test_codex_gateway_policy.py
@@ -85,6 +85,26 @@ def test_revoked_upstream_account_is_not_usable():
         raise AssertionError("expected revoked upstream account to fail closed")
 
 
+def test_multiple_active_upstream_accounts_fail_closed():
+    user_id = _uuid("11111111-1111-4111-8111-111111111111")
+    key = _key_for(user_id)
+    engine = CodexGatewayPolicyEngine()
+
+    try:
+        engine.resolve_upstream_account(
+            key,
+            [
+                _account_for(user_id),
+                _account_for(user_id),
+            ],
+        )
+    except CodexGatewayPolicyError as exc:
+        assert exc.code == "upstream_identity_ambiguous"
+        assert exc.status_code == 403
+    else:
+        raise AssertionError("expected ambiguous upstream account lookup to fail closed")
+
+
 def test_model_allowlist_denial_is_structured_and_auditable():
     user_id = _uuid("11111111-1111-4111-8111-111111111111")
     key = _key_for(user_id, allowed_models=["gpt-5.1-codex"])
@@ -104,6 +124,24 @@ def test_model_allowlist_denial_is_structured_and_auditable():
     assert decision.code == "model_not_allowed"
     assert decision.audit_metadata["policy_decision"] == "deny"
     assert decision.openai_error.type == "invalid_request_error"
+
+
+def test_visible_models_are_filtered_by_allowlist_and_denylist():
+    user_id = _uuid("11111111-1111-4111-8111-111111111111")
+    key = _key_for(user_id, allowed_models=["gpt-5.1-codex", "gpt-5.1"])
+    key.denied_models = ["gpt-5.1"]
+    engine = CodexGatewayPolicyEngine()
+
+    visible = engine.filter_visible_models(
+        key,
+        [
+            "gpt-5.1-codex",
+            "gpt-5.1",
+            "gpt-4.1",
+        ],
+    )
+
+    assert visible == ["gpt-5.1-codex"]
 
 
 def test_metadata_logging_excludes_prompt_and_response_by_default():

--- a/api/tests/unit/services/test_codex_gateway_policy.py
+++ b/api/tests/unit/services/test_codex_gateway_policy.py
@@ -1,0 +1,134 @@
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from src.models.contracts.codex_gateway import (
+    CodexGatewayKeyContext,
+    CodexGatewayRequestContext,
+    CodexGatewayUpstreamAccount,
+)
+from src.services.codex_gateway.policy import (
+    CodexGatewayPolicyEngine,
+    CodexGatewayPolicyError,
+)
+
+
+def _uuid(value: str) -> UUID:
+    return UUID(value)
+
+
+def _key_for(user_id: UUID, *, allowed_models: list[str] | None = None) -> CodexGatewayKeyContext:
+    return CodexGatewayKeyContext(
+        id=uuid4(),
+        user_id=user_id,
+        project_id=uuid4(),
+        name="developer workstation",
+        allowed_models=allowed_models or ["gpt-5.1-codex"],
+        denied_models=[],
+        status="active",
+    )
+
+
+def _account_for(user_id: UUID, *, revoked: bool = False) -> CodexGatewayUpstreamAccount:
+    return CodexGatewayUpstreamAccount(
+        id=uuid4(),
+        user_id=user_id,
+        upstream_subject=f"chatgpt-user-{user_id}",
+        upstream_email=f"{user_id}@example.test",
+        upstream_workspace_id="workspace-midtown",
+        access_token_expires_at=datetime(2026, 5, 22, 20, 0, tzinfo=timezone.utc),
+        revoked_at=datetime(2026, 5, 22, 12, 0, tzinfo=timezone.utc) if revoked else None,
+    )
+
+
+def test_gateway_key_resolves_only_same_users_upstream_account():
+    user_a = _uuid("11111111-1111-4111-8111-111111111111")
+    user_b = _uuid("22222222-2222-4222-8222-222222222222")
+    key = _key_for(user_a)
+    engine = CodexGatewayPolicyEngine()
+
+    resolved = engine.resolve_upstream_account(
+        key,
+        [
+            _account_for(user_b),
+            _account_for(user_a),
+        ],
+    )
+
+    assert resolved.user_id == user_a
+
+
+def test_gateway_key_fails_closed_instead_of_using_another_users_account():
+    user_a = _uuid("11111111-1111-4111-8111-111111111111")
+    user_b = _uuid("22222222-2222-4222-8222-222222222222")
+    key = _key_for(user_a)
+    engine = CodexGatewayPolicyEngine()
+
+    try:
+        engine.resolve_upstream_account(key, [_account_for(user_b)])
+    except CodexGatewayPolicyError as exc:
+        assert exc.code == "upstream_identity_not_connected"
+        assert exc.status_code == 403
+    else:
+        raise AssertionError("expected cross-user upstream lookup to fail closed")
+
+
+def test_revoked_upstream_account_is_not_usable():
+    user_id = _uuid("11111111-1111-4111-8111-111111111111")
+    key = _key_for(user_id)
+    engine = CodexGatewayPolicyEngine()
+
+    try:
+        engine.resolve_upstream_account(key, [_account_for(user_id, revoked=True)])
+    except CodexGatewayPolicyError as exc:
+        assert exc.code == "upstream_identity_revoked"
+    else:
+        raise AssertionError("expected revoked upstream account to fail closed")
+
+
+def test_model_allowlist_denial_is_structured_and_auditable():
+    user_id = _uuid("11111111-1111-4111-8111-111111111111")
+    key = _key_for(user_id, allowed_models=["gpt-5.1-codex"])
+    account = _account_for(user_id)
+    request = CodexGatewayRequestContext(
+        request_id="req_bifrost_123",
+        endpoint="/v1/responses",
+        model="gpt-5.1",
+        streaming=False,
+        client_type="openai-compatible",
+    )
+    engine = CodexGatewayPolicyEngine()
+
+    decision = engine.evaluate(key, account, request)
+
+    assert decision.allowed is False
+    assert decision.code == "model_not_allowed"
+    assert decision.audit_metadata["policy_decision"] == "deny"
+    assert decision.openai_error.type == "invalid_request_error"
+
+
+def test_metadata_logging_excludes_prompt_and_response_by_default():
+    user_id = _uuid("11111111-1111-4111-8111-111111111111")
+    key = _key_for(user_id)
+    account = _account_for(user_id)
+    request = CodexGatewayRequestContext(
+        request_id="req_bifrost_123",
+        endpoint="/v1/responses",
+        model="gpt-5.1-codex",
+        streaming=True,
+        client_type="codex-cli",
+        source_ip="192.0.2.10",
+        client_user_agent="codex-cli/1.0",
+        sensitive_input_preview="do not log this prompt",
+        sensitive_output_preview="do not log this response",
+    )
+    engine = CodexGatewayPolicyEngine()
+
+    decision = engine.evaluate(key, account, request)
+    metadata = decision.audit_metadata
+
+    assert decision.allowed is True
+    assert metadata["request_id"] == "req_bifrost_123"
+    assert metadata["upstream_email"] == account.upstream_email
+    assert metadata["streaming"] is True
+    assert "do not log this prompt" not in str(metadata)
+    assert "do not log this response" not in str(metadata)

--- a/docs/plans/2026-05-22-bifrost-codex-gateway.md
+++ b/docs/plans/2026-05-22-bifrost-codex-gateway.md
@@ -1,0 +1,66 @@
+# Bifrost Codex Gateway
+
+## Decision
+
+Build the Codex Gateway as a Bifrost-native application backed by platform API
+primitives in this AGPL repo. The first implementation path is not a standalone
+LLM gateway and not a shared ChatGPT account proxy. It is a governance surface
+for Bifrost users who connect their own ChatGPT/Codex identity.
+
+The core attribution rule is:
+
+```text
+Bifrost user -> Bifrost gateway key/session -> same user's ChatGPT/Codex identity
+```
+
+If the same-user upstream identity cannot be resolved unambiguously, the gateway
+fails closed. Service accounts are allowed only as an explicit, labeled policy
+class with separate audit treatment.
+
+## Official OpenAI/Codex Grounding
+
+OpenAI's Codex documentation currently describes ChatGPT sign-in as a supported
+Codex authentication path for subscription access, while API key sign-in remains
+the usage-based path. It also states that the Codex CLI and IDE extension can use
+ChatGPT sign-in, browser login, beta device-code login for headless cases, and
+local cached credentials that must be treated like password-equivalent secret
+material.
+
+The Bifrost implementation should therefore avoid undocumented token exposure,
+avoid logging upstream credentials, and prefer an onboarding path that either
+delegates to official Codex login behavior or stores equivalent token material in
+Bifrost's encrypted vault with tighter controls than local plaintext files.
+
+## Prior Art Boundaries
+
+The prior-art projects are useful references for compatibility behavior, but
+should not be copied into Bifrost:
+
+- LiteLLM's ChatGPT provider shows the practical shape of subscription-backed
+  Codex requests, token refresh, `store=false`, streaming, and model filtering.
+- CLIProxyAPI shows gateway operations, management APIs, request logs, and model
+  compatibility breadth.
+- ChatMock and Codex-Wrapper show small OpenAI-compatible facades and Codex CLI
+  credential delegation.
+- Several projects use multi-account pooling, direct private ChatGPT backend
+  calls, local token files, or unclear licenses. Those are not appropriate for
+  this Bifrost-native path.
+
+Implementation borrowing must be limited to independently reimplemented behavior
+and documented compatibility observations. No GPL or unclear-license code should
+be copied.
+
+## First Slice
+
+The initial platform slice establishes reusable backend primitives:
+
+- downstream gateway key/session context
+- connected upstream ChatGPT/Codex identity metadata
+- same-user upstream account resolution
+- model allow/deny policy evaluation
+- OpenAI-compatible structured denial shape
+- audit metadata that excludes prompts and responses by default
+
+This is intentionally below the router/UI layer. Routers, app-admin views,
+token-vault persistence, `/v1/responses`, and streaming can build on this
+without weakening the per-user attribution invariant.


### PR DESCRIPTION
## Summary
- add Bifrost Codex Gateway contracts for downstream key context, upstream ChatGPT/Codex identity metadata, request context, policy decisions, and OpenAI-compatible errors
- add a pure policy engine that enforces same-user upstream identity resolution, model allow/deny decisions, and metadata-only audit payloads by default
- document the Bifrost-native route, official Codex auth grounding, and prior-art boundaries

## Verification
- `git diff --check`
- on `codex-vm-netbird` / `codex-dev-01`: `./test.sh tests/unit/services/test_codex_gateway_policy.py -q` -> `5 passed in 0.26s`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Codex Gateway governance layer for access control and policy decisions
  * Added upstream identity resolution with same-user attribution validation (fail-closed)
  * Added model filtering based on policy allow/deny lists
  * Returns structured denial responses including OpenAI-compatible error payloads and audit metadata (sensitive I/O excluded by default)

* **Tests**
  * Added unit tests covering policy engine, identity resolution, model filtering, and audit behavior

* **Documentation**
  * Added implementation plan for the Codex Gateway governance design

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->