### PR TITLE
Add orchestrator detail to infrastructure diagnostics

### DIFF
--- a/client/src/pages/InfrastructureStatus.test.tsx
+++ b/client/src/pages/InfrastructureStatus.test.tsx
@@ -38,6 +38,9 @@ describe("InfrastructureStatus", () => {
 		expect(
 			screen.getByText(/External integrations are third-party systems/i),
 		).toBeInTheDocument();
+		expect(screen.getByText("Orchestrator Detail")).toBeInTheDocument();
+		expect(screen.getByText("AKS worker lane")).toBeInTheDocument();
+		expect(screen.getByText("ACA worker lane")).toBeInTheDocument();
 	});
 
 	it("keeps external integrations advisory in the instance rollup", () => {
@@ -83,6 +86,20 @@ describe("InfrastructureStatus", () => {
 						},
 					],
 					edges: [],
+					orchestrators: [
+						{
+							id: "aks-worker-lane",
+							label: "AKS worker lane",
+							runtime: "AKS",
+							status: "Healthy",
+							summary: "3 pods running with KEDA max 6.",
+							details: [
+								{ label: "Pods", value: "3 / 6" },
+								{ label: "Nodepool", value: "1 / 3 nodes" },
+							],
+							links: [{ label: "Open Diagnostics", target: "/diagnostics" }],
+						},
+					],
 				}),
 				{ headers: { "Content-Type": "application/json" }, status: 200 },
 			),
