### PR TITLE
Add Codex Gateway persistence primitives

### DIFF
--- a/api/alembic/versions/20260522_codex_gateway.py
+++ b/api/alembic/versions/20260522_codex_gateway.py
@@ -1,0 +1,235 @@
+"""Add Codex Gateway persistence tables.
+
+Revision ID: 20260522_codex_gateway
+Revises: 20260516_per_token_status
+Create Date: 2026-05-22
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260522_codex_gateway"
+down_revision: str | Sequence[str] | None = "20260516_per_token_status"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "codex_gateway_upstream_accounts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "provider",
+            sa.String(length=64),
+            server_default="chatgpt_codex",
+            nullable=False,
+        ),
+        sa.Column("upstream_subject", sa.String(length=512), nullable=False),
+        sa.Column("upstream_email", sa.String(length=320), nullable=True),
+        sa.Column("upstream_workspace_id", sa.String(length=512), nullable=True),
+        sa.Column("encrypted_access_token", sa.Text(), nullable=True),
+        sa.Column("encrypted_refresh_token", sa.Text(), nullable=True),
+        sa.Column("access_token_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("scopes", postgresql.JSONB(), server_default="[]", nullable=False),
+        sa.Column("last_refresh_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_codex_gateway_upstream_accounts_user_provider",
+        "codex_gateway_upstream_accounts",
+        ["user_id", "provider", "revoked_at"],
+    )
+    op.create_index(
+        "ix_codex_gateway_upstream_accounts_subject",
+        "codex_gateway_upstream_accounts",
+        ["provider", "upstream_subject"],
+    )
+
+    op.create_table(
+        "codex_gateway_keys",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("key_hash", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "allowed_models",
+            postgresql.JSONB(),
+            server_default="[]",
+            nullable=False,
+        ),
+        sa.Column(
+            "denied_models",
+            postgresql.JSONB(),
+            server_default="[]",
+            nullable=False,
+        ),
+        sa.Column("daily_limit", sa.Integer(), nullable=True),
+        sa.Column("monthly_limit", sa.Integer(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="active",
+            nullable=False,
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key_hash", name="uq_codex_gateway_keys_key_hash"),
+    )
+    op.create_index(
+        "ix_codex_gateway_keys_user_status",
+        "codex_gateway_keys",
+        ["user_id", "status"],
+    )
+    op.create_index(
+        "ix_codex_gateway_keys_project_status",
+        "codex_gateway_keys",
+        ["project_id", "status"],
+    )
+
+    op.create_table(
+        "codex_gateway_request_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("request_id", sa.String(length=128), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("gateway_key_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("oauth_account_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("endpoint", sa.String(length=128), nullable=False),
+        sa.Column("model", sa.String(length=255), nullable=True),
+        sa.Column(
+            "streaming",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("status_code", sa.Integer(), nullable=False),
+        sa.Column("provider_error_code", sa.String(length=128), nullable=True),
+        sa.Column("input_token_count", sa.Integer(), nullable=True),
+        sa.Column("output_token_count", sa.Integer(), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("policy_decision", sa.String(length=32), nullable=False),
+        sa.Column("denied_reason", sa.Text(), nullable=True),
+        sa.Column("source_ip", sa.String(length=45), nullable=True),
+        sa.Column("client_user_agent", sa.Text(), nullable=True),
+        sa.Column(
+            "request_metadata",
+            postgresql.JSONB(),
+            server_default="{}",
+            nullable=False,
+        ),
+        sa.Column("captured_prompt", sa.Text(), nullable=True),
+        sa.Column("captured_response", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["gateway_key_id"],
+            ["codex_gateway_keys.id"],
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["oauth_account_id"],
+            ["codex_gateway_upstream_accounts.id"],
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "request_id", name="uq_codex_gateway_request_logs_request_id"
+        ),
+    )
+    op.create_index(
+        "ix_codex_gateway_request_logs_user_time",
+        "codex_gateway_request_logs",
+        ["user_id", "created_at"],
+    )
+    op.create_index(
+        "ix_codex_gateway_request_logs_project_time",
+        "codex_gateway_request_logs",
+        ["project_id", "created_at"],
+    )
+    op.create_index(
+        "ix_codex_gateway_request_logs_decision_time",
+        "codex_gateway_request_logs",
+        ["policy_decision", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_codex_gateway_request_logs_decision_time",
+        table_name="codex_gateway_request_logs",
+    )
+    op.drop_index(
+        "ix_codex_gateway_request_logs_project_time",
+        table_name="codex_gateway_request_logs",
+    )
+    op.drop_index(
+        "ix_codex_gateway_request_logs_user_time",
+        table_name="codex_gateway_request_logs",
+    )
+    op.drop_table("codex_gateway_request_logs")
+    op.drop_index(
+        "ix_codex_gateway_keys_project_status",
+        table_name="codex_gateway_keys",
+    )
+    op.drop_index("ix_codex_gateway_keys_user_status", table_name="codex_gateway_keys")
+    op.drop_table("codex_gateway_keys")
+    op.drop_index(
+        "ix_codex_gateway_upstream_accounts_subject",
+        table_name="codex_gateway_upstream_accounts",
+    )
+    op.drop_index(
+        "ix_codex_gateway_upstream_accounts_user_provider",
+        table_name="codex_gateway_upstream_accounts",
+    )
+    op.drop_table("codex_gateway_upstream_accounts")

--- a/api/src/models/orm/__init__.py
+++ b/api/src/models/orm/__init__.py
@@ -22,6 +22,11 @@ from src.models.orm.audit import AuditLog
 from src.models.orm.base import Base
 from src.models.orm.branding import GlobalBranding
 from src.models.orm.cli import CLISession
+from src.models.orm.codex_gateway import (
+    CodexGatewayKey,
+    CodexGatewayRequestLog,
+    CodexGatewayUpstreamAccount,
+)
 from src.models.orm.config import Config, SystemConfig
 from src.models.orm.developer import DeveloperContext
 from src.models.orm.events import Event, EventDelivery, EventSource, EventSubscription, WebhookSource
@@ -88,6 +93,10 @@ __all__ = [
     "ExecutionLog",
     # CLI Sessions
     "CLISession",
+    # Codex Gateway
+    "CodexGatewayKey",
+    "CodexGatewayRequestLog",
+    "CodexGatewayUpstreamAccount",
     # Config
     "Config",
     "SystemConfig",

--- a/api/src/models/orm/codex_gateway.py
+++ b/api/src/models/orm/codex_gateway.py
@@ -1,0 +1,198 @@
+"""ORM models for the Bifrost Codex Gateway."""
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.orm.base import Base
+
+if TYPE_CHECKING:
+    from src.models.orm.users import User
+
+
+class CodexGatewayUpstreamAccount(Base):
+    """Per-user upstream ChatGPT/Codex OAuth account.
+
+    These rows carry encrypted upstream tokens and must never be treated as
+    global/shared credentials. Ambiguous or revoked mappings should fail closed
+    at the repository/service layer.
+    """
+
+    __tablename__ = "codex_gateway_upstream_accounts"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE", onupdate="CASCADE"),
+        nullable=False,
+    )
+    provider: Mapped[str] = mapped_column(
+        String(64), default="chatgpt_codex", nullable=False
+    )
+    upstream_subject: Mapped[str] = mapped_column(String(512), nullable=False)
+    upstream_email: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    upstream_workspace_id: Mapped[str | None] = mapped_column(
+        String(512), nullable=True
+    )
+    encrypted_access_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    encrypted_refresh_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    access_token_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    scopes: Mapped[list[str]] = mapped_column(
+        JSONB, default=list, nullable=False, server_default="[]"
+    )
+    last_refresh_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    user: Mapped["User"] = relationship(lazy="select")
+
+    __table_args__ = (
+        Index(
+            "ix_codex_gateway_upstream_accounts_user_provider",
+            "user_id",
+            "provider",
+            "revoked_at",
+        ),
+        Index(
+            "ix_codex_gateway_upstream_accounts_subject",
+            "provider",
+            "upstream_subject",
+        ),
+    )
+
+
+class CodexGatewayKey(Base):
+    """Downstream gateway key mapped to one Bifrost user and optional project."""
+
+    __tablename__ = "codex_gateway_keys"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE", onupdate="CASCADE"),
+        nullable=False,
+    )
+    project_id: Mapped[UUID | None] = mapped_column(nullable=True)
+    key_hash: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    allowed_models: Mapped[list[str]] = mapped_column(
+        JSONB, default=list, nullable=False, server_default="[]"
+    )
+    denied_models: Mapped[list[str]] = mapped_column(
+        JSONB, default=list, nullable=False, server_default="[]"
+    )
+    daily_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    monthly_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), default="active", nullable=False)
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    user: Mapped["User"] = relationship(lazy="select")
+
+    __table_args__ = (
+        Index("ix_codex_gateway_keys_user_status", "user_id", "status"),
+        Index("ix_codex_gateway_keys_project_status", "project_id", "status"),
+    )
+
+
+class CodexGatewayRequestLog(Base):
+    """Metadata-only gateway request log.
+
+    Raw prompts and responses stay empty by default. They are only populated by
+    callers that explicitly enable sensitive payload capture for a project or
+    policy path.
+    """
+
+    __tablename__ = "codex_gateway_request_logs"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    request_id: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+    )
+    project_id: Mapped[UUID | None] = mapped_column(nullable=True)
+    gateway_key_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("codex_gateway_keys.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+    )
+    oauth_account_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey(
+            "codex_gateway_upstream_accounts.id",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        nullable=True,
+    )
+    endpoint: Mapped[str] = mapped_column(String(128), nullable=False)
+    model: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    streaming: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    status_code: Mapped[int] = mapped_column(Integer, nullable=False)
+    provider_error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    input_token_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_token_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    policy_decision: Mapped[str] = mapped_column(String(32), nullable=False)
+    denied_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_ip: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    client_user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    request_metadata: Mapped[dict] = mapped_column(
+        JSONB, default=dict, nullable=False, server_default="{}"
+    )
+    captured_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    captured_response: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+
+    user: Mapped["User | None"] = relationship(lazy="select")
+    gateway_key: Mapped["CodexGatewayKey | None"] = relationship(lazy="select")
+    oauth_account: Mapped["CodexGatewayUpstreamAccount | None"] = relationship(
+        lazy="select"
+    )
+
+    __table_args__ = (
+        Index("ix_codex_gateway_request_logs_user_time", "user_id", "created_at"),
+        Index(
+            "ix_codex_gateway_request_logs_project_time",
+            "project_id",
+            "created_at",
+        ),
+        Index(
+            "ix_codex_gateway_request_logs_decision_time",
+            "policy_decision",
+            "created_at",
+        ),
+    )

--- a/api/src/repositories/codex_gateway.py
+++ b/api/src/repositories/codex_gateway.py
@@ -1,0 +1,207 @@
+"""Persistence helpers for the Bifrost Codex Gateway."""
+
+from dataclasses import dataclass
+import secrets
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.security import encrypt_secret, get_password_hash, verify_password
+from src.models.orm.codex_gateway import (
+    CodexGatewayKey,
+    CodexGatewayRequestLog,
+    CodexGatewayUpstreamAccount,
+)
+
+
+SENSITIVE_METADATA_KEYS = {
+    "content",
+    "input",
+    "messages",
+    "output",
+    "prompt",
+    "response",
+}
+
+
+@dataclass(frozen=True)
+class CodexGatewayKeyMaterial:
+    """Created gateway key record plus the one-time plaintext secret."""
+
+    record: CodexGatewayKey
+    plaintext_key: str
+
+
+class CodexGatewayRepository:
+    """Repository for gateway keys, upstream accounts, and request logs."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    @staticmethod
+    def generate_gateway_key() -> str:
+        """Generate a downstream key with a recognizable Bifrost prefix."""
+        return f"bfck_{secrets.token_urlsafe(32)}"
+
+    @staticmethod
+    def hash_gateway_key(plaintext_key: str) -> str:
+        """Hash a gateway key for storage."""
+        return get_password_hash(plaintext_key)
+
+    @staticmethod
+    def verify_gateway_key(plaintext_key: str, key_hash: str) -> bool:
+        """Verify a gateway key without leaking hash parsing failures."""
+        try:
+            return verify_password(plaintext_key, key_hash)
+        except Exception:
+            return False
+
+    async def create_gateway_key(
+        self,
+        *,
+        user_id: UUID,
+        name: str,
+        project_id: UUID | None = None,
+        allowed_models: list[str] | None = None,
+        denied_models: list[str] | None = None,
+        daily_limit: int | None = None,
+        monthly_limit: int | None = None,
+    ) -> CodexGatewayKeyMaterial:
+        plaintext_key = self.generate_gateway_key()
+        record = CodexGatewayKey(
+            user_id=user_id,
+            project_id=project_id,
+            key_hash=self.hash_gateway_key(plaintext_key),
+            name=name,
+            allowed_models=allowed_models or [],
+            denied_models=denied_models or [],
+            daily_limit=daily_limit,
+            monthly_limit=monthly_limit,
+        )
+        self.session.add(record)
+        await self.session.flush()
+        await self.session.refresh(record)
+        return CodexGatewayKeyMaterial(record=record, plaintext_key=plaintext_key)
+
+    async def get_active_gateway_key_by_plaintext(
+        self, plaintext_key: str
+    ) -> CodexGatewayKey | None:
+        result = await self.session.execute(
+            select(CodexGatewayKey)
+            .where(CodexGatewayKey.status == "active")
+            .where(CodexGatewayKey.revoked_at.is_(None))
+        )
+        candidates = result.scalars().all()
+        for candidate in candidates:
+            if candidate.status != "active" or candidate.revoked_at is not None:
+                continue
+            if self.verify_gateway_key(plaintext_key, candidate.key_hash):
+                return candidate
+        return None
+
+    async def get_active_upstream_account_for_user(
+        self, user_id: UUID, provider: str = "chatgpt_codex"
+    ) -> CodexGatewayUpstreamAccount | None:
+        result = await self.session.execute(
+            select(CodexGatewayUpstreamAccount)
+            .where(CodexGatewayUpstreamAccount.user_id == user_id)
+            .where(CodexGatewayUpstreamAccount.provider == provider)
+            .where(CodexGatewayUpstreamAccount.revoked_at.is_(None))
+        )
+        return result.scalar_one_or_none()
+
+    async def create_upstream_account(
+        self,
+        *,
+        user_id: UUID,
+        upstream_subject: str,
+        upstream_email: str | None = None,
+        upstream_workspace_id: str | None = None,
+        access_token: str | None = None,
+        refresh_token: str | None = None,
+        access_token_expires_at: Any = None,
+        scopes: list[str] | None = None,
+        provider: str = "chatgpt_codex",
+    ) -> CodexGatewayUpstreamAccount:
+        account = CodexGatewayUpstreamAccount(
+            user_id=user_id,
+            provider=provider,
+            upstream_subject=upstream_subject,
+            upstream_email=upstream_email,
+            upstream_workspace_id=upstream_workspace_id,
+            encrypted_access_token=(
+                encrypt_secret(access_token) if access_token is not None else None
+            ),
+            encrypted_refresh_token=(
+                encrypt_secret(refresh_token) if refresh_token is not None else None
+            ),
+            access_token_expires_at=access_token_expires_at,
+            scopes=scopes or [],
+        )
+        self.session.add(account)
+        await self.session.flush()
+        await self.session.refresh(account)
+        return account
+
+    async def create_request_log(
+        self,
+        *,
+        request_id: str,
+        endpoint: str,
+        status_code: int,
+        policy_decision: str,
+        user_id: UUID | None = None,
+        project_id: UUID | None = None,
+        gateway_key_id: UUID | None = None,
+        oauth_account_id: UUID | None = None,
+        model: str | None = None,
+        streaming: bool = False,
+        provider_error_code: str | None = None,
+        input_token_count: int | None = None,
+        output_token_count: int | None = None,
+        latency_ms: int | None = None,
+        denied_reason: str | None = None,
+        source_ip: str | None = None,
+        client_user_agent: str | None = None,
+        request_metadata: dict[str, Any] | None = None,
+        captured_prompt: str | None = None,
+        captured_response: str | None = None,
+        capture_sensitive_payloads: bool = False,
+    ) -> CodexGatewayRequestLog:
+        safe_metadata = self._redact_sensitive_metadata(request_metadata or {})
+        log = CodexGatewayRequestLog(
+            request_id=request_id,
+            user_id=user_id,
+            project_id=project_id,
+            gateway_key_id=gateway_key_id,
+            oauth_account_id=oauth_account_id,
+            endpoint=endpoint,
+            model=model,
+            streaming=streaming,
+            status_code=status_code,
+            provider_error_code=provider_error_code,
+            input_token_count=input_token_count,
+            output_token_count=output_token_count,
+            latency_ms=latency_ms,
+            policy_decision=policy_decision,
+            denied_reason=denied_reason,
+            source_ip=source_ip,
+            client_user_agent=client_user_agent,
+            request_metadata=safe_metadata,
+            captured_prompt=captured_prompt if capture_sensitive_payloads else None,
+            captured_response=captured_response if capture_sensitive_payloads else None,
+        )
+        self.session.add(log)
+        await self.session.flush()
+        await self.session.refresh(log)
+        return log
+
+    @staticmethod
+    def _redact_sensitive_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in metadata.items()
+            if key.lower() not in SENSITIVE_METADATA_KEYS
+        }

