### PR TITLE
Add Codex Gateway responses route

### DIFF
--- a/api/shared/models.py
+++ b/api/shared/models.py
@@ -1,7 +1,13 @@
 """Shared Pydantic models used by API routers and clients."""
 
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, RootModel
 
 
 class VersionResponse(BaseModel):
     version: str
+
+
+class CodexGatewayResponsesRequest(RootModel[dict[str, Any]]):
+    """OpenAI-compatible Responses API request payload."""

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -47,6 +47,7 @@ from src.routers import (
     oauth_connections_router,
     endpoints_router,
     cli_router,
+    codex_gateway_router,
     notifications_router,
     profile_router,
     agent_runs_router,
@@ -545,6 +546,7 @@ def create_app() -> FastAPI:
     app.include_router(oauth_connections_router)
     app.include_router(endpoints_router)
     app.include_router(cli_router)
+    app.include_router(codex_gateway_router)
     app.include_router(notifications_router)
     app.include_router(profile_router)
     app.include_router(agents_router)

--- a/api/src/routers/__init__.py
+++ b/api/src/routers/__init__.py
@@ -23,6 +23,7 @@ from src.routers.github import router as github_router
 from src.routers.oauth_connections import router as oauth_connections_router
 from src.routers.endpoints import router as endpoints_router
 from src.routers.cli import router as cli_router
+from src.routers.codex_gateway import router as codex_gateway_router
 from src.routers.notifications import router as notifications_router
 from src.routers.profile import router as profile_router
 from src.routers.agents import router as agents_router
@@ -94,6 +95,7 @@ __all__ = [
     "oauth_connections_router",
     "endpoints_router",
     "cli_router",
+    "codex_gateway_router",
     "notifications_router",
     "profile_router",
     "agents_router",

--- a/api/src/routers/codex_gateway.py
+++ b/api/src/routers/codex_gateway.py
@@ -1,0 +1,43 @@
+"""OpenAI-compatible facade routes for the Bifrost Codex Gateway."""
+
+from typing import Any
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import JSONResponse
+
+from src.core.database import DbSession
+from src.repositories.codex_gateway import CodexGatewayRepository
+from src.services.codex_gateway.runtime import (
+    CODEX_GATEWAY_KEY_HEADER,
+    CodexGatewayRuntime,
+    extract_gateway_key,
+)
+
+
+router = APIRouter(tags=["Codex Gateway"])
+
+
+def get_codex_gateway_runtime(db: DbSession) -> CodexGatewayRuntime:
+    return CodexGatewayRuntime(repository=CodexGatewayRepository(db))
+
+
+@router.post("/v1/responses")
+async def create_response(
+    request: Request,
+    runtime: Annotated[CodexGatewayRuntime, Depends(get_codex_gateway_runtime)],
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+    x_bifrost_codex_key: Annotated[
+        str | None,
+        Header(alias=CODEX_GATEWAY_KEY_HEADER),
+    ] = None,
+) -> JSONResponse:
+    gateway_key = extract_gateway_key(authorization, x_bifrost_codex_key)
+    payload: dict[str, Any] = await request.json()
+    result = await runtime.create_response(
+        gateway_key=gateway_key or "",
+        payload=payload,
+        source_ip=request.client.host if request.client else None,
+        client_user_agent=request.headers.get("user-agent"),
+    )
+    return JSONResponse(status_code=result.status_code, content=result.body)

--- a/api/src/routers/codex_gateway.py
+++ b/api/src/routers/codex_gateway.py
@@ -1,10 +1,11 @@
 """OpenAI-compatible facade routes for the Bifrost Codex Gateway."""
 
-from typing import Any
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
+
+from shared.models import CodexGatewayResponsesRequest
 
 from src.core.database import DbSession
 from src.repositories.codex_gateway import CodexGatewayRepository
@@ -25,6 +26,7 @@ def get_codex_gateway_runtime(db: DbSession) -> CodexGatewayRuntime:
 @router.post("/v1/responses")
 async def create_response(
     request: Request,
+    payload: CodexGatewayResponsesRequest,
     runtime: Annotated[CodexGatewayRuntime, Depends(get_codex_gateway_runtime)],
     authorization: Annotated[str | None, Header(alias="Authorization")] = None,
     x_bifrost_codex_key: Annotated[
@@ -33,10 +35,9 @@ async def create_response(
     ] = None,
 ) -> JSONResponse:
     gateway_key = extract_gateway_key(authorization, x_bifrost_codex_key)
-    payload: dict[str, Any] = await request.json()
     result = await runtime.create_response(
         gateway_key=gateway_key or "",
-        payload=payload,
+        payload=payload.model_dump(),
         source_ip=request.client.host if request.client else None,
         client_user_agent=request.headers.get("user-agent"),
     )

--- a/api/src/services/codex_gateway/runtime.py
+++ b/api/src/services/codex_gateway/runtime.py
@@ -1,0 +1,377 @@
+"""Runtime orchestration for the Bifrost Codex Gateway."""
+
+from __future__ import annotations
+
+from asyncio import sleep
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any, Protocol, cast
+from uuid import uuid4
+
+from sqlalchemy.exc import MultipleResultsFound
+
+from src.core.security import decrypt_secret
+from src.models.contracts.codex_gateway import (
+    CodexGatewayKeyContext,
+    CodexGatewayKeyStatus,
+    CodexGatewayRequestContext,
+    CodexGatewayUpstreamAccount as CodexGatewayUpstreamAccountContext,
+    OpenAICompatibleError,
+)
+from src.models.orm.codex_gateway import (
+    CodexGatewayKey,
+    CodexGatewayUpstreamAccount,
+)
+from src.repositories.codex_gateway import CodexGatewayRepository
+from src.services.codex_gateway.policy import CodexGatewayPolicyEngine
+
+
+CODEX_GATEWAY_KEY_HEADER = "X-Bifrost-Codex-Key"
+CODEX_GATEWAY_RESPONSES_ENDPOINT = "/v1/responses"
+
+
+@dataclass(frozen=True)
+class CodexGatewayUpstreamResponse:
+    """Provider response normalized for gateway logging and transport."""
+
+    status_code: int
+    body: dict[str, Any]
+    provider_error_code: str | None = None
+    input_token_count: int | None = None
+    output_token_count: int | None = None
+
+
+class CodexGatewayUpstreamClient(Protocol):
+    async def create_response(
+        self, *, access_token: str, payload: dict[str, Any]
+    ) -> CodexGatewayUpstreamResponse:
+        """Dispatch a Responses API request with a user-scoped upstream token."""
+        ...
+
+
+class UnconfiguredCodexGatewayUpstreamClient:
+    """Placeholder upstream client until the subscription backend is pinned down."""
+
+    async def create_response(
+        self, *, access_token: str, payload: dict[str, Any]
+    ) -> CodexGatewayUpstreamResponse:
+        await sleep(0)
+        configured_model = payload.get("model") if access_token else None
+        return CodexGatewayUpstreamResponse(
+            status_code=502,
+            provider_error_code="upstream_not_configured",
+            body={
+                "error": {
+                    "message": "The upstream ChatGPT/Codex transport is not configured.",
+                    "type": "server_error",
+                    "param": "model" if configured_model else None,
+                    "code": "upstream_not_configured",
+                }
+            },
+        )
+
+
+@dataclass(frozen=True)
+class CodexGatewayResponse:
+    """HTTP response payload produced by the gateway runtime."""
+
+    status_code: int
+    body: dict[str, Any]
+
+
+class CodexGatewayRuntime:
+    """Authenticate, authorize, dispatch, and audit OpenAI-compatible calls."""
+
+    def __init__(
+        self,
+        *,
+        repository: CodexGatewayRepository,
+        upstream_client: CodexGatewayUpstreamClient | None = None,
+        policy_engine: CodexGatewayPolicyEngine | None = None,
+    ):
+        self.repository = repository
+        self.upstream_client = (
+            upstream_client or UnconfiguredCodexGatewayUpstreamClient()
+        )
+        self.policy_engine = policy_engine or CodexGatewayPolicyEngine()
+
+    async def create_response(
+        self,
+        *,
+        gateway_key: str,
+        payload: dict[str, Any],
+        source_ip: str | None = None,
+        client_user_agent: str | None = None,
+        client_type: str = "openai-compatible",
+    ) -> CodexGatewayResponse:
+        request_id = f"req_bifrost_{uuid4().hex}"
+        model = payload.get("model")
+        streaming = bool(payload.get("stream") or payload.get("streaming"))
+
+        key_record = await self.repository.get_active_gateway_key_by_plaintext(
+            gateway_key
+        )
+        if key_record is None:
+            response = self._error(
+                status_code=401,
+                code="invalid_gateway_key",
+                message="The Bifrost Codex Gateway key is invalid or revoked.",
+            )
+            await self._log_denial(
+                request_id=request_id,
+                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+                model=model if isinstance(model, str) else None,
+                status_code=response.status_code,
+                code="invalid_gateway_key",
+                source_ip=source_ip,
+                client_user_agent=client_user_agent,
+            )
+            return response
+
+        if not isinstance(model, str) or not model:
+            response = self._error(
+                status_code=400,
+                code="missing_model",
+                message="The request body must include a model.",
+                param="model",
+            )
+            await self._log_denial(
+                request_id=request_id,
+                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+                model=model if isinstance(model, str) else None,
+                status_code=response.status_code,
+                code="missing_model",
+                source_ip=source_ip,
+                client_user_agent=client_user_agent,
+            )
+            return response
+
+        try:
+            account_record = (
+                await self.repository.get_active_upstream_account_for_user(
+                    key_record.user_id
+                )
+            )
+        except MultipleResultsFound:
+            response = self._error(
+                status_code=403,
+                code="upstream_identity_ambiguous",
+                message="Multiple active ChatGPT/Codex accounts are connected for this Bifrost user.",
+            )
+            await self._log_denial(
+                request_id=request_id,
+                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+                model=model,
+                status_code=response.status_code,
+                code="upstream_identity_ambiguous",
+                key=key_record,
+                source_ip=source_ip,
+                client_user_agent=client_user_agent,
+            )
+            return response
+        if account_record is None:
+            response = self._error(
+                status_code=403,
+                code="upstream_identity_not_connected",
+                message="No active ChatGPT/Codex account is connected for this Bifrost user.",
+            )
+            await self._log_denial(
+                request_id=request_id,
+                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+                model=model,
+                status_code=response.status_code,
+                code="upstream_identity_not_connected",
+                key=key_record,
+                source_ip=source_ip,
+                client_user_agent=client_user_agent,
+            )
+            return response
+
+        key_context = self._key_context(key_record)
+        account_context = self._account_context(account_record)
+        request_context = CodexGatewayRequestContext(
+            request_id=request_id,
+            endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+            model=model,
+            streaming=streaming,
+            client_type=client_type,
+            source_ip=source_ip,
+            client_user_agent=client_user_agent,
+        )
+        decision = self.policy_engine.evaluate(
+            key_context,
+            account_context,
+            request_context,
+        )
+        if not decision.allowed:
+            response = CodexGatewayResponse(
+                status_code=decision.status_code,
+                body={"error": decision.openai_error.model_dump()},
+            )
+            await self.repository.create_request_log(
+                request_id=request_id,
+                user_id=key_record.user_id,
+                project_id=key_record.project_id,
+                gateway_key_id=key_record.id,
+                oauth_account_id=account_record.id,
+                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+                model=model,
+                streaming=streaming,
+                status_code=decision.status_code,
+                policy_decision="deny",
+                denied_reason=decision.code,
+                source_ip=source_ip,
+                client_user_agent=client_user_agent,
+                request_metadata=decision.audit_metadata,
+            )
+            return response
+
+        if not account_record.encrypted_access_token:
+            response = self._error(
+                status_code=403,
+                code="upstream_token_unavailable",
+                message="The connected ChatGPT/Codex account does not have an active access token.",
+            )
+            await self._log_denial(
+                request_id=request_id,
+                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+                model=model,
+                status_code=response.status_code,
+                code="upstream_token_unavailable",
+                key=key_record,
+                account=account_record,
+                source_ip=source_ip,
+                client_user_agent=client_user_agent,
+            )
+            return response
+
+        start = perf_counter()
+        upstream_response = await self.upstream_client.create_response(
+            access_token=decrypt_secret(account_record.encrypted_access_token),
+            payload=payload,
+        )
+        latency_ms = int((perf_counter() - start) * 1000)
+
+        await self.repository.create_request_log(
+            request_id=request_id,
+            user_id=key_record.user_id,
+            project_id=key_record.project_id,
+            gateway_key_id=key_record.id,
+            oauth_account_id=account_record.id,
+            endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+            model=model,
+            streaming=streaming,
+            status_code=upstream_response.status_code,
+            provider_error_code=upstream_response.provider_error_code,
+            input_token_count=upstream_response.input_token_count,
+            output_token_count=upstream_response.output_token_count,
+            latency_ms=latency_ms,
+            policy_decision="allow",
+            source_ip=source_ip,
+            client_user_agent=client_user_agent,
+            request_metadata=decision.audit_metadata,
+        )
+        return CodexGatewayResponse(
+            status_code=upstream_response.status_code,
+            body=upstream_response.body,
+        )
+
+    def _error(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        message: str,
+        param: str | None = None,
+    ) -> CodexGatewayResponse:
+        return CodexGatewayResponse(
+            status_code=status_code,
+            body={
+                "error": OpenAICompatibleError(
+                    message=message,
+                    code=code,
+                    param=param,
+                ).model_dump()
+            },
+        )
+
+    async def _log_denial(
+        self,
+        *,
+        request_id: str,
+        endpoint: str,
+        model: str | None,
+        status_code: int,
+        code: str,
+        key: CodexGatewayKey | None = None,
+        account: CodexGatewayUpstreamAccount | None = None,
+        source_ip: str | None = None,
+        client_user_agent: str | None = None,
+    ) -> None:
+        await self.repository.create_request_log(
+            request_id=request_id,
+            user_id=key.user_id if key else None,
+            project_id=key.project_id if key else None,
+            gateway_key_id=key.id if key else None,
+            oauth_account_id=account.id if account else None,
+            endpoint=endpoint,
+            model=model,
+            streaming=False,
+            status_code=status_code,
+            policy_decision="deny",
+            denied_reason=code,
+            source_ip=source_ip,
+            client_user_agent=client_user_agent,
+            request_metadata={
+                "request_id": request_id,
+                "user_id": str(key.user_id) if key else None,
+                "gateway_key_id": str(key.id) if key else None,
+                "project_id": str(key.project_id) if key and key.project_id else None,
+                "oauth_account_id": str(account.id) if account else None,
+                "endpoint": endpoint,
+                "model": model,
+                "policy_decision": "deny",
+                "denied_reason": code,
+            },
+        )
+
+    @staticmethod
+    def _key_context(key: CodexGatewayKey) -> CodexGatewayKeyContext:
+        return CodexGatewayKeyContext(
+            id=key.id,
+            user_id=key.user_id,
+            project_id=key.project_id,
+            name=key.name,
+            allowed_models=key.allowed_models or [],
+            denied_models=key.denied_models or [],
+            daily_limit=key.daily_limit,
+            monthly_limit=key.monthly_limit,
+            status=cast(CodexGatewayKeyStatus, key.status),
+        )
+
+    @staticmethod
+    def _account_context(
+        account: CodexGatewayUpstreamAccount,
+    ) -> CodexGatewayUpstreamAccountContext:
+        return CodexGatewayUpstreamAccountContext(
+            id=account.id,
+            user_id=account.user_id,
+            upstream_subject=account.upstream_subject,
+            upstream_email=account.upstream_email,
+            upstream_workspace_id=account.upstream_workspace_id,
+            access_token_expires_at=account.access_token_expires_at,
+            last_refresh_at=account.last_refresh_at,
+            last_used_at=account.last_used_at,
+            revoked_at=account.revoked_at,
+        )
+
+
+def extract_gateway_key(
+    authorization: str | None,
+    x_bifrost_codex_key: str | None,
+) -> str | None:
+    """Extract downstream key from OpenAI-compatible Bearer auth or fallback header."""
+    if authorization and authorization.startswith("Bearer "):
+        token = authorization.removeprefix("Bearer ").strip()
+        return token or None
+    return x_bifrost_codex_key

--- a/api/src/services/codex_gateway/runtime.py
+++ b/api/src/services/codex_gateway/runtime.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from asyncio import sleep
+from asyncio import TimeoutError as AsyncioTimeoutError
+from asyncio import sleep, wait_for
 from dataclasses import dataclass
 from time import perf_counter
 from typing import Any, Protocol, cast
@@ -28,6 +29,7 @@ from src.services.codex_gateway.policy import CodexGatewayPolicyEngine
 
 CODEX_GATEWAY_KEY_HEADER = "X-Bifrost-Codex-Key"
 CODEX_GATEWAY_RESPONSES_ENDPOINT = "/v1/responses"
+CODEX_GATEWAY_UPSTREAM_TIMEOUT_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -46,7 +48,7 @@ class CodexGatewayUpstreamClient(Protocol):
         self, *, access_token: str, payload: dict[str, Any]
     ) -> CodexGatewayUpstreamResponse:
         """Dispatch a Responses API request with a user-scoped upstream token."""
-        ...
+        raise NotImplementedError
 
 
 class UnconfiguredCodexGatewayUpstreamClient:
@@ -245,11 +247,48 @@ class CodexGatewayRuntime:
             )
             return response
 
+        try:
+            access_token = decrypt_secret(account_record.encrypted_access_token)
+        except Exception:
+            response = self._error(
+                status_code=403,
+                code="upstream_token_unavailable",
+                message="The connected ChatGPT/Codex account token is invalid or unavailable.",
+            )
+            await self._log_denial(
+                request_id=request_id,
+                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
+                model=model,
+                status_code=response.status_code,
+                code="upstream_token_unavailable",
+                key=key_record,
+                account=account_record,
+                source_ip=source_ip,
+                client_user_agent=client_user_agent,
+            )
+            return response
+
         start = perf_counter()
-        upstream_response = await self.upstream_client.create_response(
-            access_token=decrypt_secret(account_record.encrypted_access_token),
-            payload=payload,
-        )
+        try:
+            upstream_response = await wait_for(
+                self.upstream_client.create_response(
+                    access_token=access_token,
+                    payload=payload,
+                ),
+                timeout=CODEX_GATEWAY_UPSTREAM_TIMEOUT_SECONDS,
+            )
+        except AsyncioTimeoutError:
+            upstream_response = self._upstream_error(
+                status_code=504,
+                code="upstream_timeout",
+                message="The upstream ChatGPT/Codex request timed out.",
+            )
+        except Exception:
+            upstream_response = self._upstream_error(
+                status_code=502,
+                code="upstream_unavailable",
+                message="The upstream ChatGPT/Codex transport failed.",
+            )
         latency_ms = int((perf_counter() - start) * 1000)
 
         await self.repository.create_request_log(
@@ -274,6 +313,26 @@ class CodexGatewayRuntime:
         return CodexGatewayResponse(
             status_code=upstream_response.status_code,
             body=upstream_response.body,
+        )
+
+    def _upstream_error(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        message: str,
+    ) -> CodexGatewayUpstreamResponse:
+        return CodexGatewayUpstreamResponse(
+            status_code=status_code,
+            provider_error_code=code,
+            body={
+                "error": {
+                    "message": message,
+                    "type": "server_error",
+                    "param": None,
+                    "code": code,
+                }
+            },
         )
 
     def _error(
@@ -371,7 +430,7 @@ def extract_gateway_key(
     x_bifrost_codex_key: str | None,
 ) -> str | None:
     """Extract downstream key from OpenAI-compatible Bearer auth or fallback header."""
-    if authorization and authorization.startswith("Bearer "):
-        token = authorization.removeprefix("Bearer ").strip()
+    if authorization and authorization[:7].lower() == "bearer ":
+        token = authorization[7:].strip()
         return token or None
     return x_bifrost_codex_key

--- a/api/tests/unit/routers/test_codex_gateway.py
+++ b/api/tests/unit/routers/test_codex_gateway.py
@@ -4,7 +4,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.routers.codex_gateway import get_codex_gateway_runtime, router
-from src.services.codex_gateway.runtime import CodexGatewayResponse
+from src.services.codex_gateway.runtime import (
+    CODEX_GATEWAY_KEY_HEADER,
+    CodexGatewayResponse,
+)
 
 
 class FakeRuntime:
@@ -58,3 +61,25 @@ def test_v1_responses_rejects_non_object_payload_before_runtime():
 
     assert 400 <= response.status_code < 500
     assert runtime.calls == []
+
+
+def test_v1_responses_uses_fallback_gateway_key_header():
+    app = FastAPI()
+    app.include_router(router)
+    runtime = FakeRuntime()
+    app.dependency_overrides[get_codex_gateway_runtime] = lambda: runtime
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/responses",
+        headers={CODEX_GATEWAY_KEY_HEADER: "bfck_fallback_test"},
+        json={"model": "gpt-5.1-codex", "input": "fallback header"},
+    )
+
+    assert response.status_code == 200
+    [runtime_call] = runtime.calls
+    assert runtime_call["gateway_key"] == "bfck_fallback_test"
+    assert runtime_call["payload"] == {
+        "model": "gpt-5.1-codex",
+        "input": "fallback header",
+    }

--- a/api/tests/unit/routers/test_codex_gateway.py
+++ b/api/tests/unit/routers/test_codex_gateway.py
@@ -41,3 +41,20 @@ def test_v1_responses_uses_openai_compatible_bearer_key():
         "model": "gpt-5.1-codex",
         "input": "do not log me",
     }
+
+
+def test_v1_responses_rejects_non_object_payload_before_runtime():
+    app = FastAPI()
+    app.include_router(router)
+    runtime = FakeRuntime()
+    app.dependency_overrides[get_codex_gateway_runtime] = lambda: runtime
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/responses",
+        headers={"Authorization": "Bearer bfck_route_test"},
+        json=["not", "an", "object"],
+    )
+
+    assert 400 <= response.status_code < 500
+    assert runtime.calls == []

