### PR TITLE
Reject stale app source on create

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,7 @@ jobs:
           chmod +x test.sh
           ./test.sh stack up
           ./test.sh unit --cov=. --cov-report=xml:/coverage/coverage.xml
-          docker compose -f docker-compose.test.yml --profile test run --rm test-runner \
-            sh -lc 'cat /coverage/coverage.xml' > coverage.xml
+          ./test.sh coverage coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1

--- a/api/src/core/app_scaffold.py
+++ b/api/src/core/app_scaffold.py
@@ -1,0 +1,24 @@
+"""Canonical source templates for newly created Bifrost apps."""
+
+APP_LAYOUT_SOURCE = '''import { Outlet } from "bifrost";
+
+export default function RootLayout() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Outlet />
+    </div>
+  );
+}
+'''
+
+APP_INDEX_SOURCE = '''export default function HomePage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Welcome</h1>
+      <p className="text-muted-foreground">
+        Start building your app by editing this page or adding new files.
+      </p>
+    </div>
+  );
+}
+'''

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -47,6 +47,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/applications", tags=["Applications"])
 
 
+def stale_app_source_error(slug: str) -> str:
+    """Return the app-create error used when an unclaimed source prefix exists."""
+    return (
+        f"Source files already exist under apps/{slug}/. "
+        "Create with a different slug, replace the app source after creation, "
+        "or remove the orphaned source explicitly before creating this app."
+    )
+
+
+async def ensure_no_stale_app_source(session, slug: str) -> None:
+    """Reject app creation when files already exist for an unclaimed slug."""
+    from src.models.orm.file_index import FileIndex
+
+    prefix = f"apps/{slug}/"
+    existing = await session.execute(
+        select(FileIndex.path).where(FileIndex.path.startswith(prefix)).limit(1)
+    )
+    if existing.first() is not None:
+        raise ValueError(stale_app_source_error(slug))
+
+
 class AppValidationIssue(BaseModel):
     severity: str  # "error" or "warning"
     file: str
@@ -200,6 +221,8 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         existing = await self.get_by_slug_global(data.slug)
         if existing:
             raise ValueError(f"Application with slug '{data.slug}' already exists")
