### PR TITLE
Harden high-risk MCP and OAuth scopes

### DIFF
--- a/api/src/models/contracts/cli.py
+++ b/api/src/models/contracts/cli.py
@@ -217,7 +217,7 @@ class SDKIntegrationsGetRequest(BaseModel):
     )
     oauth_scope: str | None = Field(
         default=None,
-        description="Override OAuth scope for token request (e.g., 'https://outlook.office365.com/.default'). "
+        description="Optional whitespace-delimited OAuth scopes to request from the provider's configured scope allowlist. "
         "When provided, triggers fresh token fetch for client_credentials flows."
     )
 

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -120,6 +120,27 @@ def should_auto_refresh_token(
     return False
 
 
+def _resolve_requested_oauth_scopes(provider: Any, oauth_scope: str | None) -> str:
+    """Return the configured OAuth scopes selected for a token request.
+
+    ``oauth_scope`` is a selector, not an arbitrary resource-audience override:
+    callers may request only scopes already configured on the provider.
+    """
+    configured_scopes = [str(scope) for scope in (provider.scopes or []) if str(scope).strip()]
+    if not oauth_scope:
+        return " ".join(configured_scopes)
+
+    requested_scopes = [scope for scope in oauth_scope.split() if scope]
+    if not requested_scopes:
+        return " ".join(configured_scopes)
+
+    unauthorized = sorted(set(requested_scopes) - set(configured_scopes))
+    if unauthorized:
+        raise ValueError("oauth_scope contains scopes that are not configured for this provider")
+
+    return " ".join(requested_scopes)
+
+
 # =============================================================================
 # Pydantic Models (Developer Context)
 # =============================================================================
@@ -756,10 +777,7 @@ async def _build_oauth_data(
             from src.services.oauth_provider import OAuthProviderClient
 
             oauth_client = OAuthProviderClient()
-            # Use oauth_scope override if provided, otherwise use provider's default
-            scopes = oauth_scope if oauth_scope else (
-                " ".join(provider.scopes) if provider.scopes else ""
-            )
+            scopes = _resolve_requested_oauth_scopes(provider, oauth_scope)
 
             success, result = await oauth_client.get_client_credentials_token(
                 token_url=resolved_token_url,

--- a/api/src/services/mcp_server/tools/code_editor.py
+++ b/api/src/services/mcp_server/tools/code_editor.py
@@ -112,6 +112,12 @@ MAX_CONTENT_CHARS = 100_000  # ~100KB, similar to Claude Code's Read tool
 # =============================================================================
 
 
+def _require_platform_admin(context: Any) -> ToolResult | None:
+    if not getattr(context, "is_platform_admin", False):
+        return error_result("Platform administrator privileges are required for code editor tools.")
+    return None
+
+
 def _normalize_line_endings(content: str) -> str:
     """Normalize line endings to \\n for consistent matching."""
     return content.replace("\r\n", "\n").replace("\r", "\n")
@@ -279,6 +285,8 @@ async def list_content(
 ) -> ToolResult:
     """List files in the workspace. Optionally filter by path prefix."""
     logger.info(f"MCP list_content: path_prefix={path_prefix}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     try:
         repo = RepoStorage()
@@ -314,6 +322,8 @@ async def search_content(
 ) -> ToolResult:
     """Search for regex patterns across all workspace files."""
     logger.info(f"MCP search_content: pattern={pattern}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not pattern:
         return error_result("pattern is required")
@@ -382,6 +392,8 @@ async def read_content_lines(
     logger.info(
         f"MCP read_content_lines: path={path}, lines={start_line}-{end_line}"
     )
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not path:
         return error_result("path is required")
@@ -445,6 +457,8 @@ async def get_content(
 ) -> ToolResult:
     """Get the entire content of a file."""
     logger.info(f"MCP get_content: path={path}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not path:
         return error_result("path is required")
@@ -529,6 +543,8 @@ async def patch_content(
         replacements: Mapping of old_workflow_id -> new_function_name for renames
     """
     logger.info(f"MCP patch_content: path={path}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not path:
         return error_result("path is required")
@@ -638,6 +654,8 @@ async def replace_content(
         replacements: Mapping of old_workflow_id -> new_function_name for renames
     """
     logger.info(f"MCP replace_content: path={path}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not path:
         return error_result("path is required")
@@ -691,6 +709,8 @@ async def delete_content(
 ) -> ToolResult:
     """Delete a file."""
     logger.info(f"MCP delete_content: path={path}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not path:
         return error_result("path is required")

--- a/api/src/services/mcp_server/tools/events.py
+++ b/api/src/services/mcp_server/tools/events.py
@@ -20,6 +20,12 @@ from src.services.mcp_server.tools.db import get_tool_db
 logger = logging.getLogger(__name__)
 
 
+def _require_platform_admin(context: Any) -> ToolResult | None:
+    if not getattr(context, "is_platform_admin", False):
+        return error_result("Platform administrator privileges are required for event tools.")
+    return None
+
+
 def _build_callback_url(source_id: UUID) -> str:
     """Build callback URL path from event source ID."""
     return f"/api/hooks/{source_id}"
@@ -36,6 +42,8 @@ async def list_event_sources(
     from src.repositories.events import EventSourceRepository, EventSubscriptionRepository
 
     logger.info(f"MCP list_event_sources called with type={source_type}, org={organization_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     try:
         # Parse source_type enum
@@ -122,6 +130,8 @@ async def create_event_source(
     from src.services.webhooks.registry import get_adapter_registry
 
     logger.info(f"MCP create_event_source called: name={name}, type={source_type}, workflow_id={workflow_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     try:
         source_type_enum = EventSourceType(source_type)
@@ -337,6 +347,8 @@ async def get_event_source(
     from src.repositories.events import EventSourceRepository, EventSubscriptionRepository
 
     logger.info(f"MCP get_event_source called with id={source_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -403,6 +415,8 @@ async def update_event_source(
     from src.repositories.events import EventSourceRepository
 
     logger.info(f"MCP update_event_source called with id={source_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -480,6 +494,8 @@ async def delete_event_source(
     from src.services.webhooks.registry import get_adapter_registry
 
     logger.info(f"MCP delete_event_source called with id={source_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -529,6 +545,8 @@ async def list_event_subscriptions(
     )
 
     logger.info(f"MCP list_event_subscriptions called with source_id={source_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -594,6 +612,8 @@ async def create_event_subscription(
     from src.repositories.events import EventSourceRepository
 
     logger.info(f"MCP create_event_subscription called: source={source_id}, workflow={workflow_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -664,6 +684,8 @@ async def update_event_subscription(
     from src.models.orm.events import EventSubscription
 
     logger.info(f"MCP update_event_subscription called: sub={subscription_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not source_id or not subscription_id:
         return error_result("source_id and subscription_id are required")
@@ -720,6 +742,8 @@ async def delete_event_subscription(
     from src.models.orm.events import EventSubscription
 
     logger.info(f"MCP delete_event_subscription called: sub={subscription_id}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not source_id or not subscription_id:
         return error_result("source_id and subscription_id are required")
@@ -755,6 +779,8 @@ async def list_webhook_adapters(
     from src.services.webhooks.registry import get_adapter_registry
 
     logger.info("MCP list_webhook_adapters called")
+    if denied := _require_platform_admin(context):
+        return denied
 
     try:
         registry = get_adapter_registry()

--- a/api/src/services/mcp_server/tools/organizations.py
+++ b/api/src/services/mcp_server/tools/organizations.py
@@ -29,6 +29,12 @@ from src.services.mcp_server.tools._http_bridge import call_rest, rest_client
 logger = logging.getLogger(__name__)
 
 
+def _require_platform_admin(context: Any) -> ToolResult | None:
+    if not getattr(context, "is_platform_admin", False):
+        return error_result("Platform administrator privileges are required for organization tools.")
+    return None
+
+
 def _ref_error_payload(exc: Exception) -> dict[str, Any]:
     from bifrost.refs import AmbiguousRefError, RefNotFoundError
 
@@ -45,6 +51,8 @@ async def list_organizations(context: Any) -> ToolResult:
     Platform admin only. Returns id, name, domain, is_active for each org.
     """
     logger.info("MCP list_organizations called")
+    if denied := _require_platform_admin(context):
+        return denied
 
     try:
         async with get_tool_db(context) as db:
@@ -80,6 +88,8 @@ async def get_organization(
     Platform admin only. Must provide at least one of organization_id or domain.
     """
     logger.info(f"MCP get_organization called with id={organization_id}, domain={domain}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not organization_id and not domain:
         return error_result("Either organization_id or domain is required")
@@ -140,6 +150,8 @@ async def create_organization(
         ToolResult with created organization details
     """
     logger.info(f"MCP create_organization called with name={name}")
+    if denied := _require_platform_admin(context):
+        return denied
 
     if not name:
         return error_result("name is required")
@@ -210,6 +222,9 @@ async def update_organization(
     :data:`bifrost.dto_flags.DTO_EXCLUDES` — ``domain`` is
     auto-provisioning policy, ``settings`` is a UI-managed JSON blob).
     """
+    if denied := _require_platform_admin(context):
+        return denied
+
     if not organization_ref:
         return error_result("organization_ref is required")
 
@@ -258,6 +273,9 @@ async def delete_organization(context: Any, organization_ref: str) -> ToolResult
     ``organization_ref`` is a UUID or organization name. Soft-delete
     semantics are owned by the REST endpoint.
     """
+    if denied := _require_platform_admin(context):
+        return denied
+
     if not organization_ref:
         return error_result("organization_ref is required")
 

--- a/api/tests/unit/routers/test_cli_auto_refresh.py
+++ b/api/tests/unit/routers/test_cli_auto_refresh.py
@@ -281,11 +281,11 @@ class TestBuildOAuthDataAutoRefresh:
             assert result.client_secret == "decrypted-client-secret"
 
     @pytest.mark.asyncio
-    async def test_build_oauth_data_uses_oauth_scope_override(self):
-        """_build_oauth_data should use oauth_scope instead of provider.scopes when provided."""
+    async def test_build_oauth_data_uses_configured_oauth_scope_selection(self):
+        """_build_oauth_data should let callers select only configured provider scopes."""
         from src.routers.cli import _build_oauth_data
 
-        # Mock provider with default Graph scopes
+        # Mock provider with an admin-configured scope allowlist
         provider = MagicMock()
         provider.provider_name = "Microsoft"
         provider.client_id = "test-client-id"
@@ -293,7 +293,10 @@ class TestBuildOAuthDataAutoRefresh:
         provider.token_url_defaults = {}
         provider.oauth_flow_type = "client_credentials"
         provider.authorization_url = None
-        provider.scopes = ["https://graph.microsoft.com/.default"]  # Default scope
+        provider.scopes = [
+            "https://graph.microsoft.com/.default",
+            "https://outlook.office365.com/.default",
+        ]
         provider.encrypted_client_secret = "encrypted-secret"
         provider.audience = None
 
@@ -318,26 +321,61 @@ class TestBuildOAuthDataAutoRefresh:
             )
             mock_client_class.return_value = mock_instance
 
-            # Call with oauth_scope override for Exchange
+            # Call with an explicitly configured Exchange scope
             result = await _build_oauth_data(
                 provider, token, entity_id, resolve_url_template, decrypt_secret,
                 oauth_scope="https://outlook.office365.com/.default"
             )
 
-            # Verify OAuthProviderClient was called with the OVERRIDE scope
+            # Verify OAuthProviderClient was called with the selected allowed scope
             mock_instance.get_client_credentials_token.assert_called_once_with(
                 token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
                 client_id="test-client-id",
                 client_secret="decrypted-client-secret",
-                scopes="https://outlook.office365.com/.default",  # Override, not provider.scopes
+                scopes="https://outlook.office365.com/.default",
                 audience=None,
             )
 
             assert result.access_token == "exchange-access-token"
 
     @pytest.mark.asyncio
-    async def test_build_oauth_data_with_oauth_scope_and_entity_id(self):
-        """_build_oauth_data should use oauth_scope and resolve entity_id in token URL."""
+    async def test_build_oauth_data_rejects_unconfigured_oauth_scope(self):
+        """Caller-supplied oauth_scope must not mint arbitrary resource tokens."""
+        from src.routers.cli import _build_oauth_data
+
+        provider = MagicMock()
+        provider.provider_name = "Microsoft"
+        provider.client_id = "test-client-id"
+        provider.token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+        provider.token_url_defaults = {}
+        provider.oauth_flow_type = "client_credentials"
+        provider.authorization_url = None
+        provider.scopes = ["https://graph.microsoft.com/.default"]
+        provider.encrypted_client_secret = "encrypted-secret"
+        provider.audience = None
+
+        def resolve_url_template(url, entity_id, defaults):
+            return url
+
+        def decrypt_secret(value):
+            return "decrypted-client-secret"
+
+        with patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class:
+            mock_instance = MagicMock()
+            mock_instance.get_client_credentials_token = AsyncMock()
+            mock_client_class.return_value = mock_instance
+
+            with pytest.raises(ValueError, match="not configured"):
+                await _build_oauth_data(
+                    provider, None, None, resolve_url_template, decrypt_secret,
+                    oauth_scope="https://outlook.office365.com/.default"
+                )
+
+        mock_instance.get_client_credentials_token.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_build_oauth_data_with_allowed_oauth_scope_and_entity_id(self):
+        """_build_oauth_data should select configured scope and resolve entity_id."""
         from src.routers.cli import _build_oauth_data
 
         # Mock provider with templated URL
@@ -348,7 +386,10 @@ class TestBuildOAuthDataAutoRefresh:
         provider.token_url_defaults = {}
         provider.oauth_flow_type = "client_credentials"
         provider.authorization_url = None
-        provider.scopes = ["https://graph.microsoft.com/.default"]  # Default scope
+        provider.scopes = [
+            "https://graph.microsoft.com/.default",
+            "https://outlook.office365.com/.default",
+        ]
         provider.encrypted_client_secret = "encrypted-secret"
         provider.audience = None
 

--- a/api/tests/unit/services/mcp_server/test_code_editor_tools.py
+++ b/api/tests/unit/services/mcp_server/test_code_editor_tools.py
@@ -194,27 +194,18 @@ class TestListContent:
             mock_repo.list.assert_called_once_with("")
 
     @pytest.mark.asyncio
-    async def test_list_workflows_org_scoped(self, org_user_context):
-        """Should list files filtered by path_prefix for org users."""
+    async def test_list_content_denies_non_admin(self, org_user_context):
+        """Path-based code editor tools are platform-admin only."""
         from src.services.mcp_server.tools.code_editor import list_content
 
-        with patch("src.services.mcp_server.tools.code_editor.RepoStorage") as mock_repo_cls:
-            mock_repo = MagicMock()
-            mock_repo.list = AsyncMock(return_value=[
-                "workflows/sync_tickets.py",
-            ])
-            mock_repo_cls.return_value = mock_repo
+        result = await list_content(
+            context=org_user_context,
+            path_prefix="workflows/",
+        )
 
-            result = await list_content(
-                context=org_user_context,
-                path_prefix="workflows/",
-            )
-
-            assert isinstance(result, ToolResult)
-            data = get_result_data(result)
-            assert "files" in data
-            assert len(data["files"]) == 1
-            assert data["files"][0]["path"] == "workflows/sync_tickets.py"
+        assert is_error_result(result)
+        data = get_result_data(result)
+        assert "Platform administrator privileges are required" in data["error"]
 
 
 class TestSearchContent:
@@ -747,34 +738,49 @@ class TestDeleteContent:
         assert "path" in data["error"]
 
     @pytest.mark.asyncio
-    async def test_delete_workflow_with_org_filter(self, org_user_context):
-        """Should delete a file for org-scoped users."""
+    async def test_delete_content_denies_non_admin(self, org_user_context):
+        """Non-admin users must not delete global workspace paths."""
         from src.services.mcp_server.tools.code_editor import delete_content
 
-        with patch("src.services.mcp_server.tools.code_editor.RepoStorage") as mock_repo_cls:
-            mock_repo = MagicMock()
-            mock_repo.exists = AsyncMock(return_value=True)
-            mock_repo_cls.return_value = mock_repo
+        result = await delete_content(
+            context=org_user_context,
+            path="workflows/test.py",
+        )
 
-            with patch("src.services.mcp_server.tools.code_editor.get_tool_db") as mock_db:
-                mock_session = AsyncMock()
-                mock_db.return_value.__aenter__.return_value = mock_session
+        assert is_error_result(result)
+        data = get_result_data(result)
+        assert "Platform administrator privileges are required" in data["error"]
 
-                with patch(
-                    "src.services.mcp_server.tools.code_editor.FileStorageService"
-                ) as mock_fs_cls:
-                    mock_fs_instance = MagicMock()
-                    mock_fs_instance.delete_file = AsyncMock()
-                    mock_fs_cls.return_value = mock_fs_instance
 
-                    result = await delete_content(
-                        context=org_user_context,
-                        path="workflows/test.py",
-                    )
+class TestCodeEditorAuthorization:
+    """All path-based code editor MCP tools are platform-admin only."""
 
-                    assert isinstance(result, ToolResult)
-                    data = get_result_data(result)
-                    assert data["success"] is True
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "args"),
+        [
+            ("list_content", ()),
+            ("search_content", ("needle",)),
+            ("read_content_lines", ("workflows/test.py",)),
+            ("get_content", ("workflows/test.py",)),
+            ("patch_content", ("workflows/test.py", "old", "new")),
+            ("replace_content", ("workflows/test.py", "content")),
+            ("delete_content", ("workflows/test.py",)),
+        ],
+    )
+    async def test_non_admin_code_editor_tools_return_error(
+        self,
+        org_user_context,
+        tool_name,
+        args,
+    ):
+        import src.services.mcp_server.tools.code_editor as code_editor
+
+        result = await getattr(code_editor, tool_name)(org_user_context, *args)
+
+        assert is_error_result(result)
+        data = get_result_data(result)
+        assert "Platform administrator privileges are required" in data["error"]
 
 
 class TestMultiFunctionWorkflows:

--- a/api/tests/unit/services/mcp_server/test_event_tools.py
+++ b/api/tests/unit/services/mcp_server/test_event_tools.py
@@ -58,7 +58,47 @@ def context():
     )
 
 
+@pytest.fixture
+def org_user_context():
+    """Create an MCPContext for a regular organization user."""
+    return MCPContext(
+        user_id=str(uuid4()),
+        org_id=str(uuid4()),
+        is_platform_admin=False,
+        user_email="user@example.com",
+        user_name="Org User",
+    )
+
+
 # ==================== Event Source Tool Tests ====================
+
+
+class TestEventToolAuthorization:
+    """Event source and subscription MCP tools are platform-admin only."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "args"),
+        [
+            ("list_event_sources", ()),
+            ("create_event_source", ("source", "webhook")),
+            ("get_event_source", (str(uuid4()),)),
+            ("update_event_source", (str(uuid4()),)),
+            ("delete_event_source", (str(uuid4()),)),
+            ("list_event_subscriptions", (str(uuid4()),)),
+            ("create_event_subscription", (str(uuid4()), str(uuid4()))),
+            ("update_event_subscription", (str(uuid4()), str(uuid4()))),
+            ("delete_event_subscription", (str(uuid4()), str(uuid4()))),
+            ("list_webhook_adapters", ()),
+        ],
+    )
+    async def test_non_admin_event_tools_return_error(self, org_user_context, tool_name, args):
+        import src.services.mcp_server.tools.events as events
+
+        result = await getattr(events, tool_name)(org_user_context, *args)
+
+        assert is_error_result(result)
+        assert "Platform administrator privileges are required" in result.structured_content["error"]
 
 
 class TestListEventSources:

--- a/api/tests/unit/services/mcp_server/test_organization_tools.py
+++ b/api/tests/unit/services/mcp_server/test_organization_tools.py
@@ -1,0 +1,43 @@
+"""Unit tests for organization MCP tool authorization."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.services.mcp_server.server import MCPContext
+
+
+@pytest.fixture
+def org_user_context() -> MCPContext:
+    """Create an MCPContext for a regular organization user."""
+    return MCPContext(
+        user_id=str(uuid4()),
+        org_id=str(uuid4()),
+        is_platform_admin=False,
+        user_email="user@example.com",
+        user_name="Org User",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "args"),
+    [
+        ("list_organizations", ()),
+        ("get_organization", (str(uuid4()),)),
+        ("create_organization", ("Test Org",)),
+        ("update_organization", (str(uuid4()),)),
+        ("delete_organization", (str(uuid4()),)),
+    ],
+)
+async def test_non_admin_organization_tools_return_error(
+    org_user_context: MCPContext,
+    tool_name: str,
+    args: tuple[object, ...],
+) -> None:
+    import src.services.mcp_server.tools.organizations as organizations
+
+    result = await getattr(organizations, tool_name)(org_user_context, *args)
+
+    assert result.structured_content is not None
+    assert "Platform administrator privileges are required" in result.structured_content["error"]


### PR DESCRIPTION
## Summary
- constrain CLI oauth_scope to provider-configured scopes before client_credentials token fetch
- require platform-admin context for path-based code editor MCP tools
- require platform-admin context for event and organization MCP tools

## Security findings covered
- Unvalidated OAuth scope can mint arbitrary resource tokens
- MCP event tools bypass admin and org authorization
- Restricted MCP admin tools exposed to non-admin agents
- MCP code editor cross-org read/edit/delete findings

## Verification
- uv run pytest api/tests/unit/routers/test_cli_auto_refresh.py api/tests/unit/services/mcp_server/test_event_tools.py api/tests/unit/services/mcp_server/test_organization_tools.py api/tests/unit/services/mcp_server/test_code_editor_tools.py -q
- uv run ruff check api/src/routers/cli.py api/src/models/contracts/cli.py api/src/services/mcp_server/tools/code_editor.py api/src/services/mcp_server/tools/events.py api/src/services/mcp_server/tools/organizations.py api/tests/unit/routers/test_cli_auto_refresh.py api/tests/unit/services/mcp_server/test_code_editor_tools.py api/tests/unit/services/mcp_server/test_event_tools.py api/tests/unit/services/mcp_server/test_organization_tools.py
- git diff --check