--- a/api/tests/unit/routers/test_codex_gateway.py
+++ b/api/tests/unit/routers/test_codex_gateway.py
@@ -1,0 +1,43 @@
+from asyncio import sleep
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.routers.codex_gateway import get_codex_gateway_runtime, router
+from src.services.codex_gateway.runtime import CodexGatewayResponse
+
+
+class FakeRuntime:
+    def __init__(self):
+        self.calls = []
+
+    async def create_response(self, **kwargs):
+        await sleep(0)
+        self.calls.append(kwargs)
+        return CodexGatewayResponse(
+            status_code=200,
+            body={"id": "resp_route_test", "output": []},
+        )
+
+
+def test_v1_responses_uses_openai_compatible_bearer_key():
+    app = FastAPI()
+    app.include_router(router)
+    runtime = FakeRuntime()
+    app.dependency_overrides[get_codex_gateway_runtime] = lambda: runtime
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/responses",
+        headers={"Authorization": "Bearer bfck_route_test"},
+        json={"model": "gpt-5.1-codex", "input": "do not log me"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "resp_route_test"
+    [runtime_call] = runtime.calls
+    assert runtime_call["gateway_key"] == "bfck_route_test"
+    assert runtime_call["payload"] == {
+        "model": "gpt-5.1-codex",
+        "input": "do not log me",
+    }

--- a/api/tests/unit/services/test_codex_gateway_runtime.py
+++ b/api/tests/unit/services/test_codex_gateway_runtime.py
@@ -28,6 +28,18 @@ class FakeUpstreamClient:
         )
 
 
