### PR TITLE
Load live infrastructure status data

### DIFF
--- a/client/src/pages/InfrastructureStatus.test.tsx
+++ b/client/src/pages/InfrastructureStatus.test.tsx
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, within } from "@/test-utils";
 import { InfrastructureStatus } from "./InfrastructureStatus";
 
 describe("InfrastructureStatus", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("renders instance health, evidence, and novice explainers from the fixture", () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
 		renderWithProviders(<InfrastructureStatus />);
 
 		expect(
@@ -12,6 +18,7 @@ describe("InfrastructureStatus", () => {
 		expect(screen.getByText("dev.bifrost.midtowntg.com")).toBeInTheDocument();
 		expect(screen.getAllByText("Degraded")).toHaveLength(5);
 		expect(screen.getAllByText("Limited impact")).toHaveLength(3);
+		expect(screen.getByText("Fallback snapshot")).toBeInTheDocument();
 
 		const apiNode = screen.getByRole("article", {
 			name: /API readiness Healthy/i,
@@ -34,6 +41,8 @@ describe("InfrastructureStatus", () => {
 	});
 
 	it("keeps external integrations advisory in the instance rollup", () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
 		renderWithProviders(<InfrastructureStatus />);
 
 		const externalNode = screen.getByRole("article", {
@@ -44,6 +53,66 @@ describe("InfrastructureStatus", () => {
 		expect(within(externalNode).getByText("None impact")).toBeInTheDocument();
 		expect(
 			screen.getByText(/advisory unless tied to active work/i),
+		).toBeInTheDocument();
+	});
+
+	it("renders live infrastructure status when the endpoint responds", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					environment: "poc",
+					instance: "dev.bifrost.midtowntg.com",
+					generated_at: "2026-05-22T15:25:44.479073Z",
+					status: "Healthy",
+					impact: "None",
+					nodes: [
+						{
+							id: "api-readiness",
+							label: "API readiness",
+							domain: "API Readiness",
+							status: "Healthy",
+							impact: "None",
+							summary: "Live API status loaded.",
+							explainer: "Live endpoint data replaced the baked fallback.",
+							evidence: {
+								source: "/health/ready",
+								sampled_at: "2026-05-22T15:25:44.479073Z",
+								freshness: "fresh",
+							},
+							links: [],
+						},
+					],
+					edges: [],
+				}),
+				{ headers: { "Content-Type": "application/json" }, status: 200 },
+			),
+		);
+
+		renderWithProviders(<InfrastructureStatus />);
+
+		expect(await screen.findByText("Live feed")).toBeInTheDocument();
+		expect(screen.getByText("Live API status loaded.")).toBeInTheDocument();
+		expect(screen.queryByText("Fallback snapshot")).not.toBeInTheDocument();
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"/infrastructure/status.json",
+			{
+				cache: "no-store",
+				headers: { Accept: "application/json" },
+			},
+		);
+	});
+
+	it("keeps the fallback visible when the endpoint is unavailable", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("not found", { status: 404 }),
+		);
+
+		renderWithProviders(<InfrastructureStatus />);
+
+		expect(await screen.findByText("Fallback snapshot")).toBeInTheDocument();
+		expect(screen.getByText("Using fallback snapshot")).toBeInTheDocument();
+		expect(
+			screen.getByText(/status endpoint returned 404/i),
 		).toBeInTheDocument();
 	});
 });

--- a/client/src/pages/InfrastructureStatus.tsx
+++ b/client/src/pages/InfrastructureStatus.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
 	Activity,
@@ -229,6 +230,77 @@ const graphStatus: GraphStatusFixture = {
 	],
 };
 
