### PR TITLE
Harden CLI import and skill inputs

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -149,16 +149,9 @@ def _check_cli_version() -> None:
         if installed in ("unknown", "0.0.0+source"):
             return  # dev/source install — nothing to compare against
 
-        # Re-load dotenv so a CWD-local .env's BIFROST_API_URL is honored even
-        # if bifrost.client's import-time load happened against a different cwd.
-        try:
-            from dotenv import find_dotenv, load_dotenv
-
-            dotenv_path = find_dotenv(usecwd=True)
-            if dotenv_path:
-                load_dotenv(dotenv_path, override=True)
-        except ImportError:
-            pass  # python-dotenv is optional; without it, only os.environ is consulted
+        # Re-load only the safe CWD-local .env allowlist so BIFROST_API_URL is
+        # honored even if bifrost.client imported against a different cwd.
+        credentials.load_allowed_dotenv()
 
         # Use credentials._resolve_url (not get_credentials) because the version
         # check only needs the URL — get_credentials returns None unless full
@@ -172,7 +165,7 @@ def _check_cli_version() -> None:
         # bifrost.gocovi.com being the live case) 403 the default
         # `Python-urllib/X.Y` User-Agent. httpx's default UA gets through
         # and matches what every other SDK request already sends.
-        resp = httpx.get(f"{api_url}/api/version", timeout=3)
+        resp = httpx.get(f"{api_url}/api/version", timeout=3, trust_env=False)
         resp.raise_for_status()
         data = resp.json()
 

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -24,6 +24,7 @@ from .credentials import (
     clear_credentials,
     get_credentials,
     is_token_expired,
+    load_allowed_dotenv,
     save_credentials,
 )
 
@@ -123,16 +124,11 @@ def raise_for_status_with_detail(response: httpx.Response) -> None:
 # and httpx.AsyncClient is bound to the event loop that created it.
 _thread_local = threading.local()
 
-# Auto-load .env file if present (for local development).
+# Auto-load only the CLI-safe .env allowlist if present (for local development).
 # Walk upward from cwd, not from this file. With pipx-installed CLIs, __file__
 # lives in the pipx venv and the default upward walk never reaches the user's
 # workspace, so a .env in the project root is silently ignored.
-try:
-    from dotenv import find_dotenv, load_dotenv
-
-    load_dotenv(find_dotenv(usecwd=True))
-except ImportError:
-    pass  # dotenv not installed, rely on environment variables
+load_allowed_dotenv()
 
 
 async def refresh_tokens() -> bool:
@@ -153,7 +149,9 @@ async def refresh_tokens() -> bool:
     refresh_token = creds["refresh_token"]
 
     try:
-        async with httpx.AsyncClient(base_url=api_url, timeout=30.0) as client:
+        async with httpx.AsyncClient(
+            base_url=api_url, timeout=30.0, trust_env=False
+        ) as client:
             response = await client.post(
                 "/auth/refresh",
                 json={"refresh_token": refresh_token}
@@ -204,7 +202,9 @@ async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool
     api_url = api_url.rstrip("/")
 
     try:
-        async with httpx.AsyncClient(base_url=api_url, timeout=30.0) as client:
+        async with httpx.AsyncClient(
+            base_url=api_url, timeout=30.0, trust_env=False
+        ) as client:
             # Step 1: Request device code
             response = await client.post("/auth/device/code")
             if response.status_code != 200:
@@ -346,6 +346,7 @@ class BifrostClient:
             base_url=self.api_url,
             headers={"Authorization": f"Bearer {access_token}"},
             timeout=30.0,
+            trust_env=False,
         )
         self._context: dict[str, Any] | None = None
 
@@ -374,6 +375,7 @@ class BifrostClient:
                 base_url=self.api_url,
                 headers={"Authorization": f"Bearer {self._access_token}"},
                 timeout=30.0,
+                trust_env=False,
             )
             self._http_loop = current_loop
 

