### PR TITLE
Harden CLI local path handling

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -2511,14 +2511,8 @@ async def _process_incoming(
                     data = resp.json()
                     content = base64.b64decode(data["content"])
                     content_hash = _hash_for_cache(content)
-                    # Convert repo_path to local path
-                    if repo_prefix and repo_path.startswith(repo_prefix + "/"):
-                        rel = repo_path[len(repo_prefix) + 1:]
-                    elif repo_prefix and repo_path.startswith(repo_prefix):
-                        rel = repo_path[len(repo_prefix):]
-                    else:
-                        rel = repo_path
-                    local_file = base_path / rel
+                    rel = _strip_repo_prefix(repo_path, repo_prefix)
+                    local_file = _safe_local_path(base_path, rel)
                     local_file.parent.mkdir(parents=True, exist_ok=True)
                     # Skip if we already know the server has this content and
                     # the local file matches (cache hit). Falls back to a byte
@@ -2558,13 +2552,16 @@ async def _process_incoming(
     # Process incoming deletes
     for paths, user_name in deletes:
         for repo_path in paths:
-            if repo_prefix and repo_path.startswith(repo_prefix + "/"):
-                rel = repo_path[len(repo_prefix) + 1:]
-            elif repo_prefix and repo_path.startswith(repo_prefix):
-                rel = repo_path[len(repo_prefix):]
-            else:
-                rel = repo_path
-            local_file = base_path / rel
+            try:
+                rel = _strip_repo_prefix(repo_path, repo_prefix)
+                local_file = _safe_local_path(base_path, rel)
+            except ValueError as e:
+                if watch_app:
+                    watch_app.log_error(f"Error deleting {repo_path}: {e}")
+                else:
+                    print(f"  [{ts}] ← Error deleting {repo_path}: {e}", flush=True)
+                state.forget_known_hash(repo_path)
+                continue
             if local_file.exists():
                 try:
                     local_file.unlink()
@@ -2793,9 +2790,35 @@ def _strip_repo_prefix(repo_path: str, repo_prefix: str) -> str:
     """Strip the repo prefix from a repo path to get the local relative path."""
     if repo_prefix and repo_path.startswith(repo_prefix + "/"):
         return repo_path[len(repo_prefix) + 1:]
-    if repo_prefix and repo_path.startswith(repo_prefix):
-        return repo_path[len(repo_prefix):]
+    if repo_prefix and repo_path == repo_prefix:
+        return ""
     return repo_path
+
+
+def _validate_server_rel_path(rel_path: str) -> str:
+    """Return a normalized server path that is safe to join under a local root."""
+    if "\x00" in rel_path or "\\" in rel_path:
+        raise ValueError(f"unsafe server path: {rel_path!r}")
+    if pathlib.PureWindowsPath(rel_path).drive:
+        raise ValueError(f"unsafe server path: {rel_path!r}")
+    pure = pathlib.PurePosixPath(rel_path)
+    if pure.is_absolute():
+        raise ValueError(f"unsafe server path: {rel_path!r}")
+    parts = rel_path.split("/")
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"unsafe server path: {rel_path!r}")
+    return pure.as_posix()
+
+
+def _safe_local_path(base_path: pathlib.Path, rel_path: str) -> pathlib.Path:
+    """Resolve a server-provided relative path and prove it stays under base_path."""
+    safe_rel = _validate_server_rel_path(rel_path)
+    base_resolved = base_path.resolve(strict=False)
+    target = base_resolved / safe_rel
+    target_resolved = target.resolve(strict=False)
+    if target_resolved != base_resolved and base_resolved not in target_resolved.parents:
+        raise ValueError(f"unsafe server path: {rel_path!r}")
+    return target
 
 
 def _should_skip_path(rel_path: str, spec: "pathspec.PathSpec") -> bool:
@@ -2900,6 +2923,7 @@ async def _sync_files(
 
     # Track which server paths we've matched to a local file
     matched_server_paths: set[str] = set()
+    unsafe_errors: list[str] = []
 
     for repo_path, content in regular_files.items():
         rel = _strip_repo_prefix(repo_path, repo_prefix)
@@ -2970,6 +2994,11 @@ async def _sync_files(
         if server_path in files:
             continue
         rel = _strip_repo_prefix(server_path, repo_prefix)
+        try:
+            rel = _validate_server_rel_path(rel)
+        except ValueError as exc:
+            unsafe_errors.append(f"Unsafe server path {server_path!r}: {exc}")
+            continue
         if _is_bifrost_path(rel):
             continue
         if _should_skip_path(rel, spec):
@@ -2989,6 +3018,11 @@ async def _sync_files(
 
     # ── 4. Check if there's anything to sync ─────────────────────────────
     if not sync_items:
+        if unsafe_errors:
+            print(f"Errors ({len(unsafe_errors)}):", file=sys.stderr)
+            for error in unsafe_errors:
+                print(f"  {error}", file=sys.stderr)
+            return 1
         print("Already up to date.")
         return 0
 
@@ -3071,7 +3105,7 @@ async def _sync_files(
             if resp.status_code == 200:
                 file_data = resp.json()
                 content_bytes = base64.b64decode(file_data["content"])
-                local_file = path / item["rel"]
+                local_file = _safe_local_path(path, item["rel"])
                 local_file.parent.mkdir(parents=True, exist_ok=True)
                 local_file.write_bytes(content_bytes)
             else:
@@ -3081,7 +3115,7 @@ async def _sync_files(
             item = work_data["item"]
             # Delete locally-only files (new locally + user chose delete)
             if item.get("why") == "new locally":
-                local_file = path / item["rel"]
+                local_file = _safe_local_path(path, item["rel"])
                 if local_file.exists():
                     local_file.unlink()
             else:
@@ -3111,7 +3145,7 @@ async def _sync_files(
             parts.append(f"{unchanged} unchanged")
         return ", ".join(parts) if parts else "No changes"
 
-    errors: list[str] = []
+    errors: list[str] = list(unsafe_errors)
     if progress_items and _is_tty:
         from bifrost.tui.progress import ProgressApp
         app = ProgressApp("Syncing", progress_items, _do_sync_work, post_fn=_post_sync)

--- a/api/bifrost/commands/import_cmd.py
+++ b/api/bifrost/commands/import_cmd.py
@@ -503,7 +503,7 @@ async def import_apply(
     """
     await _import_impl(
         client=client,
-        bundle_dir=bundle_dir.resolve(),
+        bundle_dir=bundle_dir,
         target_org=target_org,
         role_mode=role_mode.lower(),
         dry_run=dry_run,

--- a/api/bifrost/git_commands.py
+++ b/api/bifrost/git_commands.py
@@ -5,6 +5,7 @@ Subcommands for `bifrost git` that mirror the UI's source control panel.
 Each command queues a job via the API and polls for results.
 """
 
+import shlex
 import sys
 import time
 
@@ -176,8 +177,14 @@ def _format_sync_result(result: dict) -> list[str]:
         lines.append("To resolve conflicts, run:")
         for conflict in conflicts:
             path = conflict.get("path", "unknown")
-            lines.append(f"  bifrost git resolve {path}=keep_remote")
-            lines.append(f"  bifrost git resolve {path}=keep_local")
+            lines.append(
+                "  "
+                + shlex.join(["bifrost", "git", "resolve", f"{path}=keep_remote"])
+            )
+            lines.append(
+                "  "
+                + shlex.join(["bifrost", "git", "resolve", f"{path}=keep_local"])
+            )
         lines.append("")
         lines.append(
             "Or manage this in the Code Editor's Source Control at your Bifrost instance."

--- a/api/bifrost/skill.py
+++ b/api/bifrost/skill.py
@@ -61,6 +61,16 @@ def _validate_skill_relpath(relpath: str) -> str:
     return PurePosixPath(*parts).as_posix()
 
 
+def _validate_public_skill_link(linkname: str) -> str:
+    """Return the skill folder targeted by a public ``skills/`` symlink."""
+    if "\\" in linkname or PurePosixPath(linkname).is_absolute() or Path(linkname).drive:
+        raise ValueError(f"unsafe public skill link in tarball: {linkname!r}")
+    parts = PurePosixPath(linkname).parts
+    if len(parts) != 4 or parts[:3] != ("..", ".claude", "skills"):
+        raise ValueError(f"unsafe public skill link in tarball: {linkname!r}")
+    return _validate_skill_name(parts[3])
+
+
 def _safe_skill_target(root: Path, skill_name: str) -> Path:
     """Build a skill target path and prove it stays below ``root``."""
     safe_name = _validate_skill_name(skill_name)
@@ -285,7 +295,7 @@ def _fetch_skill_files(repo: str, ref: str) -> dict[str, bytes]:
             _validate_skill_name(name)
             if member.issym() or member.islnk():
                 try:
-                    target_name = _validate_skill_name(PurePosixPath(member.linkname).name)
+                    target_name = _validate_public_skill_link(member.linkname)
                 except ValueError as exc:
                     raise ValueError(str(exc)) from exc
                 public_skills.add(target_name or name)

--- a/api/tests/unit/cli/test_import_security.py
+++ b/api/tests/unit/cli/test_import_security.py
@@ -55,6 +55,20 @@ def test_code_symlink_is_rejected_before_upload(
         _collect_code_files(bundle)
 
 
+def test_bundle_directory_symlink_is_rejected(tmp_path: pathlib.Path) -> None:
+    real_bundle = tmp_path / "real-bundle"
+    (real_bundle / ".bifrost").mkdir(parents=True)
+    (real_bundle / ".bifrost/workflows.yaml").write_text("[]\n", encoding="utf-8")
+    bundle_link = tmp_path / "bundle-link"
+    try:
+        bundle_link.symlink_to(real_bundle, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    with pytest.raises(click.ClickException, match="must not be a symlink"):
+        _validate_bundle_dir(bundle_link)
+
+
 def test_regular_bundle_files_are_still_collected(tmp_path: pathlib.Path) -> None:
     bundle = tmp_path / "bundle"
     (bundle / ".bifrost").mkdir(parents=True)

--- a/api/tests/unit/cli/test_path_safety.py
+++ b/api/tests/unit/cli/test_path_safety.py
@@ -1,0 +1,81 @@
+"""Security regressions for CLI local path handling."""
+
+from __future__ import annotations
+
+import base64
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from bifrost import cli
+
+
+class _Response:
+    def __init__(self, status_code: int, body: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+        self.text = ""
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _PullClient:
+    def __init__(self, server_path: str, content: bytes) -> None:
+        self.server_path = server_path
+        self.content = content
+
+    async def post(self, endpoint: str, json: dict[str, Any]) -> _Response:
+        if endpoint == "/api/files/list":
+            return _Response(
+                200,
+                {
+                    "files_metadata": [
+                        {
+                            "path": self.server_path,
+                            "etag": "server-md5",
+                            "last_modified": datetime.now(timezone.utc).isoformat(),
+                            "updated_by": "attacker",
+                        }
+                    ]
+                },
+            )
+        if endpoint == "/api/files/read":
+            assert json["path"] == self.server_path
+            return _Response(
+                200,
+                {"content": base64.b64encode(self.content).decode("ascii")},
+            )
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+
+@pytest.mark.asyncio
+async def test_pull_rejects_server_path_traversal(tmp_path: pathlib.Path) -> None:
+    outside = tmp_path.parent / "outside.txt"
+    outside.unlink(missing_ok=True)
+
+    rc = await cli._sync_files(
+        str(tmp_path),
+        force=True,
+        client=_PullClient("../outside.txt", b"stolen"),
+    )
+
+    assert rc == 1
+    assert not outside.exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_rejects_absolute_server_path(tmp_path: pathlib.Path) -> None:
+    absolute = pathlib.Path(tmp_path.anchor) / "bifrost-escape.txt"
+    if not tmp_path.anchor:
+        absolute = pathlib.Path("/tmp/bifrost-escape.txt")
+
+    rc = await cli._sync_files(
+        str(tmp_path),
+        force=True,
+        client=_PullClient(absolute.as_posix(), b"stolen"),
+    )
+
+    assert rc == 1

--- a/api/tests/unit/cli/test_path_safety.py
+++ b/api/tests/unit/cli/test_path_safety.py
@@ -68,9 +68,7 @@ async def test_pull_rejects_server_path_traversal(tmp_path: pathlib.Path) -> Non
 
 @pytest.mark.asyncio
 async def test_pull_rejects_absolute_server_path(tmp_path: pathlib.Path) -> None:
-    absolute = pathlib.Path(tmp_path.anchor) / "bifrost-escape.txt"
-    if not tmp_path.anchor:
-        absolute = pathlib.Path("/tmp/bifrost-escape.txt")
+    absolute = tmp_path / "absolute-server-path.txt"
 
     rc = await cli._sync_files(
         str(tmp_path),
@@ -79,3 +77,4 @@ async def test_pull_rejects_absolute_server_path(tmp_path: pathlib.Path) -> None
     )
 
     assert rc == 1
+    assert not absolute.exists()

--- a/api/tests/unit/cli/test_sync.py
+++ b/api/tests/unit/cli/test_sync.py
@@ -52,6 +52,25 @@ class TestFormatSyncResult:
         assert "keep_remote" in text
         assert "keep_local" in text
 
+    def test_conflict_resolution_commands_quote_paths(self):
+        """Suggested resolve commands must be safe to copy into a shell."""
+        result = {
+            "status": "conflict",
+            "conflicts": [
+                {
+                    "path": "workflows/billing.py; echo owned",
+                    "display_name": "billing",
+                    "entity_type": "workflow",
+                },
+            ],
+        }
+
+        lines = _format_sync_result(result)
+        text = "\n".join(lines)
+
+        assert "bifrost git resolve 'workflows/billing.py; echo owned=keep_remote'" in text
+        assert "bifrost git resolve workflows/billing.py; echo owned=keep_remote" not in text
+
     def test_multiple_conflicts(self):
         """Should list all conflicts."""
         result = {

--- a/api/tests/unit/test_cli_skill.py
+++ b/api/tests/unit/test_cli_skill.py
@@ -252,6 +252,27 @@ class TestSkillUpdate:
         out = capsys.readouterr().out
         assert "Installed bifrost-build" in out
 
+    def test_rejects_public_skill_symlink_target_traversal(
+        self,
+        workspace: Path,
+        stub_github,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        stub_github["install"](
+            {
+                ".claude/skills/evil/SKILL.md": b"evil\n",
+            },
+        )
+        stub_github["public_skills"] = ["build"]  # type: ignore[index]
+        stub_github["public_skill_targets"] = {"build": "../../evil"}  # type: ignore[index]
+
+        rc = skill_module.handle_skill(["update"])
+
+        assert rc == 1
+        assert "unsafe public skill link" in capsys.readouterr().err
+        assert not (workspace / ".claude/skills/evil").exists()
+        assert not (workspace / ".agents/skills/evil").exists()
+
     def test_repo_with_no_public_skills_errors(
         self,
         workspace: Path,


### PR DESCRIPTION
## Summary
- reject unsafe local path traversal and symlink escapes in CLI import/pull flows
- harden skill archive extraction/install paths against escaping the intended directory
- render sync conflict guidance without shell-injection-prone command strings

## Verification
- python -m pytest api/tests/unit/cli/test_path_safety.py api/tests/unit/cli/test_sync.py::TestFormatSyncResult::test_conflict_resolution_commands_quote_paths api/tests/unit/test_cli_skill.py::TestSkillUpdate::test_rejects_public_skill_symlink_target_traversal api/tests/unit/cli/test_import_security.py::test_bundle_directory_symlink_is_rejected -q
- python -m pytest api/tests/unit/cli/test_path_safety.py api/tests/unit/cli/test_import_security.py api/tests/unit/cli/test_sync.py api/tests/unit/test_cli_skill.py -q
- python -m pytest api/tests/unit/cli -q