+const INFRASTRUCTURE_STATUS_URL = "/infrastructure/status.json";
+
+function isGraphStatusFixture(value: unknown): value is GraphStatusFixture {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+
+	const candidate = value as Partial<GraphStatusFixture>;
+	return (
+		typeof candidate.environment === "string" &&
+		typeof candidate.instance === "string" &&
+		typeof candidate.generated_at === "string" &&
+		typeof candidate.status === "string" &&
+		typeof candidate.impact === "string" &&
+		Array.isArray(candidate.nodes) &&
+		Array.isArray(candidate.edges)
+	);
+}
+
+function useInfrastructureStatus() {
+	const [status, setStatus] = useState(graphStatus);
+	const [source, setSource] = useState<"live" | "fallback">("fallback");
+	const [loadError, setLoadError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		async function loadStatus() {
+			try {
+				const response = await fetch(INFRASTRUCTURE_STATUS_URL, {
+					cache: "no-store",
+					headers: { Accept: "application/json" },
+				});
+
+				if (!response.ok) {
+					throw new Error(`status endpoint returned ${response.status}`);
+				}
+
+				const payload: unknown = await response.json();
+				if (!isGraphStatusFixture(payload)) {
+					throw new Error("status endpoint returned an unexpected payload");
+				}
+
+				if (!cancelled) {
+					setStatus(payload);
+					setSource("live");
+					setLoadError(null);
+				}
+			} catch (error) {
+				if (!cancelled) {
+					setStatus(graphStatus);
+					setSource("fallback");
+					setLoadError(
+						error instanceof Error
+							? error.message
+							: "status endpoint could not be loaded",
+					);
+				}
+			}
+		}
+
+		void loadStatus();
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return { status, source, loadError };
+}
+
 const statusStyles: Record<GraphStatus, string> = {
 	Healthy: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
 	Advisory: "border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
@@ -338,7 +410,9 @@ function EdgeList({ edges }: Readonly<{ edges: GraphEdge[] }>) {
 }
 
 export function InfrastructureStatus() {
-	const degradedNodes = graphStatus.nodes.filter(
+	const { status: infrastructureStatus, source, loadError } =
+		useInfrastructureStatus();
+	const degradedNodes = infrastructureStatus.nodes.filter(
 		(node) => node.status === "Degraded" || node.status === "Blocked",
 	);
 	const blockedCount = degradedNodes.filter(
@@ -366,7 +440,7 @@ export function InfrastructureStatus() {
 						<h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
 							Infrastructure Status
 						</h1>
-						<StatusBadge status={graphStatus.status} />
+						<StatusBadge status={infrastructureStatus.status} />
 					</div>
 					<p className="max-w-3xl leading-7 text-muted-foreground">
 						Read-only instance map for runtime health, pressure,
@@ -374,18 +448,37 @@ export function InfrastructureStatus() {
 					</p>
 				</div>
 				<div className="rounded-lg border bg-muted/30 p-4 text-sm">
-					<div className="font-medium">{graphStatus.instance}</div>
+					<div className="font-medium">{infrastructureStatus.instance}</div>
 					<div className="mt-1 text-muted-foreground">
-						{graphStatus.environment} environment
+						{infrastructureStatus.environment} environment
 					</div>
 					<div className="mt-3 flex flex-wrap gap-2">
-						<Badge variant="outline">{graphStatus.impact} impact</Badge>
 						<Badge variant="outline">
-							Sampled {formatTimestamp(graphStatus.generated_at)}
+							{infrastructureStatus.impact} impact
+						</Badge>
+						<Badge variant="outline">
+							Sampled {formatTimestamp(infrastructureStatus.generated_at)}
+						</Badge>
+						<Badge variant={source === "live" ? "secondary" : "outline"}>
+							{source === "live" ? "Live feed" : "Fallback snapshot"}
 						</Badge>
 					</div>
 				</div>
 			</div>
+
+			{loadError ? (
+				<Card className="border-sky-500/40 bg-sky-500/5">
+					<CardHeader className="pb-3">
+						<CardTitle className="flex items-center gap-2 text-base">
+							<Info className="h-4 w-4 text-sky-600" />
+							Using fallback snapshot
+						</CardTitle>
+						<CardDescription>
+							Live infrastructure status could not be loaded: {loadError}.
+						</CardDescription>
+					</CardHeader>
+				</Card>
+			) : null}
 
 			{degradedNodes.length > 0 ? (
 				<Card className="border-amber-500/40 bg-amber-500/5">
@@ -415,7 +508,7 @@ export function InfrastructureStatus() {
 					<Badge variant="secondary">Read-only</Badge>
 				</div>
 				<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-					{graphStatus.nodes.map((node) => (
+					{infrastructureStatus.nodes.map((node) => (
 						<InfrastructureNode key={node.id} node={node} />
 					))}
 				</div>
@@ -423,13 +516,13 @@ export function InfrastructureStatus() {
 
 			<section className="space-y-3" aria-label="Causal dependencies">
 				<h2 className="text-xl font-semibold">Causal Edges</h2>
-				<EdgeList edges={graphStatus.edges} />
+				<EdgeList edges={infrastructureStatus.edges} />
 			</section>
 
 			<section className="space-y-3" aria-label="Operator notes">
 				<h2 className="text-xl font-semibold">What Each Layer Proves</h2>
 				<div className="grid gap-4 lg:grid-cols-2">
-					{graphStatus.nodes.map((node) => (
+					{infrastructureStatus.nodes.map((node) => (
 						<Card key={`${node.id}-details`}>
 							<CardHeader className="pb-3">
 								<CardTitle className="flex items-center justify-between gap-3 text-base">


### PR DESCRIPTION
## Summary
- Fetch /infrastructure/status.json on the Infrastructure page
- Keep the baked graph snapshot as a fallback when the live feed is unavailable
- Cover live-feed and fallback behavior in page tests

## Verification
- npm audit
- npm test -- InfrastructureStatus.test.tsx
- npm run tsc
- npm run build