@@ -92,6 +109,8 @@ describe("InfrastructureStatus", () => {
 
 		expect(await screen.findByText("Live feed")).toBeInTheDocument();
 		expect(screen.getByText("Live API status loaded.")).toBeInTheDocument();
+		expect(screen.getByText("3 pods running with KEDA max 6.")).toBeInTheDocument();
+		expect(screen.getByText("1 / 3 nodes")).toBeInTheDocument();
 		expect(screen.queryByText("Fallback snapshot")).not.toBeInTheDocument();
 		expect(globalThis.fetch).toHaveBeenCalledWith(
 			"/infrastructure/status.json",

--- a/client/src/pages/InfrastructureStatus.tsx
+++ b/client/src/pages/InfrastructureStatus.tsx
@@ -8,6 +8,7 @@ import {
 	ExternalLink,
 	GitBranch,
 	Info,
+	Boxes,
 	Network,
 	ServerCog,
 	ShieldAlert,
@@ -60,6 +61,22 @@ interface GraphEdge {
 	summary: string;
 }
 
+interface OrchestratorTarget {
+	id: string;
+	label: string;
+	runtime: "VM" | "AKS" | "ACA" | "Other";
+	status: GraphStatus;
+	summary: string;
+	details: Array<{
+		label: string;
+		value: string;
+	}>;
+	links: Array<{
+		label: string;
+		target: string;
+	}>;
+}
+
 interface GraphStatusFixture {
 	environment: string;
 	instance: string;
@@ -68,6 +85,7 @@ interface GraphStatusFixture {
 	impact: GraphImpact;
 	nodes: GraphNode[];
 	edges: GraphEdge[];
+	orchestrators?: OrchestratorTarget[];
 }
 
 const generatedAt = "2026-05-14T00:00:00Z";
@@ -108,6 +126,24 @@ const causalEdge = (
 	kind: "causal",
 	status,
 	summary,
+});
+
+const orchestratorTarget = (
+	id: string,
+	label: string,
+	runtime: OrchestratorTarget["runtime"],
+	status: GraphStatus,
+	summary: string,
+	details: OrchestratorTarget["details"],
+	links: OrchestratorTarget["links"] = [],
+): OrchestratorTarget => ({
+	id,
+	label,
+	runtime,
+	status,
+	summary,
+	details,
+	links,
 });
 
 const graphStatus: GraphStatusFixture = {
@@ -228,6 +264,45 @@ const graphStatus: GraphStatusFixture = {
 			"External integrations are advisory until tied to active workflow impact.",
 		),
 	],
+	orchestrators: [
+		orchestratorTarget(
+			"vm-compose-workers",
+			"VM Compose workers",
+			"VM",
+			"Healthy",
+			"Steady worker fallback remains on the Azure VM.",
+			[
+				{ label: "Runtime", value: "Docker Compose" },
+				{ label: "Placement", value: "Azure VM" },
+				{ label: "Role", value: "Fallback execution capacity" },
+			],
+			[{ label: "Open Diagnostics", target: "/diagnostics" }],
+		),
+		orchestratorTarget(
+			"aks-worker-lane",
+			"AKS worker lane",
+			"AKS",
+			"Unknown",
+			"AKS scaling facts are reported when the live infrastructure feed includes them.",
+			[
+				{ label: "Worker pods", value: "reported by live feed" },
+				{ label: "KEDA", value: "reported by live feed" },
+				{ label: "Nodepool", value: "reported by live feed" },
+			],
+			[{ label: "Open Diagnostics", target: "/diagnostics" }],
+		),
+		orchestratorTarget(
+			"aca-worker-lane",
+			"ACA worker lane",
+			"ACA",
+			"Disabled",
+			"ACA worker apps are expected to stay drained during the AKS transition.",
+			[
+				{ label: "Desired state", value: "0 active worker revisions" },
+				{ label: "Rollback", value: "container app definitions retained" },
+			],
+		),
+	],
 };
 
 const INFRASTRUCTURE_STATUS_URL = "/infrastructure/status.json";
@@ -245,7 +320,9 @@ function isGraphStatusFixture(value: unknown): value is GraphStatusFixture {
 		typeof candidate.status === "string" &&
 		typeof candidate.impact === "string" &&
 		Array.isArray(candidate.nodes) &&
-		Array.isArray(candidate.edges)
+		Array.isArray(candidate.edges) &&
+		(candidate.orchestrators === undefined ||
+			Array.isArray(candidate.orchestrators))
 	);
 }
 
@@ -409,6 +486,70 @@ function EdgeList({ edges }: Readonly<{ edges: GraphEdge[] }>) {
 	);
 }
 
+const runtimeIcons: Record<OrchestratorTarget["runtime"], React.ElementType> = {
+	VM: ServerCog,
+	AKS: Boxes,
+	ACA: Network,
+	Other: Info,
+};
+
+function OrchestratorList({
+	orchestrators,
+}: Readonly<{ orchestrators: OrchestratorTarget[] }>) {
+	return (
+		<div className="grid gap-4 lg:grid-cols-3">
+			{orchestrators.map((target) => {
+				const Icon = runtimeIcons[target.runtime] ?? Info;
+				return (
+					<Card key={target.id}>
+						<CardHeader className="pb-3">
+							<CardTitle className="flex items-start justify-between gap-3 text-base">
+								<span className="flex min-w-0 items-center gap-2">
+									<Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+									<span>{target.label}</span>
+								</span>
+								<StatusBadge status={target.status} />
+							</CardTitle>
+							<CardDescription>{target.summary}</CardDescription>
+						</CardHeader>
+						<CardContent className="space-y-3">
+							<div className="grid gap-2 text-sm">
+								{target.details.map((detail) => (
+									<div
+										key={`${target.id}-${detail.label}`}
+										className="flex items-start justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2"
+									>
+										<span className="text-muted-foreground">
+											{detail.label}
+										</span>
+										<span className="text-right font-medium">
+											{detail.value}
+										</span>
+									</div>
+								))}
+							</div>
+							{target.links.length > 0 ? (
+								<div className="flex flex-wrap gap-2">
+									{target.links.map((link) => (
+										<Button
+											key={`${target.id}-${link.label}`}
+											asChild
+											size="sm"
+											variant="outline"
+										>
+											<Link to={link.target}>{link.label}</Link>
+										</Button>
+									))}
+								</div>
+							) : null}
+						</CardContent>
+					</Card>
+				);
+			})}
+		</div>
+	);
+}
+
 export function InfrastructureStatus() {
 	const { status: infrastructureStatus, source, loadError } =
 		useInfrastructureStatus();
@@ -427,6 +568,8 @@ export function InfrastructureStatus() {
 	const degradedSummary = `${degradedCount} ${
 		degradedCount === 1 ? "domain is" : "domains are"
 	} degraded`;
+	const orchestrators =
+		infrastructureStatus.orchestrators ?? graphStatus.orchestrators ?? [];
 	const attentionDescription =
 		blockedCount > 0
 			? `${blockedSummary} and ${degradedSummary}.`
@@ -517,6 +660,16 @@ export function InfrastructureStatus() {
 			<section className="space-y-3" aria-label="Causal dependencies">
 				<h2 className="text-xl font-semibold">Causal Edges</h2>
 				<EdgeList edges={infrastructureStatus.edges} />
+			</section>
+
+			<section className="space-y-3" aria-label="Orchestrator details">
+				<div className="flex items-center justify-between">
+					<h2 className="text-xl font-semibold">Orchestrator Detail</h2>
+					<Badge variant="secondary">Operator view</Badge>
+				</div>
+				<OrchestratorList
+					orchestrators={orchestrators}
+				/>
 			</section>
 
 			<section className="space-y-3" aria-label="Operator notes">

--- a/client/src/pages/diagnostics/components/ContainerTable.test.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+import { ContainerTable } from "./ContainerTable";
+import type { PoolSummary } from "@/services/workers";
+
+function pool(worker_id: string, hostname?: string): PoolSummary {
+	return {
+		worker_id,
+		hostname: hostname ?? worker_id,
+		status: "online",
+		started_at: new Date(Date.now() - 60_000).toISOString(),
+		pool_size: 2,
+		idle_count: 2,
+		busy_count: 0,
+		last_heartbeat: new Date().toISOString(),
+		requirements_installed: null,
+		requirements_total: null,
+		memory_current_bytes: 512 * 1024 * 1024,
+		memory_max_bytes: 2 * 1024 * 1024 * 1024,
+	};
+}
+
+describe("ContainerTable", () => {
+	it("labels worker runtime origin from worker identifiers", () => {
+		const pools = [
+			pool("28f617b0f52a"),
+			pool("bifrost-worker-aks-next-5b977ccc5b-l4jpz"),
+			pool("bifrost-worker-aca-next--0000003"),
+		];
+
+		renderWithProviders(
+			<ContainerTable
+				pools={pools}
+				workerIds={pools.map((item) => item.worker_id)}
+			/>,
+		);
+
+		expect(screen.getByText("VM")).toBeInTheDocument();
+		expect(screen.getByText("AKS pod")).toBeInTheDocument();
+		expect(screen.getByText("ACA app")).toBeInTheDocument();
+	});
+});

--- a/client/src/pages/diagnostics/components/ContainerTable.test.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.test.tsx
@@ -15,8 +15,6 @@ function pool(worker_id: string, hostname?: string): PoolSummary {
 		last_heartbeat: new Date().toISOString(),
 		requirements_installed: null,
 		requirements_total: null,
-		memory_current_bytes: 512 * 1024 * 1024,
-		memory_max_bytes: 2 * 1024 * 1024 * 1024,
 	};
 }
 

--- a/client/src/pages/diagnostics/components/ContainerTable.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.tsx
@@ -1,6 +1,6 @@
 // client/src/pages/diagnostics/components/ContainerTable.tsx
 import { Fragment, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Cloud, Server, Boxes } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/tooltip";
 
 type PoolData = PoolSummary | PoolDetail;
+type RuntimeKind = "AKS" | "VM" | "ACA" | "Unknown";
 
 function formatUptime(seconds: number): string {
     if (seconds < 60) return `${Math.floor(seconds)}s`;
@@ -71,6 +72,43 @@ function getUptimeSeconds(pool: PoolData): number {
     return (Date.now() - new Date(startedAt).getTime()) / 1000;
 }
 
+function getRuntimeKind(pool: PoolData): RuntimeKind {
+    const workerId = pool.worker_id.toLowerCase();
+    const hostname = (pool.hostname ?? "").toLowerCase();
+    const source = `${workerId} ${hostname}`;
+
+    if (source.includes("aks") || source.includes("k8s")) {
+        return "AKS";
+    }
+    if (source.includes("aca") || source.includes("containerapp")) {
+        return "ACA";
+    }
+    if (/^[a-f0-9]{12}$/.test(workerId) || source.includes("compose") || source.includes("docker")) {
+        return "VM";
+    }
+    return "Unknown";
+}
+
+function RuntimeBadge({ pool }: Readonly<{ pool: PoolData }>) {
+    const runtime = getRuntimeKind(pool);
+    const Icon = runtime === "AKS" ? Boxes : runtime === "ACA" ? Cloud : Server;
+    const label =
+        runtime === "AKS"
+            ? "AKS pod"
+            : runtime === "ACA"
+                ? "ACA app"
+                : runtime === "VM"
+                    ? "VM"
+                    : "Unknown";
+
+    return (
+        <Badge variant="outline" className="gap-1 text-[10px]">
+            <Icon className="h-3 w-3" />
+            {label}
+        </Badge>
+    );
+}
+
 interface ContainerTableProps {
     pools: PoolData[];
     /** Sorted worker IDs for consistent color assignment (same as chart) */
@@ -104,6 +142,7 @@ export function ContainerTable({ pools, workerIds }: ContainerTableProps) {
                     <TableRow className="text-xs">
                         <TableHead className="w-8" />
                         <TableHead>Container</TableHead>
+                        <TableHead className="w-[100px]">Runtime</TableHead>
                         <TableHead className="w-[80px]">Status</TableHead>
                         <TableHead className="w-[100px]">Forks</TableHead>
                         <TableHead className="w-[200px]">Memory</TableHead>
@@ -179,6 +218,9 @@ export function ContainerTable({ pools, workerIds }: ContainerTableProps) {
                                         </div>
                                     </TableCell>
                                     <TableCell>
+                                        <RuntimeBadge pool={pool} />
+                                    </TableCell>
+                                    <TableCell>
                                         <Badge
                                             variant={
                                                 pool.status === "online"
@@ -234,7 +276,7 @@ export function ContainerTable({ pools, workerIds }: ContainerTableProps) {
                                         counts.processes.length > 0 && (
                                             <TableRow>
                                                 <TableCell
-                                                    colSpan={6}
+                                                    colSpan={7}
                                                     className="p-0 bg-muted/30"
                                                 >
                                                     <motion.div


### PR DESCRIPTION
## Summary
- add Infrastructure page orchestrator detail for VM Compose, AKS, and ACA worker lanes
- label Diagnostics process-pool rows by inferred runtime origin
- cover fallback and live-feed orchestrator rendering plus runtime labels

## Verification
- VM 101 (`bifrost-e2e-debian13-01` on `pve-t340`): `cd /tmp/codex-vm-tests/bifrost-full/client && npm test -- --run src/pages/InfrastructureStatus.test.tsx src/pages/diagnostics/components/ContainerTable.test.tsx`
- Result: 2 test files passed, 5 tests passed
- Local: `git diff --check`