### PR TITLE
Harden Codex Gateway key rejection

### DIFF
--- a/api/src/repositories/codex_gateway.py
+++ b/api/src/repositories/codex_gateway.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import secrets
-from typing import Any
+from typing import Any, TypeGuard
 from uuid import UUID
 
 from sqlalchemy import select
@@ -24,6 +24,23 @@ SENSITIVE_METADATA_KEYS = {
     "prompt",
     "response",
 }
+
+CODEX_GATEWAY_KEY_PREFIX = "bfck_"
+CODEX_GATEWAY_KEY_MIN_LENGTH = len(CODEX_GATEWAY_KEY_PREFIX) + 32
+CODEX_GATEWAY_KEY_MAX_LENGTH = 256
+CODEX_GATEWAY_KEY_BODY_CHARS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
+)
+
+
+def is_plausible_gateway_key(value: str | None) -> TypeGuard[str]:
+    """Return whether a presented gateway key can match generated key material."""
+    if value is None or not value.startswith(CODEX_GATEWAY_KEY_PREFIX):
+        return False
+    if not (CODEX_GATEWAY_KEY_MIN_LENGTH <= len(value) <= CODEX_GATEWAY_KEY_MAX_LENGTH):
+        return False
+    body = value[len(CODEX_GATEWAY_KEY_PREFIX) :]
+    return bool(body) and all(char in CODEX_GATEWAY_KEY_BODY_CHARS for char in body)
 
 
 @dataclass(frozen=True)
@@ -88,6 +105,9 @@ class CodexGatewayRepository:
     async def get_active_gateway_key_by_plaintext(
         self, plaintext_key: str
     ) -> CodexGatewayKey | None:
+        if not is_plausible_gateway_key(plaintext_key):
+            return None
+
         result = await self.session.execute(
             select(CodexGatewayKey)
             .where(CodexGatewayKey.status == "active")

--- a/api/src/routers/codex_gateway.py
+++ b/api/src/routers/codex_gateway.py
@@ -8,7 +8,11 @@ from fastapi.responses import JSONResponse
 from shared.models import CodexGatewayResponsesRequest
 
 from src.core.database import DbSession
-from src.repositories.codex_gateway import CodexGatewayRepository
+from src.models.contracts.codex_gateway import OpenAICompatibleError
+from src.repositories.codex_gateway import (
+    CodexGatewayRepository,
+    is_plausible_gateway_key,
+)
 from src.services.codex_gateway.runtime import (
     CODEX_GATEWAY_KEY_HEADER,
     CodexGatewayRuntime,
@@ -23,6 +27,18 @@ def get_codex_gateway_runtime(db: DbSession) -> CodexGatewayRuntime:
     return CodexGatewayRuntime(repository=CodexGatewayRepository(db))
 
 
+def _invalid_gateway_key_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=401,
+        content={
+            "error": OpenAICompatibleError(
+                message="The Bifrost Codex Gateway key is invalid or revoked.",
+                code="invalid_gateway_key",
+            ).model_dump()
+        },
+    )
+
+
 @router.post("/v1/responses")
 async def create_response(
     request: Request,
@@ -35,8 +51,11 @@ async def create_response(
     ] = None,
 ) -> JSONResponse:
     gateway_key = extract_gateway_key(authorization, x_bifrost_codex_key)
+    if not is_plausible_gateway_key(gateway_key):
+        return _invalid_gateway_key_response()
+
     result = await runtime.create_response(
-        gateway_key=gateway_key or "",
+        gateway_key=gateway_key,
         payload=payload.model_dump(),
         source_ip=request.client.host if request.client else None,
         client_user_agent=request.headers.get("user-agent"),

--- a/api/src/services/codex_gateway/runtime.py
+++ b/api/src/services/codex_gateway/runtime.py
@@ -23,7 +23,10 @@ from src.models.orm.codex_gateway import (
     CodexGatewayKey,
     CodexGatewayUpstreamAccount,
 )
-from src.repositories.codex_gateway import CodexGatewayRepository
+from src.repositories.codex_gateway import (
+    CodexGatewayRepository,
+    is_plausible_gateway_key,
+)
 from src.services.codex_gateway.policy import CodexGatewayPolicyEngine
 
 
@@ -110,25 +113,19 @@ class CodexGatewayRuntime:
         model = payload.get("model")
         streaming = bool(payload.get("stream") or payload.get("streaming"))
 
+        invalid_key_response = self._error(
+            status_code=401,
+            code="invalid_gateway_key",
+            message="The Bifrost Codex Gateway key is invalid or revoked.",
+        )
+        if not is_plausible_gateway_key(gateway_key):
+            return invalid_key_response
+
         key_record = await self.repository.get_active_gateway_key_by_plaintext(
             gateway_key
         )
         if key_record is None:
-            response = self._error(
-                status_code=401,
-                code="invalid_gateway_key",
-                message="The Bifrost Codex Gateway key is invalid or revoked.",
-            )
-            await self._log_denial(
-                request_id=request_id,
-                endpoint=CODEX_GATEWAY_RESPONSES_ENDPOINT,
-                model=model if isinstance(model, str) else None,
-                status_code=response.status_code,
-                code="invalid_gateway_key",
-                source_ip=source_ip,
-                client_user_agent=client_user_agent,
-            )
-            return response
+            return invalid_key_response
 
         if not isinstance(model, str) or not model:
             response = self._error(

--- a/api/tests/unit/repositories/test_codex_gateway_repository.py
+++ b/api/tests/unit/repositories/test_codex_gateway_repository.py
@@ -9,6 +9,8 @@ from src.repositories.codex_gateway import (
     CodexGatewayRepository,
 )
 
+VALID_GATEWAY_KEY = f"bfck_{'a' * 43}"
+
 
 class _Scalars:
     def __init__(self, values):
@@ -77,7 +79,7 @@ async def test_lookup_gateway_key_uses_hash_and_ignores_revoked_keys(
     repository,
     mock_session,
 ):
-    plaintext = "bfck_test_plaintext"
+    plaintext = VALID_GATEWAY_KEY
     key_hash = repository.hash_gateway_key(plaintext)
     active_record = MagicMock(key_hash=key_hash, revoked_at=None, status="active")
     revoked_record = MagicMock(
@@ -89,6 +91,17 @@ async def test_lookup_gateway_key_uses_hash_and_ignores_revoked_keys(
 
     assert result is active_record
     mock_session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lookup_gateway_key_rejects_malformed_key_before_database_query(
+    repository,
+    mock_session,
+):
+    result = await repository.get_active_gateway_key_by_plaintext("not-a-bifrost-key")
+
+    assert result is None
+    mock_session.execute.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/routers/test_codex_gateway.py
+++ b/api/tests/unit/routers/test_codex_gateway.py
@@ -9,6 +9,8 @@ from src.services.codex_gateway.runtime import (
     CodexGatewayResponse,
 )
 
+VALID_GATEWAY_KEY = f"bfck_{'a' * 43}"
+
 
 class FakeRuntime:
     def __init__(self):
@@ -32,14 +34,14 @@ def test_v1_responses_uses_openai_compatible_bearer_key():
 
     response = client.post(
         "/v1/responses",
-        headers={"Authorization": "Bearer bfck_route_test"},
+        headers={"Authorization": f"Bearer {VALID_GATEWAY_KEY}"},
         json={"model": "gpt-5.1-codex", "input": "do not log me"},
     )
 
     assert response.status_code == 200
     assert response.json()["id"] == "resp_route_test"
     [runtime_call] = runtime.calls
-    assert runtime_call["gateway_key"] == "bfck_route_test"
+    assert runtime_call["gateway_key"] == VALID_GATEWAY_KEY
     assert runtime_call["payload"] == {
         "model": "gpt-5.1-codex",
         "input": "do not log me",
@@ -55,7 +57,7 @@ def test_v1_responses_rejects_non_object_payload_before_runtime():
 
     response = client.post(
         "/v1/responses",
-        headers={"Authorization": "Bearer bfck_route_test"},
+        headers={"Authorization": f"Bearer {VALID_GATEWAY_KEY}"},
         json=["not", "an", "object"],
     )
 
@@ -72,14 +74,49 @@ def test_v1_responses_uses_fallback_gateway_key_header():
 
     response = client.post(
         "/v1/responses",
-        headers={CODEX_GATEWAY_KEY_HEADER: "bfck_fallback_test"},
+        headers={CODEX_GATEWAY_KEY_HEADER: VALID_GATEWAY_KEY},
         json={"model": "gpt-5.1-codex", "input": "fallback header"},
     )
 
     assert response.status_code == 200
     [runtime_call] = runtime.calls
-    assert runtime_call["gateway_key"] == "bfck_fallback_test"
+    assert runtime_call["gateway_key"] == VALID_GATEWAY_KEY
     assert runtime_call["payload"] == {
         "model": "gpt-5.1-codex",
         "input": "fallback header",
     }
+
+
+def test_v1_responses_rejects_missing_gateway_key_before_runtime():
+    app = FastAPI()
+    app.include_router(router)
+    runtime = FakeRuntime()
+    app.dependency_overrides[get_codex_gateway_runtime] = lambda: runtime
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/responses",
+        json={"model": "gpt-5.1-codex", "input": "missing key"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_gateway_key"
+    assert runtime.calls == []
+
+
+def test_v1_responses_rejects_malformed_gateway_key_before_runtime():
+    app = FastAPI()
+    app.include_router(router)
+    runtime = FakeRuntime()
+    app.dependency_overrides[get_codex_gateway_runtime] = lambda: runtime
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/responses",
+        headers={"Authorization": "Bearer not-a-bifrost-key"},
+        json={"model": "gpt-5.1-codex", "input": "bad key"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_gateway_key"
+    assert runtime.calls == []

--- a/api/tests/unit/services/test_codex_gateway_runtime.py
+++ b/api/tests/unit/services/test_codex_gateway_runtime.py
@@ -12,6 +12,8 @@ from src.services.codex_gateway.runtime import (
     extract_gateway_key,
 )
 
+VALID_GATEWAY_KEY = f"bfck_{'a' * 43}"
+
 
 class FakeUpstreamClient:
     def __init__(self):
@@ -93,7 +95,7 @@ async def test_allowed_response_uses_same_user_upstream_token_and_logs_metadata(
     runtime = CodexGatewayRuntime(repository=repository, upstream_client=upstream)
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-5.1-codex", "input": "do not log me"},
         source_ip="203.0.113.10",
         client_user_agent="codex-cli",
@@ -120,21 +122,38 @@ async def test_allowed_response_uses_same_user_upstream_token_and_logs_metadata(
 
 
 @pytest.mark.asyncio
-async def test_unknown_gateway_key_returns_openai_error_and_logs_denial():
+async def test_unknown_well_formed_gateway_key_returns_openai_error_without_log():
     repository = _repository(key_record=None, account_record=None)
     runtime = CodexGatewayRuntime(
         repository=repository, upstream_client=FakeUpstreamClient()
     )
 
     response = await runtime.create_response(
-        gateway_key="bfck_missing",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-5.1-codex"},
     )
 
     assert response.status_code == 401
     assert response.body["error"]["code"] == "invalid_gateway_key"
-    repository.create_request_log.assert_awaited_once()
-    assert repository.create_request_log.call_args.kwargs["policy_decision"] == "deny"
+    repository.create_request_log.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_gateway_key_returns_openai_error_without_lookup_or_log():
+    repository = _repository(key_record=None, account_record=None)
+    runtime = CodexGatewayRuntime(
+        repository=repository, upstream_client=FakeUpstreamClient()
+    )
+
+    response = await runtime.create_response(
+        gateway_key="not-a-bifrost-key",
+        payload={"model": "gpt-5.1-codex"},
+    )
+
+    assert response.status_code == 401
+    assert response.body["error"]["code"] == "invalid_gateway_key"
+    repository.get_active_gateway_key_by_plaintext.assert_not_awaited()
+    repository.create_request_log.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -145,7 +164,7 @@ async def test_gateway_key_authentication_happens_before_payload_validation():
     )
 
     response = await runtime.create_response(
-        gateway_key="bfck_missing",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"input": "missing model"},
     )
 
@@ -162,7 +181,7 @@ async def test_missing_upstream_account_fails_closed_and_logs_denial():
     )
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-5.1-codex"},
     )
 
@@ -185,7 +204,7 @@ async def test_ambiguous_upstream_account_fails_closed_and_logs_denial():
     )
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-5.1-codex"},
     )
 
@@ -207,7 +226,7 @@ async def test_denied_model_returns_structured_error_and_does_not_call_upstream(
     runtime = CodexGatewayRuntime(repository=repository, upstream_client=upstream)
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-4o"},
     )
 
@@ -227,7 +246,7 @@ async def test_denied_model_list_blocks_request_and_logs_denial():
     runtime = CodexGatewayRuntime(repository=repository, upstream_client=upstream)
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-4o"},
     )
 
@@ -252,7 +271,7 @@ async def test_decrypt_failure_returns_gateway_error_and_logs_denial(monkeypatch
     )
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-5.1-codex"},
     )
 
@@ -278,7 +297,7 @@ async def test_upstream_failure_returns_gateway_error_and_logs_metadata(monkeypa
     )
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-5.1-codex"},
     )
 
@@ -309,7 +328,7 @@ async def test_upstream_timeout_returns_gateway_error_and_logs_metadata(monkeypa
     )
 
     response = await runtime.create_response(
-        gateway_key="bfck_test",
+        gateway_key=VALID_GATEWAY_KEY,
         payload={"model": "gpt-5.1-codex"},
     )
 
@@ -323,7 +342,7 @@ async def test_upstream_timeout_returns_gateway_error_and_logs_metadata(monkeypa
 
 
 def test_extract_gateway_key_prefers_openai_compatible_bearer_auth():
-    assert extract_gateway_key("Bearer bfck_test", None) == "bfck_test"
-    assert extract_gateway_key("bearer bfck_lower", None) == "bfck_lower"
-    assert extract_gateway_key(None, "bfck_fallback") == "bfck_fallback"
+    assert extract_gateway_key(f"Bearer {VALID_GATEWAY_KEY}", None) == VALID_GATEWAY_KEY
+    assert extract_gateway_key(f"bearer {VALID_GATEWAY_KEY}", None) == VALID_GATEWAY_KEY
+    assert extract_gateway_key(None, VALID_GATEWAY_KEY) == VALID_GATEWAY_KEY
     assert extract_gateway_key("Basic abc", None) is None


### PR DESCRIPTION
## Summary
- reject missing/malformed Codex Gateway keys before runtime/database work
- add runtime and repository short-circuits for malformed keys
- avoid denial log amplification for unknown gateway keys
- add focused router/runtime/repository regressions

## Tests
- uv run python -m pytest api/tests/unit/routers/test_codex_gateway.py api/tests/unit/services/test_codex_gateway_runtime.py api/tests/unit/repositories/test_codex_gateway_repository.py -q
- uv run python -m pytest api/tests/unit/routers/test_codex_gateway.py api/tests/unit/services/test_codex_gateway_runtime.py api/tests/unit/repositories/test_codex_gateway_repository.py api/tests/unit/services/mcp_server/test_tool_implementations.py::TestAppToolImpl::test_create_app_rejects_unclaimed_existing_source api/tests/unit/cli/test_import_security.py api/tests/unit/test_cli_skill.py api/tests/unit/test_credentials.py api/tests/unit/cli/test_cli_version_check.py api/tests/unit/sdk/test_client_injection.py -q
- uv run ruff check <touched backend files>
- git diff --check

## Note
This is the conservative first slice. It does not remove bcrypt scans for well-formed but nonexistent bfck_* keys; that should be a follow-up with a key id/prefix or fingerprint lookup design.