+
+        await ensure_no_stale_app_source(self.session, data.slug)
 
         application = Application(
             name=data.name,
@@ -459,24 +482,8 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         Creates:
         - _layout.tsx: Root layout wrapper
         - pages/index.tsx: Home page
-
-        Skipped entirely if any file already exists under apps/{slug}/ — the
-        caller (e.g. `bifrost apps create` against a slug whose source dir
-        was authored locally first) is not expected to lose their work to
-        the default Welcome scaffold.
         """
-        from src.models.orm.file_index import FileIndex
         from src.services.file_storage import FileStorageService
-
-        prefix = f"apps/{slug}/"
-        existing = await self.session.execute(
-            select(FileIndex.path).where(FileIndex.path.startswith(prefix)).limit(1)
-        )
-        if existing.first() is not None:
-            logger.info(
-                f"Skipped scaffold for app {log_safe(slug)}: files already exist at {log_safe(prefix)}"
-            )
-            return
 
         file_storage = FileStorageService(self.session)
 

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -21,8 +21,11 @@ from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.auth import Context, CurrentUser
+from src.core.app_scaffold import APP_INDEX_SOURCE, APP_LAYOUT_SOURCE
+from src.core.exceptions import AccessDeniedError
 from src.core.log_safety import log_safe
 from src.core.org_filter import OrgFilterType, resolve_org_filter
 from src.core.pubsub import publish_app_draft_update, publish_app_published
@@ -39,7 +42,6 @@ from src.models.contracts.applications import (
 )
 from src.models.orm.app_roles import AppRole
 from src.models.orm.applications import Application
-from src.core.exceptions import AccessDeniedError
 from src.repositories.org_scoped import OrgScopedRepository
 
 logger = logging.getLogger(__name__)
@@ -56,7 +58,7 @@ def stale_app_source_error(slug: str) -> str:
     )
 
 
-async def ensure_no_stale_app_source(session, slug: str) -> None:
+async def ensure_no_stale_app_source(session: AsyncSession, slug: str) -> None:
     """Reject app creation when files already exist for an unclaimed slug."""
     from src.models.orm.file_index import FileIndex
 
@@ -487,36 +489,15 @@ class ApplicationRepository(OrgScopedRepository[Application]):
 
         file_storage = FileStorageService(self.session)
 
-        layout_source = '''import { Outlet } from "bifrost";
-
-export default function RootLayout() {
-  return (
-    <div className="min-h-screen bg-background">
-      <Outlet />
-    </div>
-  );
-}
-'''
         await file_storage.write_file(
             path=f"apps/{slug}/_layout.tsx",
-            content=layout_source.encode("utf-8"),
+            content=APP_LAYOUT_SOURCE.encode("utf-8"),
             updated_by="system",
         )
 
-        index_source = '''export default function HomePage() {
-  return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold mb-4">Welcome</h1>
-      <p className="text-muted-foreground">
-        Start building your app by editing this page or adding new files.
-      </p>
-    </div>
-  );
-}
-'''
         await file_storage.write_file(
             path=f"apps/{slug}/pages/index.tsx",
-            content=index_source.encode("utf-8"),
+            content=APP_INDEX_SOURCE.encode("utf-8"),
             updated_by="system",
         )
 

--- a/api/src/services/mcp_server/tools/apps.py
+++ b/api/src/services/mcp_server/tools/apps.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from fastmcp.tools import ToolResult
 
+from src.core.app_scaffold import APP_INDEX_SOURCE, APP_LAYOUT_SOURCE
 from src.core.pubsub import publish_app_draft_update, publish_app_published
 from src.services.mcp_server.tool_result import error_result, success_result
 from src.services.mcp_server.tools._http_bridge import call_rest
@@ -157,35 +158,14 @@ async def create_app(
             scaffolded = 0
             file_storage = FileStorageService(db)
 
-            layout_source = '''import { Outlet } from "bifrost";
-
-export default function RootLayout() {
-  return (
-    <div className="min-h-screen bg-background">
-      <Outlet />
-    </div>
-  );
-}
-'''
-            index_source = '''export default function HomePage() {
-  return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold mb-4">Welcome</h1>
-      <p className="text-muted-foreground">
-        Start building your app by editing this page or adding new files.
-      </p>
-    </div>
-  );
-}
-'''
             await file_storage.write_file(
                 path=f"apps/{slug}/_layout.tsx",
-                content=layout_source.encode("utf-8"),
+                content=APP_LAYOUT_SOURCE.encode("utf-8"),
                 updated_by="system",
             )
             await file_storage.write_file(
                 path=f"apps/{slug}/pages/index.tsx",
-                content=index_source.encode("utf-8"),
+                content=APP_INDEX_SOURCE.encode("utf-8"),
                 updated_by="system",
             )
             scaffolded = 2

--- a/api/src/services/mcp_server/tools/apps.py
+++ b/api/src/services/mcp_server/tools/apps.py
@@ -98,6 +98,7 @@ async def create_app(
     from sqlalchemy import select
 
     from src.models.orm.applications import Application
+    from src.routers.applications import ensure_no_stale_app_source
     from src.services.file_storage import FileStorageService
 
     logger.info(f"MCP create_app called with name={name}, scope={scope}")
@@ -133,6 +134,11 @@ async def create_app(
             if existing.scalar_one_or_none():
                 return error_result(f"Application with slug '{slug}' already exists")
 
+            try:
+                await ensure_no_stale_app_source(db, slug)
+            except ValueError as exc:
+                return error_result(str(exc))
+
             app = Application(
                 id=uuid4(),
                 name=name,
@@ -145,21 +151,13 @@ async def create_app(
             db.add(app)
             await db.flush()
 
-            # Write scaffold files via FileStorageService — but only if no
-            # files already exist under apps/{slug}/. Authors who created
-            # the source dir locally first should not lose their work to
-            # the default Welcome scaffold.
-            from src.models.orm.file_index import FileIndex
-
-            prefix = f"apps/{slug}/"
-            existing_files = await db.execute(
-                select(FileIndex.path).where(FileIndex.path.startswith(prefix)).limit(1)
-            )
+            # Write scaffold files via FileStorageService. Creation rejects
+            # pre-existing unclaimed source, so these defaults cannot adopt
+            # orphaned code from a deleted app with the same slug.
             scaffolded = 0
-            if existing_files.first() is None:
-                file_storage = FileStorageService(db)
+            file_storage = FileStorageService(db)
 
-                layout_source = '''import { Outlet } from "bifrost";
+            layout_source = '''import { Outlet } from "bifrost";
 
 export default function RootLayout() {
   return (
@@ -169,7 +167,7 @@ export default function RootLayout() {
   );
 }
 '''
-                index_source = '''export default function HomePage() {
+            index_source = '''export default function HomePage() {
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-4">Welcome</h1>
@@ -180,17 +178,17 @@ export default function RootLayout() {
   );
 }
 '''
-                await file_storage.write_file(
-                    path=f"apps/{slug}/_layout.tsx",
-                    content=layout_source.encode("utf-8"),
-                    updated_by="system",
-                )
-                await file_storage.write_file(
-                    path=f"apps/{slug}/pages/index.tsx",
-                    content=index_source.encode("utf-8"),
-                    updated_by="system",
-                )
-                scaffolded = 2
+            await file_storage.write_file(
+                path=f"apps/{slug}/_layout.tsx",
+                content=layout_source.encode("utf-8"),
+                updated_by="system",
+            )
+            await file_storage.write_file(
+                path=f"apps/{slug}/pages/index.tsx",
+                content=index_source.encode("utf-8"),
+                updated_by="system",
+            )
+            scaffolded = 2
 
             await db.commit()
 

--- a/api/tests/e2e/api/test_applications.py
+++ b/api/tests/e2e/api/test_applications.py
@@ -698,15 +698,14 @@ class TestCodeEngineApps:
         # Cleanup
         _delete_app(e2e_client, platform_admin.headers, app["id"])
 
-    def test_app_create_preserves_existing_local_files(self, e2e_client, platform_admin):
-        """Creating an app whose source dir already has files must NOT clobber them with the default scaffold.
+    def test_app_create_rejects_unclaimed_existing_local_files(self, e2e_client, platform_admin):
+        """Creating an app whose source dir already has files must not adopt them.
 
         Repro: author writes apps/<slug>/_layout.tsx locally, pushes to S3,
-        then runs `bifrost apps create --slug <slug>`. The user-authored
-        layout must survive — losing it to the default Welcome scaffold is
-        the bug this guards against.
+        then runs `bifrost apps create --slug <slug>`. Creating the app must
+        reject the unclaimed source prefix instead of silently adopting it.
         """
-        slug = "preserve-local-source"
+        slug = f"reject-local-source-{uuid.uuid4().hex[:8]}"
 
         # Pre-stage a user-authored file at apps/<slug>/_layout.tsx,
         # mimicking a `bifrost watch` push that ran before `apps create`.
@@ -732,27 +731,10 @@ class TestCodeEngineApps:
             response = e2e_client.post(
                 "/api/applications",
                 headers=platform_admin.headers,
-                json={"name": "Preserve Local Source", "slug": slug},
+                json={"name": "Reject Local Source", "slug": slug},
             )
-            assert response.status_code == 201, f"Create app failed: {response.text}"
-            app = response.json()
-
-            files_response = e2e_client.get(
-                f"/api/applications/{app['id']}/files",
-                headers=platform_admin.headers,
-            )
-            assert files_response.status_code == 200
-            files_by_path = {f["path"]: f for f in files_response.json()["files"]}
-
-            assert "_layout.tsx" in files_by_path, "Pre-staged _layout.tsx missing after create"
-            assert 'data-test="user-authored"' in files_by_path["_layout.tsx"]["source"], (
-                "Default scaffold clobbered the pre-staged user-authored _layout.tsx"
-            )
-            assert "pages/index.tsx" not in files_by_path, (
-                "Scaffold should be skipped entirely when prefix is non-empty"
-            )
-
-            _delete_app(e2e_client, platform_admin.headers, app["id"])
+            assert response.status_code == 409
+            assert "Source files already exist" in response.text
         finally:
             e2e_client.post(
                 "/api/files/delete",
@@ -763,3 +745,18 @@ class TestCodeEngineApps:
                     "mode": "cloud",
                 },
             )
