### PR TITLE
Expose Codex Gateway through API route

### DIFF
--- a/api/src/routers/codex_gateway.py
+++ b/api/src/routers/codex_gateway.py
@@ -39,7 +39,11 @@ def _invalid_gateway_key_response() -> JSONResponse:
     )
 
 
-@router.post("/v1/responses")
+@router.post(
+    "/api/v1/responses",
+    operation_id="create_codex_gateway_response_api",
+)
+@router.post("/v1/responses", operation_id="create_codex_gateway_response")
 async def create_response(
     request: Request,
     payload: CodexGatewayResponsesRequest,

--- a/api/tests/unit/routers/test_codex_gateway.py
+++ b/api/tests/unit/routers/test_codex_gateway.py
@@ -48,6 +48,28 @@ def test_v1_responses_uses_openai_compatible_bearer_key():
     }
 
 
+def test_api_v1_responses_uses_same_gateway_facade():
+    app = FastAPI()
+    app.include_router(router)
+    runtime = FakeRuntime()
+    app.dependency_overrides[get_codex_gateway_runtime] = lambda: runtime
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/responses",
+        headers={"Authorization": f"Bearer {VALID_GATEWAY_KEY}"},
+        json={"model": "gpt-5.1-codex", "input": "api routed path"},
+    )
+
+    assert response.status_code == 200
+    [runtime_call] = runtime.calls
+    assert runtime_call["gateway_key"] == VALID_GATEWAY_KEY
+    assert runtime_call["payload"] == {
+        "model": "gpt-5.1-codex",
+        "input": "api routed path",
+    }
+
+
 def test_v1_responses_rejects_non_object_payload_before_runtime():
     app = FastAPI()
     app.include_router(router)


### PR DESCRIPTION
## Summary
- expose the Codex Gateway responses facade at /api/v1/responses for the current dev edge routing
- keep the existing /v1/responses route for environments that proxy root OpenAI-compatible paths to the API
- add a focused router test proving the API-routed path uses the same gateway key and payload handling

## Deploy check
- dev API version responded as 0.9.2-dev.194
- POST /v1/responses reached nginx and returned 405 before this patch
- POST /api/v1/responses reached the API surface but returned 404 before this patch

## Tests
- ..\\.venv\\Scripts\\python.exe -m pytest tests/unit/routers/test_codex_gateway.py -q
- ..\\.venv\\Scripts\\python.exe -m ruff check src/routers/codex_gateway.py tests/unit/routers/test_codex_gateway.py
- python -m pyright ..\\api\\src\\routers\\codex_gateway.py ..\\api\\tests\\unit\\routers\\test_codex_gateway.py
- ..\\.venv\\Scripts\\python.exe -m pytest tests/unit/services/test_codex_gateway_runtime.py tests/unit/routers/test_codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py tests/unit/services/test_codex_gateway_policy.py -q
- pve-t340 VM via codex-vm-netbird: ./test.sh tests/unit/services/test_codex_gateway_runtime.py tests/unit/routers/test_codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py tests/unit/services/test_codex_gateway_policy.py -q (32 passed; wrapper exited nonzero due to existing tee permission warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an additional API endpoint for creating responses, providing an alternative path while maintaining full feature parity with the existing endpoint.

* **Tests**
  * Added unit tests to validate the new endpoint's functionality, ensuring consistent operation with the existing response creation mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->