### PR TITLE
Harden agent-run authorization and streams

### DIFF
--- a/api/src/core/pubsub.py
+++ b/api/src/core/pubsub.py
@@ -299,7 +299,9 @@ async def publish_agent_run_update(
 
     Broadcasts to:
     - agent-run:{run_id} - for the detail page
-    - agent-runs - for the list page
+    - agent-runs:org:{org_id} - for org-scoped list pages
+    - agent-runs:global - for platform/global runs
+    - agent-runs:all - for platform admins watching every run
     """
     message = {
         "type": "agent_run_update",
@@ -323,7 +325,11 @@ async def publish_agent_run_update(
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     await manager.broadcast(f"agent-run:{run.id}", message)
-    await manager.broadcast("agent-runs", message)
+    await manager.broadcast("agent-runs:all", message)
+    if run.org_id:
+        await manager.broadcast(f"agent-runs:org:{run.org_id}", message)
+    else:
+        await manager.broadcast("agent-runs:global", message)
 
 
 async def publish_summary_backfill_update(

--- a/api/src/routers/agent_runs.py
+++ b/api/src/routers/agent_runs.py
@@ -19,6 +19,12 @@ from src.core.cache.keys import agent_run_steps_stream_key
 from src.core.cache.redis_client import get_redis
 from src.core.database import DbSession, get_session_factory
 from src.core.log_safety import log_safe
+from src.services.agent_run_access import (
+    apply_agent_run_access,
+    load_agent_by_name_for_user,
+    load_agent_for_user,
+    load_agent_run_for_user,
+)
 from src.models.contracts.agent_run_flag_conversations import (
     FlagConversationResponse,
     SendFlagMessageRequest,
@@ -46,7 +52,6 @@ from src.models.contracts.executions import AIUsagePublicSimple, AIUsageTotalsSi
 from src.models.orm.agent_run_verdict_history import AgentRunVerdictHistory
 from src.models.orm.agent_runs import AgentRun
 from src.models.orm.ai_usage import AIUsage
-from src.models.orm.agents import Agent
 from src.models.orm.summary_backfill_job import SummaryBackfillJob
 from src.core.redis_client import get_redis_client
 from src.services.execution.agent_run_service import (
@@ -141,12 +146,8 @@ async def list_agent_runs(
 ) -> AgentRunListResponse:
     """List agent runs with optional filters."""
     # Build base query — exclude delegation sub-runs from top-level list
-    query = select(AgentRun).join(AgentRun.agent).where(AgentRun.parent_run_id.is_(None))
-
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
+    query = select(AgentRun).where(AgentRun.parent_run_id.is_(None))
+    query = apply_agent_run_access(query, user)
 
     # Apply optional filters
     if agent_id is not None:
@@ -248,7 +249,7 @@ async def list_agent_runs(
 # -----------------------------------------------------------------------------
 
 
-def _enforce_agent_scope(agent_id: UUID, user) -> None:  # type: ignore[no-untyped-def]
+async def _enforce_agent_scope(agent_id: UUID, db: DbSession, user) -> None:  # type: ignore[no-untyped-def]
     """Caller must be able to see the agent to aggregate its metadata.
 
     We keep the enforcement simple: any authenticated user can ask about
@@ -258,7 +259,12 @@ def _enforce_agent_scope(agent_id: UUID, user) -> None:  # type: ignore[no-untyp
     a run the caller could have seen — so there's no separate info leak
     vector beyond what ``GET /api/agent-runs?agent_id=...`` would expose.
     """
-    _ = user  # kept in the signature for future per-agent ACL checks
+    agent = await load_agent_for_user(db, agent_id, user)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Agent {agent_id} not found",
+        )
 
 
 @router.get(
@@ -276,7 +282,7 @@ async def get_metadata_keys(
     users don't have to guess which fields the summarizer actually
     extracts on this agent.
     """
-    _enforce_agent_scope(agent_id, user)
+    await _enforce_agent_scope(agent_id, db, user)
     conditions = [AgentRun.agent_id == agent_id]
     if not user.is_superuser and user.organization_id:
         conditions.append(AgentRun.org_id == user.organization_id)
@@ -310,7 +316,7 @@ async def get_metadata_values(
     Used by the filter UI when the user picks the 'eq' operator — lets
     them pick from a known-value list instead of free-typing.
     """
-    _enforce_agent_scope(agent_id, user)
+    await _enforce_agent_scope(agent_id, db, user)
     conditions = [AgentRun.agent_id == agent_id]
     if not user.is_superuser and user.organization_id:
         conditions.append(AgentRun.org_id == user.organization_id)
@@ -429,19 +435,12 @@ async def get_agent_run(
     user: CurrentActiveUser,
 ) -> AgentRunDetailResponse:
     """Get agent run detail with steps."""
-    query = (
-        select(AgentRun)
-        .options(selectinload(AgentRun.steps))
-        .where(AgentRun.id == run_id)
+    run = await load_agent_run_for_user(
+        db,
+        run_id,
+        user,
+        options=[selectinload(AgentRun.steps)],
     )
-
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
-
-    result = await db.execute(query)
-    run = result.scalar_one_or_none()
 
     if not run:
         raise HTTPException(
@@ -601,15 +600,7 @@ async def rerun_agent_run(
     user: CurrentActiveUser,
 ) -> AgentRunRerunResponse:
     """Rerun an agent run with the same input (async, non-blocking)."""
-    query = select(AgentRun).where(AgentRun.id == run_id)
-
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
-
-    result = await db.execute(query)
-    original = result.scalar_one_or_none()
+    original = await load_agent_run_for_user(db, run_id, user)
 
     if not original:
         raise HTTPException(
@@ -643,15 +634,7 @@ async def cancel_agent_run(
     user: CurrentActiveUser,
 ) -> dict:
     """Cancel a queued or running agent run."""
-    query = select(AgentRun).where(AgentRun.id == run_id)
-
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
-
-    result = await db.execute(query)
-    agent_run = result.scalar_one_or_none()
+    agent_run = await load_agent_run_for_user(db, run_id, user)
 
     if not agent_run:
         raise HTTPException(
@@ -715,15 +698,7 @@ async def set_verdict(
     user: CurrentActiveUser,
 ) -> VerdictResponse:
     """Set a verdict on a completed run. Records an audit row."""
-    query = select(AgentRun).where(AgentRun.id == run_id)
-
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
-
-    result = await db.execute(query)
-    run = result.scalar_one_or_none()
+    run = await load_agent_run_for_user(db, run_id, user)
 
     if not run:
         raise HTTPException(
@@ -771,15 +746,7 @@ async def clear_verdict(
     user: CurrentActiveUser,
 ) -> VerdictResponse:
     """Clear the verdict on a run. Records an audit row."""
-    query = select(AgentRun).where(AgentRun.id == run_id)
-
-    # Org filter: non-superusers see only their org's runs
-    if not user.is_superuser:
-        if user.organization_id:
-            query = query.where(AgentRun.org_id == user.organization_id)
-
-    result = await db.execute(query)
-    run = result.scalar_one_or_none()
+    run = await load_agent_run_for_user(db, run_id, user)
 
     if not run:
         raise HTTPException(
@@ -829,10 +796,7 @@ async def get_flag_conversation(
     Creates an empty conversation row if none exists yet so the UI can
     stream messages into a stable ``id``.
     """
-    query = select(AgentRun).where(AgentRun.id == run_id)
-    if not user.is_superuser and user.organization_id:
-        query = query.where(AgentRun.org_id == user.organization_id)
-    run = (await db.execute(query)).scalar_one_or_none()
+    run = await load_agent_run_for_user(db, run_id, user)
     if not run:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -862,10 +826,7 @@ async def send_flag_message(
     user: CurrentActiveUser,
 ) -> FlagConversationResponse:
     """Append a user turn and synchronously get the tuning-model reply."""
-    query = select(AgentRun).where(AgentRun.id == run_id)
-    if not user.is_superuser and user.organization_id:
-        query = query.where(AgentRun.org_id == user.organization_id)
-    run = (await db.execute(query)).scalar_one_or_none()
+    run = await load_agent_run_for_user(db, run_id, user)
     if not run:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -938,11 +899,7 @@ async def dry_run_agent_run(
     decision. Records an ``AIUsage`` row on the original run for cost
     tracking (``sequence=8000``).
     """
-    query = select(AgentRun).where(AgentRun.id == run_id)
-    if not user.is_superuser and user.organization_id:
-        query = query.where(AgentRun.org_id == user.organization_id)
-
-    run = (await db.execute(query)).scalar_one_or_none()
+    run = await load_agent_run_for_user(db, run_id, user)
     if not run:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -980,11 +937,7 @@ async def execute_agent_run(
     user: CurrentActiveUser,
 ) -> dict:
     """Execute an agent synchronously via the SDK."""
-    # Look up agent by name (case-insensitive)
-    result = await db.execute(
-        select(Agent).where(Agent.name.ilike(request.agent_name))
-    )
-    agent = result.scalar_one_or_none()
+    agent = await load_agent_by_name_for_user(db, request.agent_name, user)
 
     if not agent:
         raise HTTPException(

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -32,6 +32,9 @@ from src.services.agent_run_access import load_agent_run_for_user
 
 logger = logging.getLogger(__name__)
 
+_AGENT_RUNS_CHANNEL = "agent-runs"
+_AGENT_RUNS_CHANNEL_PREFIX = "agent-runs:"
+
 
 class WSError(Exception):
     """Subscribe-protocol error surfaced as an `error` ack to the client."""
@@ -485,18 +488,21 @@ async def can_access_app(user: UserPrincipal, app_id: str) -> bool:
 
 def _agent_runs_channel_for_user(user: UserPrincipal) -> str | None:
     if user.is_superuser:
-        return "agent-runs:all"
+        return f"{_AGENT_RUNS_CHANNEL_PREFIX}all"
     if user.organization_id:
-        return f"agent-runs:org:{user.organization_id}"
+        return f"{_AGENT_RUNS_CHANNEL_PREFIX}org:{user.organization_id}"
     return None
 
 
 def _resolve_agent_runs_channel(user: UserPrincipal, channel: str) -> str | None:
-    if channel == "agent-runs":
+    if channel == _AGENT_RUNS_CHANNEL:
         return _agent_runs_channel_for_user(user)
-    if channel == "agent-runs:all" or channel == "agent-runs:global":
+    if (
+        channel == f"{_AGENT_RUNS_CHANNEL_PREFIX}all"
+        or channel == f"{_AGENT_RUNS_CHANNEL_PREFIX}global"
+    ):
         return channel if user.is_superuser else None
-    if channel.startswith("agent-runs:org:"):
+    if channel.startswith(f"{_AGENT_RUNS_CHANNEL_PREFIX}org:"):
         org_id = channel.split(":", 2)[2]
         if user.is_superuser:
             return channel
@@ -646,7 +652,9 @@ async def websocket_connect(
             run_id = channel.split(":", 1)[1]
             if await can_access_agent_run(user, run_id):
                 allowed_channels.append(channel)
-        elif channel == "agent-runs" or channel.startswith("agent-runs:"):
+        elif channel == _AGENT_RUNS_CHANNEL or channel.startswith(
+            _AGENT_RUNS_CHANNEL_PREFIX
+        ):
             scoped_channel = _resolve_agent_runs_channel(user, channel)
             if scoped_channel:
                 allowed_channels.append(scoped_channel)
@@ -812,7 +820,9 @@ async def websocket_connect(
                                 "channel": channel,
                                 "message": "Access denied"
                             })
-                    elif channel == "agent-runs" or channel.startswith("agent-runs:"):
+                    elif channel == _AGENT_RUNS_CHANNEL or channel.startswith(
+                        _AGENT_RUNS_CHANNEL_PREFIX
+                    ):
                         scoped_channel = _resolve_agent_runs_channel(user, channel)
                         if scoped_channel:
                             if scoped_channel not in manager.connections:
@@ -889,7 +899,9 @@ async def websocket_connect(
             elif data.get("type") == "unsubscribe":
                 channel = data.get("channel")
                 if channel:
-                    if channel == "agent-runs" or channel.startswith("agent-runs:"):
+                    if channel == _AGENT_RUNS_CHANNEL or channel.startswith(
+                        _AGENT_RUNS_CHANNEL_PREFIX
+                    ):
                         channel = _resolve_agent_runs_channel(user, channel) or channel
                     # Table channels may be subscribed by name but registered
                     # under the canonical UUID channel. Resolve before pop.

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -28,6 +28,7 @@ from src.models.contracts.policies import Expr, TablePolicies
 from src.models.orm import Agent
 from src.models.orm.applications import Application
 from src.models.orm.tables import Table as TableOrm
+from src.services.agent_run_access import load_agent_run_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -482,6 +483,38 @@ async def can_access_app(user: UserPrincipal, app_id: str) -> bool:
         return org_id == user.organization_id
 
 
+def _agent_runs_channel_for_user(user: UserPrincipal) -> str | None:
+    if user.is_superuser:
+        return "agent-runs:all"
+    if user.organization_id:
+        return f"agent-runs:org:{user.organization_id}"
+    return None
+
+
+def _resolve_agent_runs_channel(user: UserPrincipal, channel: str) -> str | None:
+    if channel == "agent-runs":
+        return _agent_runs_channel_for_user(user)
+    if channel == "agent-runs:all" or channel == "agent-runs:global":
+        return channel if user.is_superuser else None
+    if channel.startswith("agent-runs:org:"):
+        org_id = channel.split(":", 2)[2]
+        if user.is_superuser:
+            return channel
+        return channel if str(user.organization_id) == org_id else None
+    return None
+
+
+async def can_access_agent_run(user: UserPrincipal, run_id: str) -> bool:
+    try:
+        run_uuid = UUID(run_id)
+    except ValueError:
+        return False
+
+    async with get_db_context() as db:
+        run = await load_agent_run_for_user(db, run_uuid, user)
+        return run is not None
+
+
 router = APIRouter(prefix="/ws", tags=["WebSocket"])
 
 
@@ -609,12 +642,14 @@ async def websocket_connect(
         elif channel == "system":
             allowed_channels.append(channel)
         elif channel.startswith("agent-run:"):
-            # Agent run detail channels - any authenticated user can subscribe
-            # Org-level access is enforced at the API query level
-            allowed_channels.append(channel)
-        elif channel == "agent-runs":
-            # Agent run list channel for real-time updates
-            allowed_channels.append(channel)
+            # Agent run detail channels carry per-run metadata/steps.
+            run_id = channel.split(":", 1)[1]
+            if await can_access_agent_run(user, run_id):
+                allowed_channels.append(channel)
+        elif channel == "agent-runs" or channel.startswith("agent-runs:"):
+            scoped_channel = _resolve_agent_runs_channel(user, channel)
+            if scoped_channel:
+                allowed_channels.append(scoped_channel)
         elif channel.startswith("summary-backfill:"):
             # Summary backfill job progress — platform admins only
             if user.is_superuser:
@@ -761,15 +796,38 @@ async def websocket_connect(
                             "type": "subscribed",
                             "channel": channel
                         })
-                    elif channel.startswith("agent-run:") or channel == "agent-runs":
-                        # Agent run channels - any authenticated user can subscribe
-                        if channel not in manager.connections:
-                            manager.connections[channel] = set()
-                        manager.connections[channel].add(websocket)
-                        await websocket.send_json({
-                            "type": "subscribed",
-                            "channel": channel
-                        })
+                    elif channel.startswith("agent-run:"):
+                        run_id = channel.split(":", 1)[1]
+                        if await can_access_agent_run(user, run_id):
+                            if channel not in manager.connections:
+                                manager.connections[channel] = set()
+                            manager.connections[channel].add(websocket)
+                            await websocket.send_json({
+                                "type": "subscribed",
+                                "channel": channel
+                            })
+                        else:
+                            await websocket.send_json({
+                                "type": "error",
+                                "channel": channel,
+                                "message": "Access denied"
+                            })
+                    elif channel == "agent-runs" or channel.startswith("agent-runs:"):
+                        scoped_channel = _resolve_agent_runs_channel(user, channel)
+                        if scoped_channel:
+                            if scoped_channel not in manager.connections:
+                                manager.connections[scoped_channel] = set()
+                            manager.connections[scoped_channel].add(websocket)
+                            await websocket.send_json({
+                                "type": "subscribed",
+                                "channel": scoped_channel
+                            })
+                        else:
+                            await websocket.send_json({
+                                "type": "error",
+                                "channel": channel,
+                                "message": "Access denied"
+                            })
                     elif channel.startswith("summary-backfill:"):
                         # Summary backfill job progress — platform admins only.
                         # Mirrors the initial-connect whitelist above; without this
@@ -831,6 +889,8 @@ async def websocket_connect(
             elif data.get("type") == "unsubscribe":
                 channel = data.get("channel")
                 if channel:
+                    if channel == "agent-runs" or channel.startswith("agent-runs:"):
+                        channel = _resolve_agent_runs_channel(user, channel) or channel
                     # Table channels may be subscribed by name but registered
                     # under the canonical UUID channel. Resolve before pop.
                     if channel.startswith("table:"):

--- a/api/src/services/agent_run_access.py
+++ b/api/src/services/agent_run_access.py
@@ -1,0 +1,108 @@
+"""Authorization helpers for agent-run HTTP and WebSocket surfaces."""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import Select, and_, exists, false, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import UserPrincipal
+from src.models.enums import AgentAccessLevel
+from src.models.orm.agent_runs import AgentRun
+from src.models.orm.agents import Agent, AgentRole
+from src.models.orm.users import UserRole
+
+
+def _agent_role_exists_for_user(user: UserPrincipal):
+    user_role_ids = select(UserRole.role_id).where(UserRole.user_id == user.user_id)
+    return (
+        exists()
+        .where(AgentRole.agent_id == Agent.id)
+        .where(AgentRole.role_id.in_(user_role_ids))
+    )
+
+
+def agent_access_conditions(user: UserPrincipal) -> list:
+    """Return SQLAlchemy conditions matching the normal agent access model."""
+    if user.is_superuser:
+        return []
+
+    if user.organization_id is None:
+        return [false()]
+
+    private_owner = and_(
+        Agent.access_level == AgentAccessLevel.PRIVATE,
+        Agent.owner_user_id == user.user_id,
+    )
+    in_scope = or_(
+        Agent.organization_id == user.organization_id,
+        Agent.organization_id.is_(None),
+        private_owner,
+    )
+    has_access = or_(
+        Agent.access_level == AgentAccessLevel.AUTHENTICATED,
+        private_owner,
+        and_(
+            Agent.access_level == AgentAccessLevel.ROLE_BASED,
+            _agent_role_exists_for_user(user),
+        ),
+    )
+    return [in_scope, has_access]
+
+
+def apply_agent_run_access(
+    query: Select[tuple[AgentRun]],
+    user: UserPrincipal,
+) -> Select[tuple[AgentRun]]:
+    """Apply tenant and agent visibility checks to an AgentRun query."""
+    query = query.join(Agent, AgentRun.agent_id == Agent.id)
+    if user.is_superuser:
+        return query
+
+    if user.organization_id is None:
+        return query.where(false())
+
+    return query.where(
+        AgentRun.org_id == user.organization_id,
+        *agent_access_conditions(user),
+    )
+
+
+async def load_agent_for_user(
+    db: AsyncSession,
+    agent_id: UUID,
+    user: UserPrincipal,
+) -> Agent | None:
+    query = select(Agent).where(Agent.id == agent_id)
+    query = query.where(*agent_access_conditions(user))
+    result = await db.execute(query)
+    return result.scalar_one_or_none()
+
+
+async def load_agent_by_name_for_user(
+    db: AsyncSession,
+    agent_name: str,
+    user: UserPrincipal,
+) -> Agent | None:
+    query = select(Agent).where(Agent.name.ilike(agent_name))
+    query = query.where(*agent_access_conditions(user))
+    if user.organization_id is not None:
+        query = query.order_by((Agent.organization_id == user.organization_id).desc())
+    result = await db.execute(query)
+    return result.scalars().first()
+
+
+async def load_agent_run_for_user(
+    db: AsyncSession,
+    run_id: UUID,
+    user: UserPrincipal,
+    *,
+    options: Sequence | None = None,
+) -> AgentRun | None:
+    query = select(AgentRun).where(AgentRun.id == run_id)
+    if options:
+        query = query.options(*options)
+    query = apply_agent_run_access(query, user)
+    result = await db.execute(query)
+    return result.scalar_one_or_none()

--- a/api/tests/unit/test_agent_run_authorization.py
+++ b/api/tests/unit/test_agent_run_authorization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
@@ -289,8 +290,9 @@ async def test_websocket_agent_runs_alias_subscribes_to_user_org_channel():
         patch("src.routers.websocket.manager.connect", new=AsyncMock()) as connect,
         patch("src.routers.websocket.manager.disconnect"),
     ):
-        await websocket_connect(websocket, channels=["agent-runs"])
+        await websocket_connect(cast(Any, websocket), channels=["agent-runs"])
 
+    assert connect.await_args is not None
     subscribed_channels = connect.await_args.args[1]
     assert f"agent-runs:org:{org_id}" in subscribed_channels
     assert "agent-runs" not in subscribed_channels

--- a/api/tests/unit/test_agent_run_authorization.py
+++ b/api/tests/unit/test_agent_run_authorization.py
@@ -1,0 +1,296 @@
+"""Agent-run authorization and stream scoping regressions."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException, WebSocketDisconnect
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import UserPrincipal
+from src.core.pubsub import publish_agent_run_update
+from src.models.contracts.agent_runs import AgentRunCreateRequest
+from src.models.enums import AgentAccessLevel
+from src.models.orm.agent_runs import AgentRun
+from src.models.orm.agents import Agent, AgentRole
+from src.models.orm.organizations import Organization
+from src.models.orm.users import Role, User, UserRole
+from src.routers.agent_runs import execute_agent_run, list_agent_runs, rerun_agent_run
+from src.routers.websocket import websocket_connect
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _principal(
+    user_id: UUID,
+    org_id: UUID | None,
+    *,
+    is_superuser: bool = False,
+) -> UserPrincipal:
+    return UserPrincipal(
+        user_id=user_id,
+        email=f"{user_id}@example.test",
+        organization_id=org_id,
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+        roles=[],
+    )
+
+
+async def _make_org(db: AsyncSession, name: str) -> Organization:
+    org = Organization(
+        id=uuid4(),
+        name=name,
+        domain=f"{name.lower()}-{uuid4().hex[:8]}.example.test",
+        created_by="test@example.com",
+    )
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _make_user(db: AsyncSession, org: Organization) -> User:
+    user = User(
+        id=uuid4(),
+        email=f"user-{uuid4().hex[:8]}@example.test",
+        name="Agent Run User",
+        organization_id=org.id,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        is_registered=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_role_based_agent(
+    db: AsyncSession,
+    org: Organization,
+) -> tuple[Agent, Role]:
+    role = Role(
+        id=uuid4(),
+        name=f"agent-run-role-{uuid4().hex[:8]}",
+        created_by="test@example.com",
+    )
+    agent = Agent(
+        id=uuid4(),
+        name=f"agent-run-auth-{uuid4().hex[:8]}",
+        description="role-gated agent",
+        system_prompt="You are a role-gated test agent.",
+        channels=["chat"],
+        access_level=AgentAccessLevel.ROLE_BASED,
+        organization_id=org.id,
+        is_active=True,
+        knowledge_sources=[],
+        system_tools=[],
+        created_by="test@example.com",
+    )
+    db.add_all([role, agent])
+    await db.flush()
+    db.add(AgentRole(agent_id=agent.id, role_id=role.id, assigned_by="test@example.com"))
+    await db.flush()
+    return agent, role
+
+
+async def _make_authenticated_agent(db: AsyncSession, org: Organization) -> Agent:
+    agent = Agent(
+        id=uuid4(),
+        name=f"agent-run-authenticated-{uuid4().hex[:8]}",
+        description="org-scoped authenticated agent",
+        system_prompt="You are an authenticated test agent.",
+        channels=["chat"],
+        access_level=AgentAccessLevel.AUTHENTICATED,
+        organization_id=org.id,
+        is_active=True,
+        knowledge_sources=[],
+        system_tools=[],
+        created_by="test@example.com",
+    )
+    db.add(agent)
+    await db.flush()
+    return agent
+
+
+async def _make_run(db: AsyncSession, agent: Agent, org: Organization) -> AgentRun:
+    run = AgentRun(
+        id=uuid4(),
+        agent_id=agent.id,
+        trigger_type="api",
+        status="completed",
+        org_id=org.id,
+        iterations_used=1,
+        tokens_used=100,
+        asked="Sensitive customer question",
+        did="Sensitive customer action",
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add(run)
+    await db.flush()
+    return run
+
+
+async def _list_runs_for_user(db: AsyncSession, user: UserPrincipal):
+    return await list_agent_runs(
+        db,
+        user,
+        agent_id=None,
+        status_filter=None,
+        trigger_type=None,
+        org_id=None,
+        start_date=None,
+        end_date=None,
+        q=None,
+        verdict=None,
+        metadata_filter=None,
+        limit=50,
+        offset=0,
+    )
+
+
+async def test_list_agent_runs_hides_same_org_role_based_agent_without_role(
+    db_session: AsyncSession,
+):
+    org = await _make_org(db_session, "OrgA")
+    user = await _make_user(db_session, org)
+    agent, _role = await _make_role_based_agent(db_session, org)
+    await _make_run(db_session, agent, org)
+
+    response = await _list_runs_for_user(db_session, _principal(user.id, org.id))
+
+    assert response.total == 0
+    assert response.items == []
+
+
+async def test_rerun_agent_run_blocks_same_org_user_without_agent_role(
+    db_session: AsyncSession,
+):
+    org = await _make_org(db_session, "OrgA")
+    user = await _make_user(db_session, org)
+    agent, _role = await _make_role_based_agent(db_session, org)
+    run = await _make_run(db_session, agent, org)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await rerun_agent_run(run.id, db_session, _principal(user.id, org.id))
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_execute_agent_run_blocks_same_org_user_without_agent_role(
+    db_session: AsyncSession,
+):
+    org = await _make_org(db_session, "OrgA")
+    user = await _make_user(db_session, org)
+    agent, _role = await _make_role_based_agent(db_session, org)
+
+    request = AgentRunCreateRequest(
+        agent_name=agent.name,
+        input={"ticket_id": 123},
+        timeout=1,
+    )
+
+    with (
+        patch(
+            "src.routers.agent_runs.enqueue_agent_run",
+            new=AsyncMock(return_value=str(uuid4())),
+        ),
+        patch(
+            "src.routers.agent_runs.wait_for_agent_run_result",
+            new=AsyncMock(return_value={"status": "completed"}),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await execute_agent_run(request, db_session, _principal(user.id, org.id))
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_execute_agent_run_blocks_cross_org_authenticated_agent(
+    db_session: AsyncSession,
+):
+    owner_org = await _make_org(db_session, "OwnerOrg")
+    caller_org = await _make_org(db_session, "CallerOrg")
+    caller = await _make_user(db_session, caller_org)
+    agent = await _make_authenticated_agent(db_session, owner_org)
+
+    request = AgentRunCreateRequest(
+        agent_name=agent.name,
+        input={"ticket_id": 123},
+        timeout=1,
+    )
+
+    with (
+        patch(
+            "src.routers.agent_runs.enqueue_agent_run",
+            new=AsyncMock(return_value=str(uuid4())),
+        ),
+        patch(
+            "src.routers.agent_runs.wait_for_agent_run_result",
+            new=AsyncMock(return_value={"status": "completed"}),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await execute_agent_run(request, db_session, _principal(caller.id, caller_org.id))
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_user_with_agent_role_can_list_agent_run(db_session: AsyncSession):
+    org = await _make_org(db_session, "OrgA")
+    user = await _make_user(db_session, org)
+    agent, role = await _make_role_based_agent(db_session, org)
+    run = await _make_run(db_session, agent, org)
+    db_session.add(
+        UserRole(user_id=user.id, role_id=role.id, assigned_by="test@example.com")
+    )
+    await db_session.flush()
+
+    response = await _list_runs_for_user(db_session, _principal(user.id, org.id))
+
+    assert response.total == 1
+    assert response.items[0].id == run.id
+
+
+async def test_publish_agent_run_update_uses_scoped_list_channels(
+    db_session: AsyncSession,
+):
+    org = await _make_org(db_session, "OrgA")
+    agent, _role = await _make_role_based_agent(db_session, org)
+    run = await _make_run(db_session, agent, org)
+
+    with patch("src.core.pubsub.manager.broadcast", new=AsyncMock()) as broadcast:
+        await publish_agent_run_update(run, agent.name)
+
+    channels = [call.args[0] for call in broadcast.await_args_list]
+    assert f"agent-run:{run.id}" in channels
+    assert f"agent-runs:org:{org.id}" in channels
+    assert "agent-runs:all" in channels
+    assert "agent-runs" not in channels
+
+
+async def test_websocket_agent_runs_alias_subscribes_to_user_org_channel():
+    org_id = uuid4()
+    user_id = uuid4()
+    websocket = SimpleNamespace(state=SimpleNamespace())
+    websocket.send_json = AsyncMock()
+    websocket.receive_json = AsyncMock(side_effect=WebSocketDisconnect())
+
+    with (
+        patch(
+            "src.routers.websocket.get_current_user_ws",
+            new=AsyncMock(return_value=_principal(user_id, org_id)),
+        ),
+        patch("src.routers.websocket.manager.connect", new=AsyncMock()) as connect,
+        patch("src.routers.websocket.manager.disconnect"),
+    ):
+        await websocket_connect(websocket, channels=["agent-runs"])
+
+    subscribed_channels = connect.await_args.args[1]
+    assert f"agent-runs:org:{org_id}" in subscribed_channels
+    assert "agent-runs" not in subscribed_channels


### PR DESCRIPTION
## Summary
- add shared agent-run access checks for tenant, role, and private-agent visibility
- enforce authorization on agent run list/detail/execute/rerun/cancel/verdict/flag/dry-run surfaces
- scope agent-run pubsub and websocket subscriptions away from global cross-org broadcasts

## Verification
- ./test.sh tests/unit/test_agent_run_authorization.py -q
- Docker test-runner adjacent suite: tests/unit/test_agent_run_authorization.py tests/unit/policies/test_pubsub.py tests/unit/services/test_agent_run_service.py tests/unit/test_agent_run_response_includes_new_fields.py
- Docker test-runner Ruff on touched files
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced access control for agent runs with organization and role-based permission scoping
  * Real-time updates for agent runs now properly respect user permissions and organizational boundaries
  * WebSocket subscriptions now correctly enforce user access levels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->