+
+    def test_delete_recreate_same_slug_rejects_stale_source(self, e2e_client, platform_admin):
+        """Deleting an app record must not let the next app adopt its old files."""
+        slug = f"stale-source-{uuid.uuid4().hex[:8]}"
+        app = _create_app(e2e_client, platform_admin.headers, slug, name="Stale Source")
+        _delete_app(e2e_client, platform_admin.headers, app["id"])
+
+        response = e2e_client.post(
+            "/api/applications",
+            headers=platform_admin.headers,
+            json={"name": "Stale Source Recreated", "slug": slug},
+        )
+
+        assert response.status_code == 409
+        assert "Source files already exist" in response.text

--- a/api/tests/unit/services/mcp_server/test_tool_implementations.py
+++ b/api/tests/unit/services/mcp_server/test_tool_implementations.py
@@ -166,7 +166,8 @@ class _CreateAppDb:
         self.flushed = True
 
     async def commit(self):
-        pass
+        # Intentionally no-op: the fake only records whether create_app reaches commit.
+        return None
 
 
 class TestAppToolImpl:

--- a/api/tests/unit/services/mcp_server/test_tool_implementations.py
+++ b/api/tests/unit/services/mcp_server/test_tool_implementations.py
@@ -5,7 +5,9 @@ Tests the actual tool implementation functions that handle
 workflow validation, execution tracking, and knowledge search.
 """
 
+from contextlib import asynccontextmanager
 from uuid import uuid4
+from unittest.mock import patch
 
 import pytest
 from fastmcp.tools import ToolResult
@@ -121,6 +123,72 @@ class TestValidateWorkflowImpl:
         text = get_content_text(result)
         assert text is not None
         assert "Error" in text or "error" in text.lower()
+
+
+# ==================== App Tool Tests ====================
+
+
+class _ScalarOneResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FirstResult:
+    def __init__(self, value):
+        self._value = value
+
+    def first(self):
+        return self._value
+
+
+class _CreateAppDb:
+    def __init__(self, *, stale_source: bool):
+        self._stale_source = stale_source
+        self.execute_calls = 0
+        self.added = []
+        self.flushed = False
+
+    async def execute(self, _stmt):
+        self.execute_calls += 1
+        if self.execute_calls == 1:
+            return _ScalarOneResult(None)
+        if self.execute_calls == 2:
+            return _FirstResult(("apps/stale-mcp/_layout.tsx",) if self._stale_source else None)
+        raise AssertionError(f"unexpected execute call {self.execute_calls}")
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        self.flushed = True
+
+    async def commit(self):
+        pass
+
+
+class TestAppToolImpl:
+    @pytest.mark.asyncio
+    async def test_create_app_rejects_unclaimed_existing_source(self, context):
+        """MCP app creation must not adopt stale source under apps/<slug>/."""
+        from src.services.mcp_server.tools.apps import create_app
+
+        db = _CreateAppDb(stale_source=True)
+
+        @asynccontextmanager
+        async def fake_get_tool_db(_context):
+            yield db
+
+        with patch("src.services.mcp_server.tools.apps.get_tool_db", fake_get_tool_db):
+            result = await create_app(context, "Stale MCP", slug="stale-mcp")
+
+        assert is_error_result(result)
+        assert result.structured_content is not None
+        assert "Source files already exist" in result.structured_content["error"]
+        assert db.added == []
+        assert db.flushed is False
 
 
 # ==================== Get Workflow Tool Tests ====================

--- a/test.sh
+++ b/test.sh
@@ -239,6 +239,11 @@ run_pytest() {
 }
 
 cmd_unit() { run_pytest tests/ --ignore=tests/e2e/ -v "$@"; }
+cmd_coverage() {
+    local target="${1:-coverage.xml}"
+    docker compose -f "$COMPOSE_FILE" --profile test run --rm test-runner \
+        sh -lc 'cat /coverage/coverage.xml' > "$target"
+}
 cmd_e2e_smoke() {
     run_pytest \
         tests/e2e/api/test_auth.py::TestHealthCheck \
@@ -353,6 +358,7 @@ fi
 case "$1" in
     stack) shift; cmd_stack "$@" ;;
     unit) shift; cmd_unit "$@" ;;
+    coverage) shift; cmd_coverage "$@" ;;
     e2e-smoke) shift; cmd_e2e_smoke "$@" ;;
     e2e) shift; cmd_e2e "$@" ;;
     all) shift; cmd_all "$@" ;;


### PR DESCRIPTION
## Summary
- reject app creation when unclaimed source already exists under apps/{slug}/
- apply the same guard to MCP create_app
- add regression coverage for stale/orphaned app source adoption

## Tests
- uv run python -m pytest api/tests/unit/services/mcp_server/test_tool_implementations.py::TestAppToolImpl::test_create_app_rejects_unclaimed_existing_source -q
- uv run python -m pytest api/tests/unit/routers/test_codex_gateway.py api/tests/unit/services/test_codex_gateway_runtime.py api/tests/unit/repositories/test_codex_gateway_repository.py api/tests/unit/services/mcp_server/test_tool_implementations.py::TestAppToolImpl::test_create_app_rejects_unclaimed_existing_source api/tests/unit/cli/test_import_security.py api/tests/unit/test_cli_skill.py api/tests/unit/test_credentials.py api/tests/unit/cli/test_cli_version_check.py api/tests/unit/sdk/test_client_injection.py -q
- uv run ruff check <touched backend files>
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application creation now validates that no source files already exist at the target location before proceeding, preventing stale or unclaimed files from being unintentionally adopted during initial app creation or subsequent app recreation with the same application name. Returns a 409 Conflict error with helpful guidance when this condition is detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->