+class FailingUpstreamClient:
+    async def create_response(self, *, access_token, payload):
+        await sleep(0)
+        raise RuntimeError("upstream failed")
+
+
+class SlowUpstreamClient:
+    async def create_response(self, *, access_token, payload):
+        await sleep(1)
+        return CodexGatewayUpstreamResponse(status_code=200, body={})
+
+
 def _key_record(*, allowed_models=None, denied_models=None):
     return SimpleNamespace(
         id=uuid4(),
@@ -206,7 +218,112 @@ async def test_denied_model_returns_structured_error_and_does_not_call_upstream(
     assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
 
 
+@pytest.mark.asyncio
+async def test_denied_model_list_blocks_request_and_logs_denial():
+    key = _key_record(denied_models=["gpt-4o"])
+    account = _account_record(key.user_id)
+    repository = _repository(key_record=key, account_record=account)
+    upstream = FakeUpstreamClient()
+    runtime = CodexGatewayRuntime(repository=repository, upstream_client=upstream)
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-4o"},
+    )
+
+    assert response.status_code == 403
+    assert response.body["error"]["code"] == "model_denied"
+    assert upstream.requests == []
+    repository.create_request_log.assert_called_once()
+    assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_decrypt_failure_returns_gateway_error_and_logs_denial(monkeypatch):
+    key = _key_record(allowed_models=["gpt-5.1-codex"])
+    account = _account_record(key.user_id)
+    repository = _repository(key_record=key, account_record=account)
+    monkeypatch.setattr(
+        "src.services.codex_gateway.runtime.decrypt_secret",
+        lambda encrypted: (_ for _ in ()).throw(ValueError("bad token")),
+    )
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=FakeUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-5.1-codex"},
+    )
+
+    assert response.status_code == 403
+    assert response.body["error"]["code"] == "upstream_token_unavailable"
+    repository.create_request_log.assert_called_once()
+    log_kwargs = repository.create_request_log.call_args.kwargs
+    assert log_kwargs["oauth_account_id"] == account.id
+    assert log_kwargs["policy_decision"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_upstream_failure_returns_gateway_error_and_logs_metadata(monkeypatch):
+    key = _key_record(allowed_models=["gpt-5.1-codex"])
+    account = _account_record(key.user_id)
+    repository = _repository(key_record=key, account_record=account)
+    monkeypatch.setattr(
+        "src.services.codex_gateway.runtime.decrypt_secret",
+        lambda encrypted: f"plain::{encrypted}",
+    )
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=FailingUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-5.1-codex"},
+    )
+
+    assert response.status_code == 502
+    assert response.body["error"]["code"] == "upstream_unavailable"
+    repository.create_request_log.assert_called_once()
+    log_kwargs = repository.create_request_log.call_args.kwargs
+    assert log_kwargs["provider_error_code"] == "upstream_unavailable"
+    assert log_kwargs["policy_decision"] == "allow"
+    assert isinstance(log_kwargs["latency_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_upstream_timeout_returns_gateway_error_and_logs_metadata(monkeypatch):
+    key = _key_record(allowed_models=["gpt-5.1-codex"])
+    account = _account_record(key.user_id)
+    repository = _repository(key_record=key, account_record=account)
+    monkeypatch.setattr(
+        "src.services.codex_gateway.runtime.CODEX_GATEWAY_UPSTREAM_TIMEOUT_SECONDS",
+        0.001,
+    )
+    monkeypatch.setattr(
+        "src.services.codex_gateway.runtime.decrypt_secret",
+        lambda encrypted: f"plain::{encrypted}",
+    )
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=SlowUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-5.1-codex"},
+    )
+
+    assert response.status_code == 504
+    assert response.body["error"]["code"] == "upstream_timeout"
+    repository.create_request_log.assert_called_once()
+    log_kwargs = repository.create_request_log.call_args.kwargs
+    assert log_kwargs["provider_error_code"] == "upstream_timeout"
+    assert log_kwargs["policy_decision"] == "allow"
+    assert isinstance(log_kwargs["latency_ms"], int)
+
+
 def test_extract_gateway_key_prefers_openai_compatible_bearer_auth():
     assert extract_gateway_key("Bearer bfck_test", None) == "bfck_test"
+    assert extract_gateway_key("bearer bfck_lower", None) == "bfck_lower"
     assert extract_gateway_key(None, "bfck_fallback") == "bfck_fallback"
     assert extract_gateway_key("Basic abc", None) is None

--- a/api/tests/unit/services/test_codex_gateway_runtime.py
+++ b/api/tests/unit/services/test_codex_gateway_runtime.py
@@ -107,7 +107,7 @@ async def test_allowed_response_uses_same_user_upstream_token_and_logs_metadata(
             "payload": {"model": "gpt-5.1-codex", "input": "do not log me"},
         }
     ]
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     log_kwargs = repository.create_request_log.call_args.kwargs
     assert log_kwargs["user_id"] == key.user_id
     assert log_kwargs["gateway_key_id"] == key.id