--- a/api/bifrost/commands/import_cmd.py
+++ b/api/bifrost/commands/import_cmd.py
@@ -47,10 +47,14 @@ def _validate_bundle_dir(bundle_dir: pathlib.Path) -> pathlib.Path:
     """
     if not bundle_dir.exists():
         raise click.ClickException(f"bundle directory does not exist: {bundle_dir}")
+    if bundle_dir.is_symlink():
+        raise click.ClickException(f"bundle directory must not be a symlink: {bundle_dir}")
     if not bundle_dir.is_dir():
         raise click.ClickException(f"bundle path is not a directory: {bundle_dir}")
 
     bifrost_dir = bundle_dir / ".bifrost"
+    if bifrost_dir.is_symlink():
+        raise click.ClickException(f"bundle .bifrost/ must not be a symlink: {bifrost_dir}")
     if not bifrost_dir.is_dir():
         raise click.ClickException(
             f"bundle directory missing .bifrost/ subdirectory: {bundle_dir}"
@@ -119,6 +123,8 @@ def _read_manifest_files(
     """
     out: dict[str, str] = {}
     for yaml_path in sorted(bifrost_dir.glob("*.yaml")):
+        if yaml_path.is_symlink():
+            raise click.ClickException(f"bundle manifest file must not be a symlink: {yaml_path}")
         if drop_cross_env_seeds and yaml_path.name in _CROSS_ENV_DROPPED_FILES:
             continue
         raw = yaml_path.read_bytes()
@@ -138,9 +144,13 @@ def _collect_code_files(bundle_dir: pathlib.Path) -> dict[str, str]:
     skip_parts = {"__pycache__", "node_modules", ".venv", ".git"}
     for top in _CODE_DIRS:
         root = bundle_dir / top
+        if root.is_symlink():
+            raise click.ClickException(f"bundle code directory must not be a symlink: {root}")
         if not root.is_dir():
             continue
         for path in sorted(root.rglob("*")):
+            if path.is_symlink():
+                raise click.ClickException(f"bundle code path must not be a symlink: {path}")
             if path.is_dir():
                 continue
             if any(part in skip_parts for part in path.parts):

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Protocol
 
 KEYRING_SERVICE = "bifrost"
+_DOTENV_ALLOWED_KEYS: frozenset[str] = frozenset({"BIFROST_API_URL"})
 
 
 # --------------------------------------------------------------------------- #
@@ -63,6 +64,31 @@ def get_config_dir() -> Path:
 
 def get_credentials_path() -> Path:
     return get_config_dir() / "credentials.json"
+
+
+def load_allowed_dotenv(
+    dotenv_path: str | os.PathLike[str] | None = None, *, override: bool = True
+) -> None:
+    """Load the CWD ``.env`` allowlist used by the CLI.
+
+    The CLI still supports project-local ``BIFROST_API_URL`` discovery, but it
+    must not import credentials, proxy settings, CA bundle paths, or other
+    security-sensitive process environment from an attacker-controlled CWD.
+    """
+    try:
+        from dotenv import dotenv_values, find_dotenv
+    except ImportError:
+        return
+
+    path = str(dotenv_path) if dotenv_path is not None else find_dotenv(usecwd=True)
+    if not path:
+        return
+
+    for key, value in dotenv_values(path).items():
+        if key not in _DOTENV_ALLOWED_KEYS or value is None:
+            continue
+        if override or key not in os.environ:
+            os.environ[key] = value
 
 
 # --------------------------------------------------------------------------- #

--- a/api/bifrost/skill.py
+++ b/api/bifrost/skill.py
@@ -34,6 +34,46 @@ _DEFAULT_REPO = "jackmusick/bifrost"
 _DEFAULT_REF = "main"
 
 