--- a/api/tests/unit/repositories/test_codex_gateway_repository.py
+++ b/api/tests/unit/repositories/test_codex_gateway_repository.py
@@ -1,0 +1,192 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.repositories.codex_gateway import (
+    CodexGatewayKeyMaterial,
+    CodexGatewayRepository,
+)
+
+
+class _Scalars:
+    def __init__(self, values):
+        self._values = values
+
+    def all(self):
+        return self._values
+
+
+class _Result:
+    def __init__(self, *, one=None, values=None):
+        self._one = one
+        self._values = values or []
+
+    def scalar_one_or_none(self):
+        return self._one
+
+    def scalars(self):
+        return _Scalars(self._values)
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def repository(mock_session):
+    return CodexGatewayRepository(mock_session)
+
+
+@pytest.mark.asyncio
+async def test_create_gateway_key_hashes_secret_and_returns_key_material(
+    repository,
+    mock_session,
+):
+    user_id = uuid4()
+    project_id = uuid4()
+
+    result = await repository.create_gateway_key(
+        user_id=user_id,
+        project_id=project_id,
+        name="developer workstation",
+        allowed_models=["gpt-5.1-codex"],
+        daily_limit=100,
+    )
+
+    assert isinstance(result, CodexGatewayKeyMaterial)
+    assert result.plaintext_key.startswith("bfck_")
+    assert result.record.user_id == user_id
+    assert result.record.project_id == project_id
+    assert result.record.key_hash != result.plaintext_key
+    assert result.record.key_hash.startswith("$")
+    assert result.record.allowed_models == ["gpt-5.1-codex"]
+    assert result.record.daily_limit == 100
+    mock_session.add.assert_called_once()
+    mock_session.flush.assert_called_once()
+    mock_session.refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lookup_gateway_key_uses_hash_and_ignores_revoked_keys(
+    repository,
+    mock_session,
+):
+    plaintext = "bfck_test_plaintext"
+    key_hash = repository.hash_gateway_key(plaintext)
+    active_record = MagicMock(key_hash=key_hash, revoked_at=None, status="active")
+    revoked_record = MagicMock(
+        key_hash=key_hash, revoked_at=datetime.now(timezone.utc), status="revoked"
+    )
+    mock_session.execute.return_value = _Result(values=[revoked_record, active_record])
+
+    result = await repository.get_active_gateway_key_by_plaintext(plaintext)
+
+    assert result is active_record
+    mock_session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_active_upstream_account_for_user_excludes_revoked_accounts(
+    repository,
+    mock_session,
+):
+    user_id = uuid4()
+    active_account = MagicMock(user_id=user_id, revoked_at=None)
+    mock_session.execute.return_value = _Result(one=active_account)
+
+    result = await repository.get_active_upstream_account_for_user(user_id)
+
+    assert result is active_account
+    mock_session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_upstream_account_stores_encrypted_tokens(
+    repository,
+    mock_session,
+):
+    user_id = uuid4()
+
+    account = await repository.create_upstream_account(
+        user_id=user_id,
+        upstream_subject="chatgpt-user-123",
+        upstream_email="dev@example.test",
+        upstream_workspace_id="workspace-midtown",
+        access_token="access-token-secret",
+        refresh_token="refresh-token-secret",
+        scopes=["openid", "profile"],
+    )
+
+    assert account.user_id == user_id
+    assert account.upstream_subject == "chatgpt-user-123"
+    assert account.encrypted_access_token != "access-token-secret"
+    assert account.encrypted_refresh_token != "refresh-token-secret"
+    assert account.scopes == ["openid", "profile"]
+    mock_session.add.assert_called_once()
+    mock_session.flush.assert_called_once()
+    mock_session.refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_request_log_excludes_prompt_and_response_by_default(
+    repository,
+    mock_session,
+):
+    user_id = uuid4()
+    gateway_key_id = uuid4()
+    oauth_account_id = uuid4()
+
+    log = await repository.create_request_log(
+        request_id="req_bifrost_123",
+        user_id=user_id,
+        gateway_key_id=gateway_key_id,
+        oauth_account_id=oauth_account_id,
+        endpoint="/v1/responses",
+        model="gpt-5.1-codex",
+        streaming=True,
+        status_code=200,
+        latency_ms=123,
+        policy_decision="allow",
+        request_metadata={
+            "client_type": "codex-cli",
+            "prompt": "do not store this",
+            "response": "do not store this either",
+        },
+    )
+
+    assert log.request_id == "req_bifrost_123"
+    assert log.request_metadata == {"client_type": "codex-cli"}
+    assert log.captured_prompt is None
+    assert log.captured_response is None
+    mock_session.add.assert_called_once()
+    mock_session.flush.assert_called_once()
+    mock_session.refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_request_log_can_capture_sensitive_payloads_explicitly(
+    repository,
+    mock_session,
+):
+    user_id = uuid4()
+
+    log = await repository.create_request_log(
+        request_id="req_bifrost_123",
+        user_id=user_id,
+        endpoint="/v1/responses",
+        model="gpt-5.1-codex",
+        status_code=200,
+        policy_decision="allow",
+        captured_prompt="operator-approved prompt",
+        captured_response="operator-approved response",
+        capture_sensitive_payloads=True,
+    )
+
+    assert log.captured_prompt == "operator-approved prompt"
+    assert log.captured_response == "operator-approved response"