@@ -133,7 +133,7 @@ async def test_unknown_gateway_key_returns_openai_error_and_logs_denial():
 
     assert response.status_code == 401
     assert response.body["error"]["code"] == "invalid_gateway_key"
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
 
 
@@ -168,7 +168,7 @@ async def test_missing_upstream_account_fails_closed_and_logs_denial():
 
     assert response.status_code == 403
     assert response.body["error"]["code"] == "upstream_identity_not_connected"
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     log_kwargs = repository.create_request_log.call_args.kwargs
     assert log_kwargs["user_id"] == key.user_id
     assert log_kwargs["oauth_account_id"] is None
@@ -191,7 +191,7 @@ async def test_ambiguous_upstream_account_fails_closed_and_logs_denial():
 
     assert response.status_code == 403
     assert response.body["error"]["code"] == "upstream_identity_ambiguous"
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     log_kwargs = repository.create_request_log.call_args.kwargs
     assert log_kwargs["user_id"] == key.user_id
     assert log_kwargs["oauth_account_id"] is None
@@ -214,7 +214,7 @@ async def test_denied_model_returns_structured_error_and_does_not_call_upstream(
     assert response.status_code == 403
     assert response.body["error"]["code"] == "model_not_allowed"
     assert upstream.requests == []
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
 
 
@@ -234,7 +234,7 @@ async def test_denied_model_list_blocks_request_and_logs_denial():
     assert response.status_code == 403
     assert response.body["error"]["code"] == "model_denied"
     assert upstream.requests == []
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
 
 
@@ -258,7 +258,7 @@ async def test_decrypt_failure_returns_gateway_error_and_logs_denial(monkeypatch
 
     assert response.status_code == 403
     assert response.body["error"]["code"] == "upstream_token_unavailable"
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     log_kwargs = repository.create_request_log.call_args.kwargs
     assert log_kwargs["oauth_account_id"] == account.id
     assert log_kwargs["policy_decision"] == "deny"
@@ -284,7 +284,7 @@ async def test_upstream_failure_returns_gateway_error_and_logs_metadata(monkeypa
 
     assert response.status_code == 502
     assert response.body["error"]["code"] == "upstream_unavailable"
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     log_kwargs = repository.create_request_log.call_args.kwargs
     assert log_kwargs["provider_error_code"] == "upstream_unavailable"
     assert log_kwargs["policy_decision"] == "allow"
@@ -315,7 +315,7 @@ async def test_upstream_timeout_returns_gateway_error_and_logs_metadata(monkeypa
 
     assert response.status_code == 504
     assert response.body["error"]["code"] == "upstream_timeout"
-    repository.create_request_log.assert_called_once()
+    repository.create_request_log.assert_awaited_once()
     log_kwargs = repository.create_request_log.call_args.kwargs
     assert log_kwargs["provider_error_code"] == "upstream_timeout"
     assert log_kwargs["policy_decision"] == "allow"

--- a/api/tests/unit/services/test_codex_gateway_runtime.py
+++ b/api/tests/unit/services/test_codex_gateway_runtime.py
@@ -1,0 +1,212 @@
+from asyncio import sleep
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import MultipleResultsFound
+
+from src.services.codex_gateway.runtime import (
+    CodexGatewayRuntime,
+    CodexGatewayUpstreamResponse,
+    extract_gateway_key,
+)
+
+
+class FakeUpstreamClient:
+    def __init__(self):
+        self.requests = []
+
+    async def create_response(self, *, access_token, payload):
+        await sleep(0)
+        self.requests.append({"access_token": access_token, "payload": payload})
+        return CodexGatewayUpstreamResponse(
+            status_code=200,
+            body={"id": "resp_test", "model": payload["model"], "output": []},
+            input_token_count=12,
+            output_token_count=3,
+        )
+
+
+def _key_record(*, allowed_models=None, denied_models=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=uuid4(),
+        project_id=uuid4(),
+        name="developer workstation",
+        allowed_models=allowed_models or [],
+        denied_models=denied_models or [],
+        daily_limit=None,
+        monthly_limit=None,
+        status="active",
+        revoked_at=None,
+    )
+
+
+def _account_record(user_id):
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        upstream_subject="chatgpt-user-123",
+        upstream_email="dev@example.test",
+        upstream_workspace_id="workspace-midtown",
+        encrypted_access_token="encrypted-access-token",
+        access_token_expires_at=None,
+        last_refresh_at=None,
+        last_used_at=None,
+        revoked_at=None,
+    )
+
+
+def _repository(*, key_record, account_record):
+    repository = AsyncMock()
+    repository.get_active_gateway_key_by_plaintext.return_value = key_record
+    repository.get_active_upstream_account_for_user.return_value = account_record
+    repository.create_request_log = AsyncMock()
+    return repository
+
+
+@pytest.mark.asyncio
+async def test_allowed_response_uses_same_user_upstream_token_and_logs_metadata(
+    monkeypatch,
+):
+    key = _key_record(allowed_models=["gpt-5.1-codex"])
+    account = _account_record(key.user_id)
+    repository = _repository(key_record=key, account_record=account)
+    upstream = FakeUpstreamClient()
+    monkeypatch.setattr(
+        "src.services.codex_gateway.runtime.decrypt_secret",
+        lambda encrypted: f"plain::{encrypted}",
+    )
+    runtime = CodexGatewayRuntime(repository=repository, upstream_client=upstream)
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-5.1-codex", "input": "do not log me"},
+        source_ip="203.0.113.10",
+        client_user_agent="codex-cli",
+    )
+
+    assert response.status_code == 200
+    assert response.body["id"] == "resp_test"
+    assert upstream.requests == [
+        {
+            "access_token": "plain::encrypted-access-token",
+            "payload": {"model": "gpt-5.1-codex", "input": "do not log me"},
+        }
+    ]
+    repository.create_request_log.assert_called_once()
+    log_kwargs = repository.create_request_log.call_args.kwargs
+    assert log_kwargs["user_id"] == key.user_id
+    assert log_kwargs["gateway_key_id"] == key.id
+    assert log_kwargs["oauth_account_id"] == account.id
+    assert log_kwargs["policy_decision"] == "allow"
+    assert log_kwargs["request_metadata"]["client_type"] == "openai-compatible"
+    assert "input" not in log_kwargs["request_metadata"]
+    assert log_kwargs["input_token_count"] == 12
+    assert log_kwargs["output_token_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_unknown_gateway_key_returns_openai_error_and_logs_denial():
+    repository = _repository(key_record=None, account_record=None)
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=FakeUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="bfck_missing",
+        payload={"model": "gpt-5.1-codex"},
+    )
+
+    assert response.status_code == 401
+    assert response.body["error"]["code"] == "invalid_gateway_key"
+    repository.create_request_log.assert_called_once()
+    assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_gateway_key_authentication_happens_before_payload_validation():
+    repository = _repository(key_record=None, account_record=None)
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=FakeUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="bfck_missing",
+        payload={"input": "missing model"},
+    )
+
+    assert response.status_code == 401
+    assert response.body["error"]["code"] == "invalid_gateway_key"
+
+
+@pytest.mark.asyncio
+async def test_missing_upstream_account_fails_closed_and_logs_denial():
+    key = _key_record()
+    repository = _repository(key_record=key, account_record=None)
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=FakeUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-5.1-codex"},
+    )
+
+    assert response.status_code == 403
+    assert response.body["error"]["code"] == "upstream_identity_not_connected"
+    repository.create_request_log.assert_called_once()
+    log_kwargs = repository.create_request_log.call_args.kwargs
+    assert log_kwargs["user_id"] == key.user_id
+    assert log_kwargs["oauth_account_id"] is None
+    assert log_kwargs["policy_decision"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_upstream_account_fails_closed_and_logs_denial():
+    key = _key_record()
+    repository = _repository(key_record=key, account_record=None)
+    repository.get_active_upstream_account_for_user.side_effect = MultipleResultsFound()
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=FakeUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-5.1-codex"},
+    )
+
+    assert response.status_code == 403
+    assert response.body["error"]["code"] == "upstream_identity_ambiguous"
+    repository.create_request_log.assert_called_once()
+    log_kwargs = repository.create_request_log.call_args.kwargs
+    assert log_kwargs["user_id"] == key.user_id
+    assert log_kwargs["oauth_account_id"] is None
+    assert log_kwargs["policy_decision"] == "deny"
+
+
+@pytest.mark.asyncio
+async def test_denied_model_returns_structured_error_and_does_not_call_upstream():
+    key = _key_record(allowed_models=["gpt-5.1-codex"])
+    account = _account_record(key.user_id)
+    repository = _repository(key_record=key, account_record=account)
+    upstream = FakeUpstreamClient()
+    runtime = CodexGatewayRuntime(repository=repository, upstream_client=upstream)
+
+    response = await runtime.create_response(
+        gateway_key="bfck_test",
+        payload={"model": "gpt-4o"},
+    )
+
+    assert response.status_code == 403
+    assert response.body["error"]["code"] == "model_not_allowed"
+    assert upstream.requests == []
+    repository.create_request_log.assert_called_once()
+    assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
+
+
+def test_extract_gateway_key_prefers_openai_compatible_bearer_auth():
+    assert extract_gateway_key("Bearer bfck_test", None) == "bfck_test"
+    assert extract_gateway_key(None, "bfck_fallback") == "bfck_fallback"
+    assert extract_gateway_key("Basic abc", None) is None


