### PR TITLE
Scope embed tokens to forms and apps

### DIFF
--- a/api/src/core/embed_middleware.py
+++ b/api/src/core/embed_middleware.py
@@ -11,6 +11,7 @@ they created (tracked via Redis using the token's jti).
 
 import logging
 import re
+from dataclasses import dataclass
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -20,39 +21,44 @@ from src.core.security import decode_token
 
 logger = logging.getLogger(__name__)
 
-# Paths that embed tokens are allowed to access.
-# Uses regex patterns to support path parameters.
-EMBED_ALLOWED_PATTERNS = [
+@dataclass(frozen=True)
+class EmbedRouteRule:
+    methods: frozenset[str]
+    pattern: re.Pattern[str]
+    scope: str | None = None
+
+
+# Paths that embed tokens are allowed to access. Rules are method-aware so
+# read/render allowlist entries cannot accidentally authorize mutations.
+EMBED_ALLOWED_RULES = [
     # App loading and rendering
-    r"^/api/applications/[^/]+$",          # GET /api/applications/{slug}
-    r"^/api/applications/[^/]+/render$",   # GET /api/applications/{app_id}/render
-    r"^/api/applications/[^/]+/files",     # GET /api/applications/{app_id}/files/...
-    r"^/api/applications/[^/]+/dependencies$",  # GET /api/applications/{app_id}/dependencies
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/api/applications/([^/]+)$"), "app_ref"),
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/api/applications/([^/]+)/render$"), "app_id"),
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/api/applications/([^/]+)/files(?:/.*)?$"), "app_id"),
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/api/applications/([^/]+)/dependencies$"), "app_id"),
 
     # Workflow execution
-    r"^/api/workflows/execute$",           # POST /api/workflows/execute
-    r"^/api/executions/",                  # GET /api/executions/{id}...
+    EmbedRouteRule(frozenset({"POST"}), re.compile(r"^/api/workflows/execute$"), "app_token"),
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/api/executions/"), None),
 
     # Auth status (SPA checks this on load)
-    r"^/auth/status$",
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/auth/status$"), None),
 
     # Branding (SPA loads this for theming)
-    r"^/api/branding$",
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/api/branding$"), None),
 
     # WebSocket for execution streaming
-    r"^/ws",
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/ws"), None),
 
     # Health check
-    r"^/health$",
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/health$"), None),
 
     # Form loading and execution
-    r"^/api/forms/[^/]+$",              # GET /api/forms/{form_id}
-    r"^/api/forms/[^/]+/execute$",      # POST /api/forms/{form_id}/execute
-    r"^/api/forms/[^/]+/startup$",      # POST /api/forms/{form_id}/startup
-    r"^/api/forms/[^/]+/upload$",       # POST /api/forms/{form_id}/upload
+    EmbedRouteRule(frozenset({"GET"}), re.compile(r"^/api/forms/([^/]+)$"), "form_id"),
+    EmbedRouteRule(frozenset({"POST"}), re.compile(r"^/api/forms/([^/]+)/execute$"), "form_id"),
+    EmbedRouteRule(frozenset({"POST"}), re.compile(r"^/api/forms/([^/]+)/startup$"), "form_id"),
+    EmbedRouteRule(frozenset({"POST"}), re.compile(r"^/api/forms/([^/]+)/upload$"), "form_id"),
 ]
-
-_COMPILED_PATTERNS = [re.compile(p) for p in EMBED_ALLOWED_PATTERNS]
 
 # Pattern to extract execution_id from /api/executions/{id}... paths
 _EXECUTION_PATH_RE = re.compile(r"^/api/executions/([0-9a-f-]{36})")
@@ -61,10 +67,15 @@ _EXECUTION_PATH_RE = re.compile(r"^/api/executions/([0-9a-f-]{36})")
 def _get_embed_payload(request: Request) -> dict | None:
     """Return the decoded JWT payload if this is an embed token, else None."""
     auth_header = request.headers.get("authorization", "")
-    if not auth_header.lower().startswith("bearer "):
+    token = None
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header[7:]
+    elif "embed_token" in request.cookies:
+        token = request.cookies["embed_token"]
+
+    if not token:
         return None
 
-    token = auth_header[7:]  # Strip "Bearer "
     payload = decode_token(token)
     if payload is None:
         return None
@@ -75,9 +86,36 @@ def _get_embed_payload(request: Request) -> dict | None:
     return payload
 
 
-def _path_allowed(path: str) -> bool:
+def _scope_allowed(scope: str | None, match: re.Match[str], payload: dict) -> bool:
+    if scope is None:
+        return True
+
+    if scope == "app_token":
+        return bool(payload.get("app_id")) and not payload.get("form_id")
+
+    if scope == "app_id":
+        return match.group(1) == payload.get("app_id")
+
+    if scope == "app_ref":
+        allowed_refs = {payload.get("app_id"), payload.get("app_slug")}
+        allowed_refs.discard(None)
+        return match.group(1) in allowed_refs
+
+    if scope == "form_id":
+        return match.group(1) == payload.get("form_id")
+
+    return False
+
+
+def _path_allowed(method: str, path: str, payload: dict) -> bool:
     """Check if the path is in the embed allowlist."""
-    return any(pattern.match(path) for pattern in _COMPILED_PATTERNS)
+    for rule in EMBED_ALLOWED_RULES:
+        if method.upper() not in rule.methods:
+            continue
+        match = rule.pattern.match(path)
+        if match and _scope_allowed(rule.scope, match, payload):
+            return True
+    return False
 
 
 class EmbedScopeMiddleware(BaseHTTPMiddleware):
@@ -89,7 +127,7 @@ class EmbedScopeMiddleware(BaseHTTPMiddleware):
         if payload is None:
             return await call_next(request)
 
-        if not _path_allowed(request.url.path):
+        if not _path_allowed(request.method, request.url.path, payload):
             logger.warning(
                 f"Embed token denied access to {request.method} {request.url.path}"
             )

--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -264,11 +264,14 @@ def create_embed_token(
 
     to_encode = {
         "sub": SYSTEM_USER_ID,
+        "jti": secrets.token_urlsafe(16),
         "app_id": app_id,
         "org_id": org_id,
         "verified_params": verified_params,
         "email": "embed@internal.gobifrost.com",
-        "is_superuser": True,
+        "is_superuser": False,
+        "embed": True,
+        "roles": ["EmbedUser"],
         "exp": expire,
         "type": "embed",
         "iss": settings.jwt_issuer,

--- a/api/src/routers/embed.py
+++ b/api/src/routers/embed.py
@@ -76,6 +76,7 @@ async def embed_app(
         "sub": SYSTEM_USER_ID,
         "jti": str(uuid.uuid4()),
         "app_id": str(app.id),
+        "app_slug": app.slug,
         "org_id": str(app.organization_id) if app.organization_id else None,
         "verified_params": verified_params,
         "email": "embed@internal.gobifrost.com",

--- a/api/src/services/embed_auth.py
+++ b/api/src/services/embed_auth.py
@@ -6,8 +6,8 @@ Two signing schemes are supported, selected per stored secret via the
 1. ``shopify`` — hex-encoded HMAC-SHA256 over the sorted query parameters
    (`key=value&key=value`). All params are signed.
 2. ``halopsa`` — base64-encoded HMAC-SHA256 over only the ``agent_id`` value.
-   Other URL params are NOT covered by the signature and must be treated as
-   untrusted user input.
+   Because no other URL params are covered by the signature, requests using
+   this scheme are accepted only when they contain ``agent_id`` and ``hmac``.
 """
 
 import base64
@@ -45,6 +45,9 @@ def _verify_shopify(query_params: dict[str, str], secret: str) -> bool:
 
 
 def _verify_halopsa(query_params: dict[str, str], secret: str) -> bool:
+    if set(query_params) - {"agent_id", "hmac"}:
+        return False
+
     received_hmac = query_params.get("hmac")
     agent_id = query_params.get("agent_id")
     if not received_hmac or not agent_id:

--- a/api/tests/e2e/api/test_embed.py
+++ b/api/tests/e2e/api/test_embed.py
@@ -1,7 +1,10 @@
 """E2E tests for HMAC-authenticated embed entry point."""
 
+import base64
 import hashlib
 import hmac as hmac_module
+import uuid
+from urllib.parse import urlparse
 
 import pytest
 
@@ -22,11 +25,24 @@ def _compute_hmac(params: dict[str, str], secret: str) -> str:
     return hmac_module.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
 
 
+def _compute_halo_hmac(agent_id: str, secret: str) -> str:
+    digest = hmac_module.new(secret.encode(), agent_id.encode(), hashlib.sha256).digest()
+    return base64.b64encode(digest).decode()
+
+
+def _extract_token_from_redirect(response) -> str:
+    location = response.headers.get("location", "")
+    fragment = urlparse(location).fragment
+    assert fragment.startswith("embed_token="), f"Expected embed token in {location}"
+    return fragment.split("=", 1)[1]
+
+
 @pytest.mark.e2e
 class TestEmbedEntryPoint:
     @pytest.fixture
     def test_app_with_secret(self, e2e_client, platform_admin):
-        app = _create_app(e2e_client, platform_admin.headers, "embed-entry-test")
+        slug = f"embed-entry-test-{uuid.uuid4().hex[:8]}"
+        app = _create_app(e2e_client, platform_admin.headers, slug)
         r = e2e_client.post(
             f"/api/applications/{app['id']}/embed-secrets",
             headers=platform_admin.headers,
@@ -71,7 +87,11 @@ class TestEmbedEntryPoint:
 
     def test_no_embed_secrets_configured(self, e2e_client, platform_admin):
         """App with no embed secrets should reject all embed requests."""
-        app = _create_app(e2e_client, platform_admin.headers, "embed-no-secret")
+        app = _create_app(
+            e2e_client,
+            platform_admin.headers,
+            f"embed-no-secret-{uuid.uuid4().hex[:8]}",
+        )
         try:
             r = e2e_client.get(
                 f"/embed/apps/{app['slug']}",
@@ -106,3 +126,66 @@ class TestEmbedEntryPoint:
             params={**params, "hmac": hmac_val},
         )
         assert r.status_code == 403, r.text
+
+    def test_halopsa_unsigned_params_rejected(self, e2e_client, platform_admin):
+        app = _create_app(
+            e2e_client,
+            platform_admin.headers,
+            f"embed-halo-extra-{uuid.uuid4().hex[:8]}",
+        )
+        try:
+            r = e2e_client.post(
+                f"/api/applications/{app['id']}/embed-secrets",
+                headers=platform_admin.headers,
+                json={
+                    "name": "Halo",
+                    "secret": "halo-secret",
+                    "hmac_scheme": "halopsa",
+                },
+            )
+            assert r.status_code == 201, r.text
+
+            params = {"agent_id": "42", "ticket_id": "1001"}
+            r = e2e_client.get(
+                f"/embed/apps/{app['slug']}",
+                params={**params, "hmac": _compute_halo_hmac("42", "halo-secret")},
+                follow_redirects=False,
+            )
+            assert r.status_code == 403, r.text
+        finally:
+            _delete_app(e2e_client, platform_admin.headers, app["id"])
+
+    def test_embed_token_cannot_replay_to_other_app_or_mutate_app(
+        self, e2e_client, platform_admin, test_app_with_secret
+    ):
+        app = test_app_with_secret["app"]
+        other_app = _create_app(
+            e2e_client,
+            platform_admin.headers,
+            f"embed-other-app-{uuid.uuid4().hex[:8]}",
+        )
+        try:
+            params = {"agent_id": "42"}
+            hmac_val = _compute_hmac(params, test_app_with_secret["secret"])
+            r = e2e_client.get(
+                f"/embed/apps/{app['slug']}",
+                params={**params, "hmac": hmac_val},
+                follow_redirects=False,
+            )
+            assert r.status_code == 302, r.text
+            embed_headers = {"Authorization": f"Bearer {_extract_token_from_redirect(r)}"}
+
+            r = e2e_client.get(
+                f"/api/applications/{other_app['id']}/render",
+                headers=embed_headers,
+            )
+            assert r.status_code == 403, r.text
+
+            r = e2e_client.patch(
+                f"/api/applications/{app['id']}",
+                headers=embed_headers,
+                json={"name": "mutated-by-embed"},
+            )
+            assert r.status_code == 403, r.text
+        finally:
+            _delete_app(e2e_client, platform_admin.headers, other_app["id"])

--- a/api/tests/e2e/api/test_form_embed.py
+++ b/api/tests/e2e/api/test_form_embed.py
@@ -3,6 +3,7 @@
 import hashlib
 import hmac as hmac_module
 import uuid
+from urllib.parse import urlparse
 
 import pytest
 
@@ -10,6 +11,13 @@ import pytest
 def _compute_hmac(params: dict, secret: str) -> str:
     message = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
     return hmac_module.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+
+
+def _extract_token_from_redirect(response) -> str:
+    location = response.headers.get("location", "")
+    fragment = urlparse(location).fragment
+    assert fragment.startswith("embed_token="), f"Expected embed token in {location}"
+    return fragment.split("=", 1)[1]
 
 
 @pytest.mark.e2e
@@ -98,3 +106,31 @@ class TestFormEmbed:
         # Verify the form is accessible with embed token
         r = e2e_client.get(f"/api/forms/{form_id}", headers=embed_headers)
         assert r.status_code == 200
+
+    def test_form_embed_token_cannot_replay_to_another_form(
+        self, e2e_client, platform_admin, form_with_secret
+    ):
+        form_id = form_with_secret["form"]["id"]
+        r = e2e_client.post(
+            "/api/forms",
+            headers=platform_admin.headers,
+            json={
+                "name": "Other Embed Test Form",
+                "form_schema": {"fields": []},
+            },
+        )
+        assert r.status_code == 201, r.text
+        other_form_id = r.json()["id"]
+
+        params = {"agent_id": "42"}
+        hmac_sig = _compute_hmac(params, form_with_secret["secret"])
+        r = e2e_client.get(
+            f"/embed/forms/{form_id}",
+            params={**params, "hmac": hmac_sig},
+            follow_redirects=False,
+        )
+        assert r.status_code == 302, r.text
+        embed_headers = {"Authorization": f"Bearer {_extract_token_from_redirect(r)}"}
+
+        r = e2e_client.get(f"/api/forms/{other_form_id}", headers=embed_headers)
+        assert r.status_code == 403, r.text

--- a/api/tests/unit/core/test_embed_middleware.py
+++ b/api/tests/unit/core/test_embed_middleware.py
@@ -1,0 +1,119 @@
+"""Unit tests for embed token route scoping."""
+
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+from src.core.embed_middleware import EmbedScopeMiddleware
+from src.core.security import create_access_token
+
+
+def _embed_token(**claims: str) -> str:
+    token_claims = {
+        "sub": str(uuid4()),
+        "jti": str(uuid4()),
+        "email": "embed@internal.gobifrost.com",
+        "is_superuser": False,
+        "embed": True,
+        "roles": ["EmbedUser"],
+        **claims,
+    }
+    return create_access_token(token_claims, expires_delta=timedelta(hours=1))
+
+
+def _request(method: str, path: str, token: str, *, token_source: str = "bearer") -> Request:
+    headers = []
+    if token_source == "bearer":
+        headers.append((b"authorization", f"Bearer {token}".encode()))
+    elif token_source == "cookie":
+        headers.append((b"cookie", f"embed_token={token}".encode()))
+
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": headers,
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+        }
+    )
+
+
+async def _allowed_response(_: Request) -> Response:
+    return Response(status_code=204)
+
+
+async def _dispatch(
+    method: str,
+    path: str,
+    token: str,
+    *,
+    token_source: str = "bearer",
+) -> Response:
+    middleware = EmbedScopeMiddleware(app=None)
+    return await middleware.dispatch(
+        _request(method, path, token, token_source=token_source), _allowed_response
+    )
+
+
+@pytest.mark.asyncio
+async def test_embed_token_cannot_mutate_allowlisted_app_route():
+    token = _embed_token(app_id=str(uuid4()))
+
+    response = await _dispatch("PATCH", "/api/applications/some-app", token)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_form_embed_token_cannot_replay_against_another_form():
+    form_id = str(uuid4())
+    other_form_id = str(uuid4())
+    token = _embed_token(form_id=form_id)
+
+    response = await _dispatch("GET", f"/api/forms/{other_form_id}", token)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_app_embed_token_cannot_replay_against_another_app_render_route():
+    app_id = str(uuid4())
+    other_app_id = str(uuid4())
+    token = _embed_token(app_id=app_id)
+
+    response = await _dispatch("GET", f"/api/applications/{other_app_id}/render", token)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_embed_token_can_access_its_scoped_form_route():
+    form_id = str(uuid4())
+    token = _embed_token(form_id=form_id)
+
+    response = await _dispatch("GET", f"/api/forms/{form_id}", token)
+
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_cookie_embed_token_is_scoped_like_bearer_token():
+    form_id = str(uuid4())
+    other_form_id = str(uuid4())
+    token = _embed_token(form_id=form_id)
+
+    response = await _dispatch(
+        "GET",
+        f"/api/forms/{other_form_id}",
+        token,
+        token_source="cookie",
+    )
+
+    assert response.status_code == 403

--- a/api/tests/unit/core/test_embed_token.py
+++ b/api/tests/unit/core/test_embed_token.py
@@ -22,6 +22,8 @@ class TestEmbedToken:
         assert payload["app_id"] == app_id
         assert payload["org_id"] == org_id
         assert payload["verified_params"] == verified_params
+        assert payload["embed"] is True
+        assert payload["is_superuser"] is False
         assert payload["type"] == "embed"
 
     def test_embed_token_rejected_as_access(self):

--- a/api/tests/unit/services/test_embed_auth.py
+++ b/api/tests/unit/services/test_embed_auth.py
@@ -77,15 +77,15 @@ class TestVerifyEmbedHmacHalopsa:
         secret = "halo-shared"
         agent_id = "42"
         sig = self._halo_sig(agent_id, secret)
-        params = {"agent_id": agent_id, "ticket_id": "1001", "hmac": sig}
+        params = {"agent_id": agent_id, "hmac": sig}
         assert verify_embed_hmac(params, secret, SCHEME_HALOPSA) is True
 
-    def test_extra_params_do_not_invalidate(self):
-        """HaloPSA scheme signs only agent_id; other params are not covered."""
+    def test_unsigned_extra_params_rejected(self):
+        """HaloPSA signatures must not authenticate params outside agent_id."""
         secret = "halo-shared"
         sig = self._halo_sig("42", secret)
         params = {"agent_id": "42", "anything": "else", "hmac": sig}
-        assert verify_embed_hmac(params, secret, SCHEME_HALOPSA) is True
+        assert verify_embed_hmac(params, secret, SCHEME_HALOPSA) is False
 
     def test_tampered_agent_id(self):
         secret = "halo-shared"


### PR DESCRIPTION
## Summary
- bind embed token validation to the intended form/app context
- reject ambiguous unsigned HaloPSA embed params for privileged access
- restrict embed allowlist behavior so embed tokens cannot authorize app mutation paths

## Verification
- ./test.sh tests/unit/services/test_embed_auth.py tests/unit/core/test_embed_middleware.py tests/unit/core/test_embed_token.py tests/e2e/api/test_embed.py tests/e2e/api/test_form_embed.py
- targeted ruff check on touched files
- git diff --check on touched files