+def _is_unsafe_path_part(value: str) -> bool:
+    return (
+        not value
+        or value in {".", ".."}
+        or "\\" in value
+        or PurePosixPath(value).is_absolute()
+        or Path(value).drive != ""
+    )
+
+
+def _validate_skill_name(name: str) -> str:
+    """Return a safe single-directory skill name."""
+    if _is_unsafe_path_part(name) or "/" in name:
+        raise ValueError(f"unsafe skill name in tarball: {name!r}")
+    return name
+
+
+def _validate_skill_relpath(relpath: str) -> str:
+    """Return a normalized safe path under ``.claude/skills/``."""
+    if "\\" in relpath or PurePosixPath(relpath).is_absolute() or Path(relpath).drive:
+        raise ValueError(f"unsafe skill path in tarball: {relpath!r}")
+    parts = PurePosixPath(relpath).parts
+    if not parts or any(_is_unsafe_path_part(part) for part in parts):
+        raise ValueError(f"unsafe skill path in tarball: {relpath!r}")
+    return PurePosixPath(*parts).as_posix()
+
+
+def _safe_skill_target(root: Path, skill_name: str) -> Path:
+    """Build a skill target path and prove it stays below ``root``."""
+    safe_name = _validate_skill_name(skill_name)
+    target = root / safe_name
+    if target.exists() and target.is_symlink():
+        raise ValueError(f"refusing to replace symlinked skill directory: {target}")
+    root_resolved = root.resolve(strict=False)
+    target_resolved = target.resolve(strict=False)
+    if target_resolved != root_resolved and root_resolved not in target_resolved.parents:
+        raise ValueError(f"unsafe skill install target: {skill_name!r}")
+    return target
+
+
 def _print_help() -> None:
     print("""
 Usage: bifrost skill <subcommand> [options]
@@ -171,7 +211,7 @@ def _handle_update(args: list[str]) -> int:
         print(f"Error fetching tarball: {exc}", file=sys.stderr)
         return 1
 
-    targets = sorted({path.split("/", 1)[0] for path in skill_files})
+    targets = sorted({_validate_skill_name(path.split("/", 1)[0]) for path in skill_files})
     if not targets:
         print(
             f"No .claude/skills/ entries found in {repo}@{ref}.", file=sys.stderr
@@ -179,8 +219,12 @@ def _handle_update(args: list[str]) -> int:
         return 1
 
     for skill_name in targets:
-        claude_target = claude_dir / skill_name
-        agents_target = agents_dir / skill_name
+        try:
+            claude_target = _safe_skill_target(claude_dir, skill_name)
+            agents_target = _safe_skill_target(agents_dir, skill_name)
+        except ValueError as exc:
+            print(f"Error installing skills: {exc}", file=sys.stderr)
+            return 1
         files_for_skill = {
             relpath: contents
             for relpath, contents in skill_files.items()
@@ -214,10 +258,10 @@ def _fetch_skill_files(repo: str, ref: str) -> dict[str, bytes]:
     """
     url = f"https://codeload.github.com/{repo}/tar.gz/refs/heads/{ref}"
     # Try the branch URL first, fall back to tag URL on 404.
-    response = httpx.get(url, timeout=60.0, follow_redirects=True)
+    response = httpx.get(url, timeout=60.0, follow_redirects=True, trust_env=False)
     if response.status_code == 404:
         url = f"https://codeload.github.com/{repo}/tar.gz/refs/tags/{ref}"
-        response = httpx.get(url, timeout=60.0, follow_redirects=True)
+        response = httpx.get(url, timeout=60.0, follow_redirects=True, trust_env=False)
     response.raise_for_status()
 
     public_skills: set[str] = set()
@@ -238,8 +282,12 @@ def _fetch_skill_files(repo: str, ref: str) -> dict[str, bytes]:
             name = inner[len("skills/"):].rstrip("/")
             if not name or "/" in name:
                 continue
+            _validate_skill_name(name)
             if member.issym() or member.islnk():
-                target_name = PurePosixPath(member.linkname).name
+                try:
+                    target_name = _validate_skill_name(PurePosixPath(member.linkname).name)
+                except ValueError as exc:
+                    raise ValueError(str(exc)) from exc
                 public_skills.add(target_name or name)
 
         if not public_skills:
@@ -262,7 +310,8 @@ def _fetch_skill_files(repo: str, ref: str) -> dict[str, bytes]:
             relpath = inner[len(prefix):]
             if not relpath:
                 continue
-            skill_name = relpath.split("/", 1)[0]
+            relpath = _validate_skill_relpath(relpath)
+            skill_name = _validate_skill_name(relpath.split("/", 1)[0])
             if skill_name not in public_skills:
                 continue
             extracted = tar.extractfile(member)
@@ -287,8 +336,12 @@ def _write_skill(target_root: Path, skill_name: str, files: dict[str, bytes]) ->
             continue
         if not relpath.startswith(prefix):
             continue
-        sub = relpath[len(prefix):]
+        sub = _validate_skill_relpath(relpath[len(prefix):])
         out_path = target_root / sub
+        target_resolved = target_root.resolve(strict=False)
+        out_resolved = out_path.resolve(strict=False)
+        if target_resolved != out_resolved and target_resolved not in out_resolved.parents:
+            raise ValueError(f"unsafe skill output path: {relpath!r}")
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_bytes(contents)
 

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 from unittest.mock import patch
 
 import httpx
@@ -35,7 +36,7 @@ def _isolate_version_check_state():
       which downstream credentials tests rely on being unset.
     * ``BIFROST_API_URL`` written to ``os.environ`` by ``python-dotenv`` in
       the dotenv-resolution test — monkeypatch doesn't track it because
-      load_dotenv writes to os.environ directly. Subsequent SDK credentials
+      the allowlisted dotenv loader writes to os.environ directly. Subsequent SDK credentials
       tests assume the env var is unset and resolve via the JSON store.
     """
     import os
@@ -300,12 +301,16 @@ class TestUrlResolution:
         """A project ``.env`` containing BIFROST_API_URL is honored.
 
         ``_check_cli_version`` runs before the rest of the CLI imports
-        ``bifrost.client`` (which is where dotenv is normally loaded). The
-        check must load dotenv itself so a CWD-local ``.env`` resolves the
-        URL just like the rest of the CLI would.
+        ``bifrost.client`` (which is where the dotenv allowlist is normally
+        loaded). The check must load the allowlist itself so a CWD-local
+        ``.env`` resolves the URL just like the rest of the CLI would.
         """
         env_file = tmp_path / ".env"
-        env_file.write_text("BIFROST_API_URL=https://from-dotenv.example\n")
+        env_file.write_text(
+            "BIFROST_API_URL=https://from-dotenv.example\n"
+            "BIFROST_ACCESS_TOKEN=from-dotenv-token\n"
+            "HTTPS_PROXY=http://proxy.example\n"
+        )
 
         monkeypatch.chdir(tmp_path)
         # Make sure the env var isn't already set in the test process so we
@@ -332,6 +337,9 @@ class TestUrlResolution:
         assert urlopen.called, "httpx.get never called — dotenv URL not resolved"
         url = urlopen.call_args[0][0]
         assert url == "https://from-dotenv.example/api/version"
+        assert urlopen.call_args.kwargs["trust_env"] is False
+        assert "BIFROST_ACCESS_TOKEN" not in os.environ
+        assert "HTTPS_PROXY" not in os.environ
 
     def test_cwd_dotenv_overrides_stale_env_url(self, monkeypatch, tmp_path):
         """The current project's ``.env`` wins over a stale inherited URL."""
@@ -357,6 +365,7 @@ class TestUrlResolution:
 
         url = urlopen.call_args[0][0]
         assert url == "https://from-current-dotenv.example/api/version"
+        assert urlopen.call_args.kwargs["trust_env"] is False
 
 
 class TestTransport:

--- a/api/tests/unit/cli/test_import_security.py
+++ b/api/tests/unit/cli/test_import_security.py
@@ -1,0 +1,69 @@
+"""Security regression tests for ``bifrost import`` bundle reads."""
+
+from __future__ import annotations
+
+import base64
+import pathlib
+
+import click
+import pytest
+
+from bifrost.commands.import_cmd import (
+    _collect_code_files,
+    _read_manifest_files,
+    _validate_bundle_dir,
+)
+
+
+def _mark_symlink(monkeypatch: pytest.MonkeyPatch, symlink_path: pathlib.Path) -> None:
+    original = pathlib.Path.is_symlink
+
+    def fake_is_symlink(path: pathlib.Path) -> bool:
+        return path == symlink_path or original(path)
+
+    monkeypatch.setattr(pathlib.Path, "is_symlink", fake_is_symlink)
+
+
+def test_manifest_symlink_is_rejected_before_read(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = tmp_path / "bundle"
+    bifrost_dir = bundle / ".bifrost"
+    bifrost_dir.mkdir(parents=True)
+    manifest = bifrost_dir / "workflows.yaml"
+    manifest.write_text("token: secret\n", encoding="utf-8")
+    _mark_symlink(monkeypatch, manifest)
+
+    validated = _validate_bundle_dir(bundle)
+
+    with pytest.raises(click.ClickException, match="must not be a symlink"):
+        _read_manifest_files(validated, drop_cross_env_seeds=False)
+
+
+def test_code_symlink_is_rejected_before_upload(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = tmp_path / "bundle"
+    (bundle / ".bifrost").mkdir(parents=True)
+    (bundle / ".bifrost/workflows.yaml").write_text("[]\n", encoding="utf-8")
+    (bundle / "workflows").mkdir()
+    leaked = bundle / "workflows/leak.py"
+    leaked.write_text("API_KEY = 'secret'\n", encoding="utf-8")
+    _mark_symlink(monkeypatch, leaked)
+
+    with pytest.raises(click.ClickException, match="must not be a symlink"):
+        _collect_code_files(bundle)
+
+
+def test_regular_bundle_files_are_still_collected(tmp_path: pathlib.Path) -> None:
+    bundle = tmp_path / "bundle"
+    (bundle / ".bifrost").mkdir(parents=True)
+    (bundle / ".bifrost/workflows.yaml").write_text("[]\n", encoding="utf-8")
+    (bundle / "workflows").mkdir()
+    (bundle / "workflows/ok.py").write_text("def run(): pass\n", encoding="utf-8")
+
+    files = _collect_code_files(bundle)
+
+    assert base64.b64decode(files["workflows/ok.py"]).decode("utf-8").replace(
+        "\r\n", "\n"
+    ) == "def run(): pass\n"

--- a/api/tests/unit/sdk/test_client_injection.py
+++ b/api/tests/unit/sdk/test_client_injection.py
@@ -124,12 +124,14 @@ class TestClientInjection:
             # Sync HTTP client should be initialized eagerly
             assert client._sync_http is not None
             assert client._sync_http.headers["Authorization"] == "Bearer token_abc123"
+            assert getattr(client._sync_http, "_trust_env") is False
 
             # Async HTTP client is now lazily initialized per event loop
             # Call _get_async_client() to create it
             http = client._get_async_client()
             assert http is not None
             assert http.headers["Authorization"] == "Bearer token_abc123"
+            assert getattr(http, "_trust_env") is False
         finally:
             # Clean up async client (don't use asyncio.run to avoid nested event loop)
             pass

--- a/api/tests/unit/test_cli_skill.py
+++ b/api/tests/unit/test_cli_skill.py
@@ -270,6 +270,76 @@ class TestSkillUpdate:
         err = capsys.readouterr().err
         assert "No public skills" in err
 
+    def test_rejects_tarball_skill_path_traversal(
+        self,
+        workspace: Path,
+        stub_github,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        stub_github["install"](
+            {
+                ".claude/skills/foo/../evil/SKILL.md": b"evil\n",
+            },
+        )
+        stub_github["public_skills"] = ["foo"]  # type: ignore[index]
+
+        rc = skill_module.handle_skill(["update"])
+
+        assert rc == 1
+        assert "unsafe skill path" in capsys.readouterr().err
+        assert not (workspace / ".claude/skills/evil").exists()
+        assert not (workspace / ".agents/skills/evil").exists()
+
+    def test_rejects_tarball_backslash_skill_path(
+        self,
+        workspace: Path,
+        stub_github,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        stub_github["install"](
+            {
+                ".claude/skills/foo\\evil/SKILL.md": b"evil\n",
+            },
+        )
+        stub_github["public_skills"] = ["foo"]  # type: ignore[index]
+
+        rc = skill_module.handle_skill(["update"])
+
+        assert rc == 1
+        assert "unsafe skill path" in capsys.readouterr().err
+        assert not (workspace / ".claude/skills/foo\\evil").exists()
+        assert not (workspace / ".agents/skills/foo\\evil").exists()
+
+    def test_rejects_existing_symlink_skill_target_before_delete(
+        self,
+        workspace: Path,
+        stub_github,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        outside = workspace / "outside"
+        outside.mkdir()
+        target = workspace / ".claude/skills/foo"
+        target.mkdir(parents=True)
+        original_is_symlink = Path.is_symlink
+
+        def fake_is_symlink(path: Path) -> bool:
+            return path == target or original_is_symlink(path)
+
+        monkeypatch.setattr(Path, "is_symlink", fake_is_symlink)
+        stub_github["install"](
+            {
+                ".claude/skills/foo/SKILL.md": b"safe\n",
+            },
+        )
+
+        rc = skill_module.handle_skill(["update"])
+
+        assert rc == 1
+        assert "refusing to replace symlinked skill directory" in capsys.readouterr().err
+        assert target.exists()
+        assert outside.is_dir()
+
 
 class TestSkillList:
     def test_list_finds_skills_in_both_dirs(

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -70,6 +70,36 @@ class TestEnvBackend:
         assert os.environ.get("BIFROST_ACCESS_TOKEN") in (None, "")  # didn't pollute env
 
 
+class TestDotenvAllowlist:
+    def test_load_allowed_dotenv_only_imports_api_url(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "\n".join(
+                [
+                    "BIFROST_API_URL=https://from-dotenv.example",
+                    "BIFROST_ACCESS_TOKEN=secret-access",
+                    "BIFROST_REFRESH_TOKEN=secret-refresh",
+                    "HTTPS_PROXY=http://proxy.example",
+                    "SSL_CERT_FILE=C:/tmp/ca.pem",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.delenv("BIFROST_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("BIFROST_REFRESH_TOKEN", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+
+        creds_mod.load_allowed_dotenv(env_file)
+
+        assert os.environ["BIFROST_API_URL"] == "https://from-dotenv.example"
+        assert "BIFROST_ACCESS_TOKEN" not in os.environ
+        assert "BIFROST_REFRESH_TOKEN" not in os.environ
+        assert "HTTPS_PROXY" not in os.environ
+        assert "SSL_CERT_FILE" not in os.environ
+
+
 # ---------- JsonBackend (multi-record) ----------
 
 class TestJsonBackendMultiRecord:


### PR DESCRIPTION
## Summary
- reject symlinks during bifrost import before reading/uploading bundle content
- validate skill tarball names and paths before delete/write
- restrict CWD .env support to BIFROST_API_URL and disable httpx trust_env for authenticated clients

## Tests
- uv run python -m pytest api/tests/unit/cli/test_import_security.py api/tests/unit/test_cli_skill.py api/tests/unit/test_credentials.py api/tests/unit/cli/test_cli_version_check.py api/tests/unit/sdk/test_client_injection.py -q
- uv run python -m pytest api/tests/unit/routers/test_codex_gateway.py api/tests/unit/services/test_codex_gateway_runtime.py api/tests/unit/repositories/test_codex_gateway_repository.py api/tests/unit/services/mcp_server/test_tool_implementations.py::TestAppToolImpl::test_create_app_rejects_unclaimed_existing_source api/tests/unit/cli/test_import_security.py api/tests/unit/test_cli_skill.py api/tests/unit/test_credentials.py api/tests/unit/cli/test_cli_version_check.py api/tests/unit/sdk/test_client_injection.py -q
- uv run ruff check <touched backend files>
- git diff --check