### PR DESCRIPTION
## Summary
- add the authenticated `POST /v1/responses` facade route for the Bifrost Codex Gateway
- resolve downstream gateway keys to the same Bifrost user and that user's active ChatGPT/Codex upstream account
- enforce model allow/deny policy before dispatch and log metadata-only allow/deny request records
- keep upstream transport isolated behind a testable adapter, with the default returning `upstream_not_configured` until the subscription-backed backend is pinned down

Refs #226

## Verification
- `python -m pytest tests/unit/services/test_codex_gateway_runtime.py tests/unit/repositories/test_codex_gateway_repository.py tests/unit/services/test_codex_gateway_policy.py -q`
- `python -m ruff check src/services/codex_gateway/runtime.py src/routers/codex_gateway.py tests/unit/services/test_codex_gateway_runtime.py tests/unit/routers/test_codex_gateway.py`
- `ssh codex-vm-netbird 'cd /home/dev/.config/superpowers/worktrees/bifrost/codex-gateway-responses-20260522 && ./test.sh tests/unit/services/test_codex_gateway_runtime.py tests/unit/routers/test_codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py tests/unit/services/test_codex_gateway_policy.py -q'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI-compatible POST /v1/responses endpoint with Bearer and legacy-key header support.
  * Requests are validated, authorized against policy, and forwarded to upstream providers with mapped error responses.
  * Detailed audit logging records request metadata and token usage for compliance.

* **Tests**
  * Added comprehensive unit tests covering auth extraction, payload validation, policy decisions, upstream success/failure, timeouts, and logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->