### PR TITLE
Fix platform admin org fallback in user dialogs

### DIFF
--- a/client/src/components/users/CreateUserDialog.test.tsx
+++ b/client/src/components/users/CreateUserDialog.test.tsx
@@ -21,6 +21,7 @@ const mockCreateMutate = vi.fn();
 const mockAssignMutate = vi.fn();
 const mockOrganizations = vi.fn();
 const mockRoles = vi.fn();
+const mockAuth = vi.fn();
 
 vi.mock("@/hooks/useUsers", () => ({
 	useCreateUser: () => ({
@@ -39,6 +40,10 @@ vi.mock("@/hooks/useRoles", () => ({
 
 vi.mock("@/hooks/useOrganizations", () => ({
 	useOrganizations: () => mockOrganizations(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => mockAuth(),
 }));
 
 // Stub the Combobox to a native select so userEvent can drive it.
@@ -95,6 +100,14 @@ beforeEach(() => {
 		isLoading: false,
 	});
 	mockRoles.mockReturnValue({ data: [] });
+	mockAuth.mockReturnValue({
+		user: {
+			id: "admin-user",
+			email: "admin@example.com",
+			isSuperuser: true,
+			organizationId: "org-provider",
+		},
+	});
 });
 
 describe("CreateUserDialog — validation", () => {
@@ -205,6 +218,48 @@ describe("CreateUserDialog — happy path", () => {
 				is_superuser: true,
 				organization_id: "org-provider",
 			},
+		});
+		expect(screen.queryByText(/select an organization/i)).not.toBeInTheDocument();
+	});
+
+	it("falls back to the current platform admin organization when provider org is absent from the list", async () => {
+		const onOpenChange = vi.fn();
+		mockOrganizations.mockReturnValue({
+			data: [
+				{
+					id: "org-1",
+					name: "Acme",
+					domain: "acme.com",
+					is_provider: false,
+				},
+			],
+			isLoading: false,
+		});
+		mockAuth.mockReturnValue({
+			user: {
+				id: "admin-user",
+				email: "admin@example.com",
+				isSuperuser: true,
+				organizationId: "provider-from-auth",
+			},
+		});
+
+		const { user } = renderWithProviders(
+			<CreateUserDialog open={true} onOpenChange={onOpenChange} />,
+		);
+
+		await user.type(
+			screen.getByLabelText(/email address/i),
+			"admin@example.com",
+		);
+		await user.type(screen.getByLabelText(/display name/i), "Admin User");
+		await user.selectOptions(screen.getByLabelText(/userType/i), "platform");
+		await user.click(screen.getByRole("button", { name: /create user/i }));
+
+		await waitFor(() => expect(mockCreateMutate).toHaveBeenCalled());
+		expect(mockCreateMutate.mock.calls[0]![0].body).toMatchObject({
+			is_superuser: true,
+			organization_id: "provider-from-auth",
 		});
 		expect(screen.queryByText(/select an organization/i)).not.toBeInTheDocument();
 	});

--- a/client/src/components/users/CreateUserDialog.tsx
+++ b/client/src/components/users/CreateUserDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -33,6 +33,7 @@ import { useCreateUser } from "@/hooks/useUsers";
 import { useRoles, useAssignUsersToRole } from "@/hooks/useRoles";
 import { useOrganizations } from "@/hooks/useOrganizations";
 import { useAuth } from "@/contexts/AuthContext";
+import { usePlatformAdminOrgSelection } from "./platformAdminOrg";
 import { toast } from "sonner";
 import type { components } from "@/lib/v1";
 
@@ -67,29 +68,15 @@ function CreateUserDialogContent({
 
 	const roles = useMemo(() => (allRoles ?? []) as Role[], [allRoles]);
 
-	// Find the provider org (for auto-selecting when platform admin is chosen)
-	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
-	const providerOrgId =
-		providerOrg?.id ??
-		(currentUser?.isSuperuser ? currentUser.organizationId : null);
-
-	useEffect(() => {
-		if (isPlatformAdmin && providerOrgId && orgId !== providerOrgId) {
-			setOrgId(providerOrgId);
-		}
-	}, [isPlatformAdmin, orgId, providerOrgId]);
-
-	// Auto-select provider org when switching to platform admin
-	const handleUserTypeChange = (value: string) => {
-		const isAdmin = value === "platform";
-		setIsPlatformAdmin(isAdmin);
-		if (isAdmin && providerOrgId) {
-			setOrgId(providerOrgId);
-		} else if (!isAdmin && orgId === providerOrgId) {
-			// Clear provider org if switching to org user
-			setOrgId("");
-		}
-	};
+	const { effectiveOrgId, handleUserTypeChange } =
+		usePlatformAdminOrgSelection({
+			organizations,
+			currentUser,
+			isPlatformAdmin,
+			setIsPlatformAdmin,
+			orgId,
+			setOrgId,
+		});
 
 	const toggleRole = (roleId: string) => {
 		setSelectedRoleIds((prev) => {
@@ -126,7 +113,7 @@ function CreateUserDialogContent({
 			setValidationError("Please enter a display name");
 			return false;
 		}
-		if (!(isPlatformAdmin ? providerOrgId || orgId : orgId)) {
+		if (!effectiveOrgId) {
 			setValidationError("Please select an organization");
 			return false;
 		}
@@ -140,8 +127,6 @@ function CreateUserDialogContent({
 		if (!validateForm()) {
 			return;
 		}
-
-		const effectiveOrgId = isPlatformAdmin ? providerOrgId || orgId : orgId;
 
 		try {
 			const result = await createMutation.mutateAsync({

--- a/client/src/components/users/CreateUserDialog.tsx
+++ b/client/src/components/users/CreateUserDialog.tsx
@@ -32,6 +32,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCreateUser } from "@/hooks/useUsers";
 import { useRoles, useAssignUsersToRole } from "@/hooks/useRoles";
 import { useOrganizations } from "@/hooks/useOrganizations";
+import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "sonner";
 import type { components } from "@/lib/v1";
 
@@ -62,25 +63,29 @@ function CreateUserDialogContent({
 	const assignUsersToRole = useAssignUsersToRole();
 	const { data: organizations, isLoading: orgsLoading } = useOrganizations();
 	const { data: allRoles } = useRoles();
+	const { user: currentUser } = useAuth();
 
 	const roles = useMemo(() => (allRoles ?? []) as Role[], [allRoles]);
 
 	// Find the provider org (for auto-selecting when platform admin is chosen)
 	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
+	const providerOrgId =
+		providerOrg?.id ??
+		(currentUser?.isSuperuser ? currentUser.organizationId : null);
 
 	useEffect(() => {
-		if (isPlatformAdmin && providerOrg && orgId !== providerOrg.id) {
-			setOrgId(providerOrg.id);
+		if (isPlatformAdmin && providerOrgId && orgId !== providerOrgId) {
+			setOrgId(providerOrgId);
 		}
-	}, [isPlatformAdmin, orgId, providerOrg]);
+	}, [isPlatformAdmin, orgId, providerOrgId]);
 
 	// Auto-select provider org when switching to platform admin
 	const handleUserTypeChange = (value: string) => {
 		const isAdmin = value === "platform";
 		setIsPlatformAdmin(isAdmin);
-		if (isAdmin && providerOrg) {
-			setOrgId(providerOrg.id);
-		} else if (!isAdmin && orgId === providerOrg?.id) {
+		if (isAdmin && providerOrgId) {
+			setOrgId(providerOrgId);
+		} else if (!isAdmin && orgId === providerOrgId) {
 			// Clear provider org if switching to org user
 			setOrgId("");
 		}
@@ -121,7 +126,7 @@ function CreateUserDialogContent({
 			setValidationError("Please enter a display name");
 			return false;
 		}
-		if (!orgId) {
+		if (!(isPlatformAdmin ? providerOrgId || orgId : orgId)) {
 			setValidationError("Please select an organization");
 			return false;
 		}
@@ -136,6 +141,8 @@ function CreateUserDialogContent({
 			return;
 		}
 
+		const effectiveOrgId = isPlatformAdmin ? providerOrgId || orgId : orgId;
+
 		try {
 			const result = await createMutation.mutateAsync({
 				body: {
@@ -143,7 +150,7 @@ function CreateUserDialogContent({
 					name: displayName.trim(),
 					is_active: true,
 					is_superuser: isPlatformAdmin,
-					organization_id: orgId || null,
+					organization_id: effectiveOrgId || null,
 				},
 			});
 

--- a/client/src/components/users/EditUserDialog.tsx
+++ b/client/src/components/users/EditUserDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -34,6 +34,7 @@ import { useUpdateUser, useUserRoles } from "@/hooks/useUsers";
 import { useRoles, useAssignUsersToRole, useRemoveUserFromRole } from "@/hooks/useRoles";
 import { useOrganizations } from "@/hooks/useOrganizations";
 import { useAuth } from "@/contexts/AuthContext";
+import { usePlatformAdminOrgSelection } from "./platformAdminOrg";
 import { toast } from "sonner";
 import type { components } from "@/lib/v1";
 
@@ -91,17 +92,15 @@ function EditUserDialogContent({
 
 	const roles = useMemo(() => (allRoles ?? []) as Role[], [allRoles]);
 
-	// Find the provider org (for auto-selecting when promoting to platform admin)
-	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
-	const providerOrgId =
-		providerOrg?.id ??
-		(currentUser?.isSuperuser ? currentUser.organizationId : null);
-
-	useEffect(() => {
-		if (isPlatformAdmin && providerOrgId && orgId !== providerOrgId) {
-			setOrgId(providerOrgId);
-		}
-	}, [isPlatformAdmin, orgId, providerOrgId]);
+	const { effectiveOrgId, handleUserTypeChange } =
+		usePlatformAdminOrgSelection({
+			organizations,
+			currentUser,
+			isPlatformAdmin,
+			setIsPlatformAdmin,
+			orgId,
+			setOrgId,
+		});
 
 	// Check if editing own account
 	const isEditingSelf = !!(currentUser && user.id === currentUser.id);
@@ -109,18 +108,6 @@ function EditUserDialogContent({
 	const isRoleChanging = user.is_superuser !== isPlatformAdmin;
 	const isDemoting = user.is_superuser && !isPlatformAdmin;
 	const isPromoting = !user.is_superuser && isPlatformAdmin;
-
-	// Auto-select provider org when promoting to platform admin
-	const handleUserTypeChange = (value: string) => {
-		const isAdmin = value === "platform";
-		setIsPlatformAdmin(isAdmin);
-		if (isAdmin && providerOrgId) {
-			setOrgId(providerOrgId);
-		} else if (!isAdmin && orgId === providerOrgId) {
-			// Clear provider org if switching to org user
-			setOrgId("");
-		}
-	};
 
 	const toggleRole = (roleId: string) => {
 		setSelectedRoleIds((prev) => {
@@ -153,7 +140,7 @@ function EditUserDialogContent({
 			setValidationError("Please enter a display name");
 			return false;
 		}
-		if (!(isPlatformAdmin ? providerOrgId || orgId : orgId)) {
+		if (!effectiveOrgId) {
 			setValidationError("Please select an organization");
 			return false;
 		}
@@ -167,8 +154,6 @@ function EditUserDialogContent({
 		if (!validateForm()) {
 			return;
 		}
-
-		const effectiveOrgId = isPlatformAdmin ? providerOrgId || orgId : orgId;
 
 		// Build request body - only send changed fields
 		const body = {

--- a/client/src/components/users/EditUserDialog.tsx
+++ b/client/src/components/users/EditUserDialog.tsx
@@ -93,12 +93,15 @@ function EditUserDialogContent({
 
 	// Find the provider org (for auto-selecting when promoting to platform admin)
 	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
+	const providerOrgId =
+		providerOrg?.id ??
+		(currentUser?.isSuperuser ? currentUser.organizationId : null);
 
 	useEffect(() => {
-		if (isPlatformAdmin && providerOrg && orgId !== providerOrg.id) {
-			setOrgId(providerOrg.id);
+		if (isPlatformAdmin && providerOrgId && orgId !== providerOrgId) {
+			setOrgId(providerOrgId);
 		}
-	}, [isPlatformAdmin, orgId, providerOrg]);
+	}, [isPlatformAdmin, orgId, providerOrgId]);
 
 	// Check if editing own account
 	const isEditingSelf = !!(currentUser && user.id === currentUser.id);
@@ -111,9 +114,9 @@ function EditUserDialogContent({
 	const handleUserTypeChange = (value: string) => {
 		const isAdmin = value === "platform";
 		setIsPlatformAdmin(isAdmin);
-		if (isAdmin && providerOrg) {
-			setOrgId(providerOrg.id);
-		} else if (!isAdmin && orgId === providerOrg?.id) {
+		if (isAdmin && providerOrgId) {
+			setOrgId(providerOrgId);
+		} else if (!isAdmin && orgId === providerOrgId) {
 			// Clear provider org if switching to org user
 			setOrgId("");
 		}
@@ -150,7 +153,7 @@ function EditUserDialogContent({
 			setValidationError("Please enter a display name");
 			return false;
 		}
-		if (!orgId) {
+		if (!(isPlatformAdmin ? providerOrgId || orgId : orgId)) {
 			setValidationError("Please select an organization");
 			return false;
 		}
@@ -165,6 +168,8 @@ function EditUserDialogContent({
 			return;
 		}
 
+		const effectiveOrgId = isPlatformAdmin ? providerOrgId || orgId : orgId;
+
 		// Build request body - only send changed fields
 		const body = {
 			name:
@@ -178,8 +183,8 @@ function EditUserDialogContent({
 					? isPlatformAdmin
 					: null,
 			organization_id:
-				!isEditingSelf && orgId !== (user.organization_id || "")
-					? orgId || null
+				!isEditingSelf && effectiveOrgId !== (user.organization_id || "")
+					? effectiveOrgId || null
 					: null,
 		};
 

--- a/client/src/components/users/platformAdminOrg.ts
+++ b/client/src/components/users/platformAdminOrg.ts
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import type { AuthUser } from "@/contexts/AuthContext";
+import type { components } from "@/lib/v1";
+
+type Organization = components["schemas"]["OrganizationPublic"];
+
+export function getPlatformAdminOrgId(
+	organizations: Organization[] | undefined,
+	currentUser: AuthUser | null | undefined,
+): string | null {
+	const providerOrg = organizations?.find((org) => org.is_provider);
+	return providerOrg?.id ?? (currentUser?.isSuperuser ? currentUser.organizationId : null);
+}
+
+export function getEffectiveUserOrgId(
+	isPlatformAdmin: boolean,
+	orgId: string,
+	platformAdminOrgId: string | null,
+): string {
+	return isPlatformAdmin ? platformAdminOrgId || orgId : orgId;
+}
+
+export function usePlatformAdminOrgSelection({
+	organizations,
+	currentUser,
+	isPlatformAdmin,
+	setIsPlatformAdmin,
+	orgId,
+	setOrgId,
+}: {
+	organizations: Organization[] | undefined;
+	currentUser: AuthUser | null | undefined;
+	isPlatformAdmin: boolean;
+	setIsPlatformAdmin: (value: boolean) => void;
+	orgId: string;
+	setOrgId: (value: string) => void;
+}) {
+	const platformAdminOrgId = getPlatformAdminOrgId(organizations, currentUser);
+	const effectiveOrgId = getEffectiveUserOrgId(
+		isPlatformAdmin,
+		orgId,
+		platformAdminOrgId,
+	);
+
+	useEffect(() => {
+		if (isPlatformAdmin && platformAdminOrgId && orgId !== platformAdminOrgId) {
+			setOrgId(platformAdminOrgId);
+		}
+	}, [isPlatformAdmin, orgId, platformAdminOrgId, setOrgId]);
+
+	const handleUserTypeChange = (value: string) => {
+		const isAdmin = value === "platform";
+		setIsPlatformAdmin(isAdmin);
+		if (isAdmin && platformAdminOrgId) {
+			setOrgId(platformAdminOrgId);
+		} else if (!isAdmin && orgId === platformAdminOrgId) {
+			setOrgId("");
+		}
+	};
+
+	return { effectiveOrgId, handleUserTypeChange };
+}


### PR DESCRIPTION
## Summary
- fall back to the authenticated platform admin org id when the provider org is omitted from the organization list
- apply the fallback to create and edit user dialogs
- add a regression case for the live dev org-list shape

## Verification
- git diff --check -- client/src/components/users/CreateUserDialog.tsx client/src/components/users/EditUserDialog.tsx client/src/components/users/CreateUserDialog.test.tsx
- Not run locally: repo guidance routes Bifrost test execution through the pve-t340 e2e VM.