### PR TITLE
Secure bundled SeaweedFS S3 service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,9 @@ jobs:
         run: |
           chmod +x test.sh
           ./test.sh stack up
-          ./test.sh unit
+          ./test.sh unit --cov=. --cov-report=xml:/coverage/coverage.xml
+          docker compose -f docker-compose.test.yml --profile test run --rm test-runner \
+            sh -lc 'cat /coverage/coverage.xml' > coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1

--- a/api/tests/unit/test_docker_compose_security.py
+++ b/api/tests/unit/test_docker_compose_security.py
@@ -1,25 +1,29 @@
 """Security invariants for the production Docker Compose stack."""
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 
 def _compose_path() -> Path:
+    """Find the mounted production Docker Compose file."""
     for parent in Path(__file__).resolve().parents:
         candidate = parent / "docker-compose.yml"
         if candidate.exists():
             return candidate
 
-    raise FileNotFoundError("docker-compose.yml was not mounted for compose security tests")
+    msg = "docker-compose.yml was not mounted for compose security tests"
+    raise FileNotFoundError(msg)
 
 
-def _load_compose() -> dict:
+def _load_compose() -> dict[str, Any]:
+    """Load the production Docker Compose model."""
     with _compose_path().open(encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
-def test_seaweedfs_s3_api_is_not_published_to_host():
+def test_seaweedfs_s3_api_is_not_published_to_host() -> None:
     """The bundled object store is internal-only in the production stack."""
     seaweedfs = _load_compose()["services"]["seaweedfs"]
 
@@ -27,7 +31,7 @@ def test_seaweedfs_s3_api_is_not_published_to_host():
     assert seaweedfs["expose"] == ["8333"]
 
 
-def test_seaweedfs_uses_explicit_s3_identity_config():
+def test_seaweedfs_uses_explicit_s3_identity_config() -> None:
     """SeaweedFS must not rely on unauthenticated S3 defaults."""
     seaweedfs = _load_compose()["services"]["seaweedfs"]
     command = seaweedfs["command"]

--- a/api/tests/unit/test_docker_compose_security.py
+++ b/api/tests/unit/test_docker_compose_security.py
@@ -1,0 +1,35 @@
+"""Security invariants for the production Docker Compose stack."""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_compose() -> dict:
+    with (REPO_ROOT / "docker-compose.yml").open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def test_seaweedfs_s3_api_is_not_published_to_host():
+    """The bundled object store is internal-only in the production stack."""
+    seaweedfs = _load_compose()["services"]["seaweedfs"]
+
+    assert "ports" not in seaweedfs
+    assert seaweedfs["expose"] == ["8333"]
+
+
+def test_seaweedfs_uses_explicit_s3_identity_config():
+    """SeaweedFS must not rely on unauthenticated S3 defaults."""
+    seaweedfs = _load_compose()["services"]["seaweedfs"]
+    command = seaweedfs["command"]
+
+    assert seaweedfs["entrypoint"] == ["/bin/sh", "-ec"]
+    assert "seaweedfs-s3.json" in command
+    assert '"identities"' in command
+    assert '"credentials"' in command
+    assert "$${AWS_ACCESS_KEY_ID}" in command
+    assert "$${AWS_SECRET_ACCESS_KEY}" in command
+    assert "-s3.config=/tmp/seaweedfs-s3.json" in command

--- a/api/tests/unit/test_docker_compose_security.py
+++ b/api/tests/unit/test_docker_compose_security.py
@@ -5,11 +5,17 @@ from pathlib import Path
 import yaml
 
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+def _compose_path() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "docker-compose.yml"
+        if candidate.exists():
+            return candidate
+
+    raise FileNotFoundError("docker-compose.yml was not mounted for compose security tests")
 
 
 def _load_compose() -> dict:
-    with (REPO_ROOT / "docker-compose.yml").open(encoding="utf-8") as f:
+    with _compose_path().open(encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -323,6 +323,7 @@ services:
       - ./api/alembic.ini:/app/alembic.ini:ro
       - ./api/pytest.ini:/app/pytest.ini:ro
       - ./api/pyproject.toml:/app/pyproject.toml:ro
+      - ./docker-compose.yml:/app/docker-compose.yml:ro
       - ./client/src:/client/src:ro  # Read-only — the drift test in
                                       # tests/unit/test_platform_names_match_runtime.py
                                       # parses app-code-runtime.ts to detect new platform exports.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,30 @@ services:
       AWS_ACCESS_KEY_ID: ${SEAWEEDFS_ACCESS_KEY:-bifrost}
       AWS_SECRET_ACCESS_KEY: ${SEAWEEDFS_SECRET_KEY:?SEAWEEDFS_SECRET_KEY is required}
       S3_BUCKET: ${BIFROST_S3_BUCKET:-bifrost-local}
-    ports:
-      - "8333:8333"
+    entrypoint: ["/bin/sh", "-ec"]
+    command: |
+      cat > /tmp/seaweedfs-s3.json <<EOF
+      {
+        "identities": [
+          {
+            "name": "bifrost",
+            "credentials": [
+              {
+                "accessKey": "$${AWS_ACCESS_KEY_ID}",
+                "secretKey": "$${AWS_SECRET_ACCESS_KEY}"
+              }
+            ],
+            "actions": ["Admin", "Read", "List", "Tagging", "Write"]
+          }
+        ]
+      }
+      EOF
+      exec weed mini -dir=/data -s3.config=/tmp/seaweedfs-s3.json
+    # Do not publish the S3 API in the production stack. Bifrost services use
+    # the internal Docker DNS endpoint (http://seaweedfs:8333); expose it only
+    # in a local override when an operator explicitly needs host access.
+    expose:
+      - "8333"
     volumes:
       - seaweedfs_data:/data
 


### PR DESCRIPTION
## Summary
- stop publishing the bundled SeaweedFS S3 API from the production compose stack
- generate an explicit SeaweedFS S3 identity config from required container secrets
- add compose security regressions for host exposure and explicit S3 auth config

## Verification
- uv run python -m pytest api/tests/unit/test_docker_compose_security.py api/tests/unit/core/test_module_cache.py -q
- uv run ruff check api/tests/unit/test_docker_compose_security.py
- docker compose -f docker-compose.yml config --quiet with dummy required secrets
- docker run --rm chrislusf/seaweedfs:latest mini -h confirmed `-s3.config` is supported
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to validate SeaweedFS and Docker Compose configuration.

* **Chores**
  * Updated SeaweedFS service to restrict port exposure to the internal Docker network.
  * Modified S3 configuration to be explicitly set during container startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->