### PR DESCRIPTION
## Summary
- add Codex Gateway upstream-account, downstream-key, and request-log ORM tables plus migration
- add repository helpers for encrypted upstream tokens, hashed gateway keys, active token/key lookup, and metadata-only request logging
- cover key hashing, revoked-key filtering, token encryption, upstream lookup, and prompt/response capture opt-in behavior

## Verification
- Local: python -m ruff check src/models/orm/codex_gateway.py src/repositories/codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py alembic/versions/20260522_codex_gateway.py
- Local: python -m pytest tests/unit/repositories/test_codex_gateway_repository.py tests/unit/models/test_orm_import_hygiene.py -q -> 8 passed
- VM codex-dev-01: ./test.sh stack up rebuilt template DB and applied migration through 20260522_codex_gateway
- VM codex-dev-01: lembic heads inside API container -> 20260522_codex_gateway (head)
- VM codex-dev-01: ./test.sh tests/unit/repositories/test_codex_gateway_repository.py -q -> 6 passed

Note: a broader VM run of repository + policy + import-hygiene tests reported 15 passed but initially exited nonzero because the wrapper could not write /tmp/bifrost-bifrost-test-8a11c0b0/test-runner.log; after fixing the VM temp-dir permission, the focused stack-backed repository run exited 0.