### PR TITLE
Add Codex Gateway key lifecycle APIs

### DIFF
--- a/api/shared/models.py
+++ b/api/shared/models.py
@@ -1,8 +1,10 @@
 """Shared Pydantic models used by API routers and clients."""
 
+from datetime import datetime
 from typing import Any
+from uuid import UUID
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, Field, RootModel
 
 
 class VersionResponse(BaseModel):
@@ -11,3 +13,44 @@ class VersionResponse(BaseModel):
 
 class CodexGatewayResponsesRequest(RootModel[dict[str, Any]]):
     """OpenAI-compatible Responses API request payload."""
+
+
+class CodexGatewayKeyCreateRequest(BaseModel):
+    """Request to create a downstream Codex Gateway key."""
+
+    name: str = Field(min_length=1, max_length=255)
+    project_id: UUID | None = None
+    allowed_models: list[str] = Field(default_factory=list)
+    denied_models: list[str] = Field(default_factory=list)
+    daily_limit: int | None = Field(default=None, ge=1)
+    monthly_limit: int | None = Field(default=None, ge=1)
+
+
+class CodexGatewayKeyRecord(BaseModel):
+    """Gateway key metadata safe to return to clients."""
+
+    id: UUID
+    user_id: UUID
+    project_id: UUID | None = None
+    name: str
+    allowed_models: list[str] = Field(default_factory=list)
+    denied_models: list[str] = Field(default_factory=list)
+    daily_limit: int | None = None
+    monthly_limit: int | None = None
+    status: str
+    created_at: datetime | None = None
+    revoked_at: datetime | None = None
+    last_used_at: datetime | None = None
+
+
+class CodexGatewayKeyCreateResponse(BaseModel):
+    """Created gateway key plus one-time plaintext key material."""
+
+    record: CodexGatewayKeyRecord
+    key: str
+
+
+class CodexGatewayKeyListResponse(BaseModel):
+    """List of gateway keys without plaintext or hashes."""
+
+    items: list[CodexGatewayKeyRecord]

--- a/api/src/models/contracts/__init__.py
+++ b/api/src/models/contracts/__init__.py
@@ -298,7 +298,11 @@ from src.models.contracts.common import (
 
 # Codex Gateway
 from src.models.contracts.codex_gateway import (
+    CodexGatewayKeyCreateRequest,
+    CodexGatewayKeyCreateResponse,
     CodexGatewayKeyContext,
+    CodexGatewayKeyListResponse,
+    CodexGatewayKeyRecord,
     CodexGatewayPolicyDecision,
     CodexGatewayRequestContext,
     CodexGatewayUpstreamAccount,
@@ -727,6 +731,10 @@ __all__ = [
     "FileUploadResponse",
     "UploadedFileMetadata",
     "CodexGatewayKeyContext",
+    "CodexGatewayKeyCreateRequest",
+    "CodexGatewayKeyCreateResponse",
+    "CodexGatewayKeyListResponse",
+    "CodexGatewayKeyRecord",
     "CodexGatewayPolicyDecision",
     "CodexGatewayRequestContext",
     "CodexGatewayUpstreamAccount",

--- a/api/src/models/contracts/codex_gateway.py
+++ b/api/src/models/contracts/codex_gateway.py
@@ -30,6 +30,47 @@ class CodexGatewayKeyContext(BaseModel):
     status: CodexGatewayKeyStatus = "active"
 
 
+class CodexGatewayKeyCreateRequest(BaseModel):
+    """Request to create a downstream Codex Gateway key."""
+
+    name: str = Field(min_length=1, max_length=255)
+    project_id: UUID | None = None
+    allowed_models: list[str] = Field(default_factory=list)
+    denied_models: list[str] = Field(default_factory=list)
+    daily_limit: int | None = Field(default=None, ge=1)
+    monthly_limit: int | None = Field(default=None, ge=1)
+
+
+class CodexGatewayKeyRecord(BaseModel):
+    """Gateway key metadata safe to return to clients."""
+
+    id: UUID
+    user_id: UUID
+    project_id: UUID | None = None
+    name: str
+    allowed_models: list[str] = Field(default_factory=list)
+    denied_models: list[str] = Field(default_factory=list)
+    daily_limit: int | None = None
+    monthly_limit: int | None = None
+    status: CodexGatewayKeyStatus
+    created_at: datetime | None = None
+    revoked_at: datetime | None = None
+    last_used_at: datetime | None = None
+
+
+class CodexGatewayKeyCreateResponse(BaseModel):
+    """Created gateway key plus one-time plaintext key material."""
+
+    record: CodexGatewayKeyRecord
+    key: str
+
+
+class CodexGatewayKeyListResponse(BaseModel):
+    """List of gateway keys without plaintext or hashes."""
+
+    items: list[CodexGatewayKeyRecord]
+
+
 class CodexGatewayUpstreamAccount(BaseModel):
     """Metadata for a user's connected ChatGPT/Codex identity."""
 

--- a/api/src/models/contracts/codex_gateway.py
+++ b/api/src/models/contracts/codex_gateway.py
@@ -11,9 +11,27 @@ from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+from shared.models import (
+    CodexGatewayKeyCreateRequest,
+    CodexGatewayKeyCreateResponse,
+    CodexGatewayKeyListResponse,
+    CodexGatewayKeyRecord,
+)
 
 
 CodexGatewayKeyStatus = Literal["active", "revoked"]
+
+__all__ = [
+    "CodexGatewayKeyContext",
+    "CodexGatewayKeyCreateRequest",
+    "CodexGatewayKeyCreateResponse",
+    "CodexGatewayKeyListResponse",
+    "CodexGatewayKeyRecord",
+    "CodexGatewayPolicyDecision",
+    "CodexGatewayRequestContext",
+    "CodexGatewayUpstreamAccount",
+    "OpenAICompatibleError",
+]
 
 
 class CodexGatewayKeyContext(BaseModel):
@@ -28,47 +46,6 @@ class CodexGatewayKeyContext(BaseModel):
     daily_limit: int | None = None
     monthly_limit: int | None = None
     status: CodexGatewayKeyStatus = "active"
-
-
-class CodexGatewayKeyCreateRequest(BaseModel):
-    """Request to create a downstream Codex Gateway key."""
-
-    name: str = Field(min_length=1, max_length=255)
-    project_id: UUID | None = None
-    allowed_models: list[str] = Field(default_factory=list)
-    denied_models: list[str] = Field(default_factory=list)
-    daily_limit: int | None = Field(default=None, ge=1)
-    monthly_limit: int | None = Field(default=None, ge=1)
-
-
-class CodexGatewayKeyRecord(BaseModel):
-    """Gateway key metadata safe to return to clients."""
-
-    id: UUID
-    user_id: UUID
-    project_id: UUID | None = None
-    name: str
-    allowed_models: list[str] = Field(default_factory=list)
-    denied_models: list[str] = Field(default_factory=list)
-    daily_limit: int | None = None
-    monthly_limit: int | None = None
-    status: CodexGatewayKeyStatus
-    created_at: datetime | None = None
-    revoked_at: datetime | None = None
-    last_used_at: datetime | None = None
-
-
-class CodexGatewayKeyCreateResponse(BaseModel):
-    """Created gateway key plus one-time plaintext key material."""
-
-    record: CodexGatewayKeyRecord
-    key: str
-
-
-class CodexGatewayKeyListResponse(BaseModel):
-    """List of gateway keys without plaintext or hashes."""
-
-    items: list[CodexGatewayKeyRecord]
 
 
 class CodexGatewayUpstreamAccount(BaseModel):

--- a/api/src/repositories/codex_gateway.py
+++ b/api/src/repositories/codex_gateway.py
@@ -1,6 +1,7 @@
 """Persistence helpers for the Bifrost Codex Gateway."""
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import secrets
 from typing import Any, TypeGuard
 from uuid import UUID
@@ -120,6 +121,34 @@ class CodexGatewayRepository:
             if self.verify_gateway_key(plaintext_key, candidate.key_hash):
                 return candidate
         return None
+
+    async def list_gateway_keys_for_user(self, user_id: UUID) -> list[CodexGatewayKey]:
+        result = await self.session.execute(
+            select(CodexGatewayKey)
+            .where(CodexGatewayKey.user_id == user_id)
+            .order_by(CodexGatewayKey.created_at.desc(), CodexGatewayKey.id.desc())
+        )
+        return list(result.scalars().all())
+
+    async def revoke_gateway_key_for_user(
+        self,
+        *,
+        key_id: UUID,
+        user_id: UUID,
+    ) -> CodexGatewayKey | None:
+        result = await self.session.execute(
+            select(CodexGatewayKey)
+            .where(CodexGatewayKey.id == key_id)
+            .where(CodexGatewayKey.user_id == user_id)
+        )
+        key = result.scalar_one_or_none()
+        if key is None:
+            return None
+        if key.revoked_at is None:
+            key.status = "revoked"
+            key.revoked_at = datetime.now(timezone.utc)
+            await self.session.flush()
+        return key
 
     async def get_active_upstream_account_for_user(
         self, user_id: UUID, provider: str = "chatgpt_codex"

--- a/api/src/routers/codex_gateway.py
+++ b/api/src/routers/codex_gateway.py
@@ -1,18 +1,27 @@
 """OpenAI-compatible facade routes for the Bifrost Codex Gateway."""
 
 from typing import Annotated
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 
 from shared.models import CodexGatewayResponsesRequest
 
+from src.core.auth import CurrentActiveUser
 from src.core.database import DbSession
-from src.models.contracts.codex_gateway import OpenAICompatibleError
+from src.models.contracts.codex_gateway import (
+    CodexGatewayKeyCreateRequest,
+    CodexGatewayKeyCreateResponse,
+    CodexGatewayKeyListResponse,
+    CodexGatewayKeyRecord,
+    OpenAICompatibleError,
+)
 from src.repositories.codex_gateway import (
     CodexGatewayRepository,
     is_plausible_gateway_key,
 )
+from src.services.audit import emit_audit
 from src.services.codex_gateway.runtime import (
     CODEX_GATEWAY_KEY_HEADER,
     CodexGatewayRuntime,
@@ -21,6 +30,10 @@ from src.services.codex_gateway.runtime import (
 
 
 router = APIRouter(tags=["Codex Gateway"])
+
+
+def get_codex_gateway_repository(db: DbSession) -> CodexGatewayRepository:
+    return CodexGatewayRepository(db)
 
 
 def get_codex_gateway_runtime(db: DbSession) -> CodexGatewayRuntime:
@@ -37,6 +50,118 @@ def _invalid_gateway_key_response() -> JSONResponse:
             ).model_dump()
         },
     )
+
+
+def _key_record_response(record) -> CodexGatewayKeyRecord:
+    return CodexGatewayKeyRecord(
+        id=record.id,
+        user_id=record.user_id,
+        project_id=record.project_id,
+        name=record.name,
+        allowed_models=list(record.allowed_models or []),
+        denied_models=list(record.denied_models or []),
+        daily_limit=record.daily_limit,
+        monthly_limit=record.monthly_limit,
+        status=record.status,
+        created_at=record.created_at,
+        revoked_at=record.revoked_at,
+        last_used_at=record.last_used_at,
+    )
+
+
+@router.post(
+    "/api/codex-gateway/keys",
+    response_model=CodexGatewayKeyCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="create_codex_gateway_key",
+)
+async def create_gateway_key(
+    payload: CodexGatewayKeyCreateRequest,
+    current_user: CurrentActiveUser,
+    repository: Annotated[
+        CodexGatewayRepository,
+        Depends(get_codex_gateway_repository),
+    ],
+    db: DbSession,
+) -> CodexGatewayKeyCreateResponse:
+    material = await repository.create_gateway_key(
+        user_id=current_user.user_id,
+        project_id=payload.project_id,
+        name=payload.name,
+        allowed_models=payload.allowed_models,
+        denied_models=payload.denied_models,
+        daily_limit=payload.daily_limit,
+        monthly_limit=payload.monthly_limit,
+    )
+    await emit_audit(
+        db,
+        "codex_gateway.key.create",
+        resource_type="codex_gateway_key",
+        resource_id=material.record.id,
+        details={
+            "project_id": str(material.record.project_id)
+            if material.record.project_id
+            else None,
+            "name": material.record.name,
+            "allowed_models": material.record.allowed_models,
+            "denied_models": material.record.denied_models,
+        },
+    )
+    return CodexGatewayKeyCreateResponse(
+        record=_key_record_response(material.record),
+        key=material.plaintext_key,
+    )
+
+
+@router.get(
+    "/api/codex-gateway/keys",
+    response_model=CodexGatewayKeyListResponse,
+    operation_id="list_codex_gateway_keys",
+)
+async def list_gateway_keys(
+    current_user: CurrentActiveUser,
+    repository: Annotated[
+        CodexGatewayRepository,
+        Depends(get_codex_gateway_repository),
+    ],
+) -> CodexGatewayKeyListResponse:
+    keys = await repository.list_gateway_keys_for_user(current_user.user_id)
+    return CodexGatewayKeyListResponse(
+        items=[_key_record_response(record) for record in keys]
+    )
+
+
+@router.delete(
+    "/api/codex-gateway/keys/{key_id}",
+    response_model=CodexGatewayKeyRecord,
+    operation_id="revoke_codex_gateway_key",
+)
+async def revoke_gateway_key(
+    key_id: UUID,
+    current_user: CurrentActiveUser,
+    repository: Annotated[
+        CodexGatewayRepository,
+        Depends(get_codex_gateway_repository),
+    ],
+    db: DbSession,
+) -> CodexGatewayKeyRecord:
+    record = await repository.revoke_gateway_key_for_user(
+        key_id=key_id,
+        user_id=current_user.user_id,
+    )
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    await emit_audit(
+        db,
+        "codex_gateway.key.revoke",
+        resource_type="codex_gateway_key",
+        resource_id=record.id,
+        details={
+            "project_id": str(record.project_id) if record.project_id else None,
+            "name": record.name,
+        },
+    )
+    return _key_record_response(record)
 
 
 @router.post(

--- a/api/tests/e2e/api/test_codex_gateway_keys.py
+++ b/api/tests/e2e/api/test_codex_gateway_keys.py
@@ -1,0 +1,97 @@
+"""E2E coverage for Codex Gateway downstream key lifecycle."""
+
+import pytest
+
+
+@pytest.mark.e2e
+class TestCodexGatewayKeys:
+    def test_requires_authenticated_user(self, e2e_client):
+        response = e2e_client.get("/api/codex-gateway/keys")
+
+        assert response.status_code == 401
+
+    def test_create_list_and_revoke_gateway_key_for_same_user(
+        self,
+        e2e_client,
+        org1_user,
+        platform_admin,
+    ):
+        create_response = e2e_client.post(
+            "/api/codex-gateway/keys",
+            headers=org1_user.headers,
+            json={
+                "name": "e2e developer workstation",
+                "allowed_models": ["gpt-5.1-codex"],
+                "daily_limit": 25,
+            },
+        )
+        assert create_response.status_code == 201, create_response.text
+        created = create_response.json()
+        key_id = created["record"]["id"]
+        plaintext_key = created["key"]
+
+        assert plaintext_key.startswith("bfck_")
+        assert created["record"]["name"] == "e2e developer workstation"
+        assert created["record"]["status"] == "active"
+        assert "key_hash" not in created["record"]
+
+        list_response = e2e_client.get(
+            "/api/codex-gateway/keys",
+            headers=org1_user.headers,
+        )
+        assert list_response.status_code == 200, list_response.text
+        listed = list_response.json()["items"]
+        matching = [item for item in listed if item["id"] == key_id]
+        assert matching
+        assert "key" not in matching[0]
+        assert "key_hash" not in matching[0]
+
+        audit_response = e2e_client.get(
+            "/api/audit?action=codex_gateway.key.",
+            headers=platform_admin.headers,
+        )
+        assert audit_response.status_code == 200, audit_response.text
+        create_events = [
+            event
+            for event in audit_response.json()["entries"]
+            if event["action"] == "codex_gateway.key.create"
+            and event.get("resource_id") == key_id
+        ]
+        assert create_events
+
+        revoke_response = e2e_client.delete(
+            f"/api/codex-gateway/keys/{key_id}",
+            headers=org1_user.headers,
+        )
+        assert revoke_response.status_code == 200, revoke_response.text
+        assert revoke_response.json()["status"] == "revoked"
+        assert "key" not in revoke_response.json()
+        assert "key_hash" not in revoke_response.json()
+
+    def test_gateway_keys_are_user_scoped(self, e2e_client, org1_user, org2_user):
+        create_response = e2e_client.post(
+            "/api/codex-gateway/keys",
+            headers=org1_user.headers,
+            json={"name": "e2e user scoped key"},
+        )
+        assert create_response.status_code == 201, create_response.text
+        key_id = create_response.json()["record"]["id"]
+
+        list_response = e2e_client.get(
+            "/api/codex-gateway/keys",
+            headers=org2_user.headers,
+        )
+        assert list_response.status_code == 200, list_response.text
+        assert all(item["id"] != key_id for item in list_response.json()["items"])
+
+        revoke_response = e2e_client.delete(
+            f"/api/codex-gateway/keys/{key_id}",
+            headers=org2_user.headers,
+        )
+        assert revoke_response.status_code == 404
+
+        cleanup_response = e2e_client.delete(
+            f"/api/codex-gateway/keys/{key_id}",
+            headers=org1_user.headers,
+        )
+        assert cleanup_response.status_code == 200, cleanup_response.text

--- a/api/tests/unit/repositories/test_codex_gateway_repository.py
+++ b/api/tests/unit/repositories/test_codex_gateway_repository.py
@@ -105,6 +105,42 @@ async def test_lookup_gateway_key_rejects_malformed_key_before_database_query(
 
 
 @pytest.mark.asyncio
+async def test_list_gateway_keys_for_user_excludes_hashes_and_other_users(
+    repository,
+    mock_session,
+):
+    user_id = uuid4()
+    keys = [
+        MagicMock(user_id=user_id, key_hash="secret-hash-1"),
+        MagicMock(user_id=user_id, key_hash="secret-hash-2"),
+    ]
+    mock_session.execute.return_value = _Result(values=keys)
+
+    result = await repository.list_gateway_keys_for_user(user_id)
+
+    assert result == keys
+    mock_session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_revoke_gateway_key_for_user_marks_key_revoked(repository, mock_session):
+    user_id = uuid4()
+    key_id = uuid4()
+    key = MagicMock(user_id=user_id, status="active", revoked_at=None)
+    mock_session.execute.return_value = _Result(one=key)
+
+    result = await repository.revoke_gateway_key_for_user(
+        key_id=key_id,
+        user_id=user_id,
+    )
+
+    assert result is key
+    assert key.status == "revoked"
+    assert key.revoked_at is not None
+    mock_session.flush.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_get_active_upstream_account_for_user_excludes_revoked_accounts(
     repository,
     mock_session,

--- a/api/tests/unit/repositories/test_codex_gateway_repository.py
+++ b/api/tests/unit/repositories/test_codex_gateway_repository.py
@@ -120,6 +120,9 @@ async def test_list_gateway_keys_for_user_excludes_hashes_and_other_users(
 
     assert result == keys
     mock_session.execute.assert_called_once()
+    statement = mock_session.execute.call_args.args[0]
+    compiled = statement.compile(compile_kwargs={"literal_binds": True})
+    assert user_id.hex in str(compiled)
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/routers/test_codex_gateway.py
+++ b/api/tests/unit/routers/test_codex_gateway.py
@@ -1,9 +1,17 @@
 from asyncio import sleep
+from unittest.mock import AsyncMock
+from uuid import uuid4
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from src.routers.codex_gateway import get_codex_gateway_runtime, router
+from src.core.auth import UserPrincipal, get_current_active_user
+from src.routers.codex_gateway import (
+    get_codex_gateway_repository,
+    get_codex_gateway_runtime,
+    router,
+)
+from src.repositories.codex_gateway import CodexGatewayKeyMaterial
 from src.services.codex_gateway.runtime import (
     CODEX_GATEWAY_KEY_HEADER,
     CodexGatewayResponse,
@@ -23,6 +31,97 @@ class FakeRuntime:
             status_code=200,
             body={"id": "resp_route_test", "output": []},
         )
+
+
+class FakeRepository:
+    def __init__(self):
+        self.created = []
+        self.listed_for = []
+        self.revoked = []
+        self.key_id = uuid4()
+        self.plaintext_key = VALID_GATEWAY_KEY
+
+    async def create_gateway_key(self, **kwargs):
+        await sleep(0)
+        self.created.append(kwargs)
+        record = type(
+            "GatewayKey",
+            (),
+            {
+                "id": self.key_id,
+                "user_id": kwargs["user_id"],
+                "project_id": kwargs.get("project_id"),
+                "name": kwargs["name"],
+                "allowed_models": kwargs.get("allowed_models") or [],
+                "denied_models": kwargs.get("denied_models") or [],
+                "daily_limit": kwargs.get("daily_limit"),
+                "monthly_limit": kwargs.get("monthly_limit"),
+                "status": "active",
+                "created_at": None,
+                "revoked_at": None,
+                "last_used_at": None,
+            },
+        )()
+        return CodexGatewayKeyMaterial(
+            record=record,
+            plaintext_key=self.plaintext_key,
+        )
+
+    async def list_gateway_keys_for_user(self, user_id):
+        await sleep(0)
+        self.listed_for.append(user_id)
+        return [
+            type(
+                "GatewayKey",
+                (),
+                {
+                    "id": self.key_id,
+                    "user_id": user_id,
+                    "project_id": None,
+                    "name": "developer workstation",
+                    "allowed_models": ["gpt-5.1-codex"],
+                    "denied_models": [],
+                    "daily_limit": 100,
+                    "monthly_limit": None,
+                    "status": "active",
+                    "created_at": None,
+                    "revoked_at": None,
+                    "last_used_at": None,
+                },
+            )()
+        ]
+
+    async def revoke_gateway_key_for_user(self, *, key_id, user_id):
+        await sleep(0)
+        self.revoked.append({"key_id": key_id, "user_id": user_id})
+        return type(
+            "GatewayKey",
+            (),
+            {
+                "id": key_id,
+                "user_id": user_id,
+                "project_id": None,
+                "name": "developer workstation",
+                "allowed_models": ["gpt-5.1-codex"],
+                "denied_models": [],
+                "daily_limit": 100,
+                "monthly_limit": None,
+                "status": "revoked",
+                "created_at": None,
+                "revoked_at": None,
+                "last_used_at": None,
+            },
+        )()
+
+
+def _principal(user_id):
+    return UserPrincipal(
+        user_id=user_id,
+        email="dev@example.test",
+        organization_id=uuid4(),
+        is_active=True,
+        is_superuser=False,
+    )
 
 
 def test_v1_responses_uses_openai_compatible_bearer_key():
@@ -124,6 +223,84 @@ def test_v1_responses_rejects_missing_gateway_key_before_runtime():
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "invalid_gateway_key"
     assert runtime.calls == []
+
+
+def test_create_gateway_key_returns_plaintext_once_and_audits(monkeypatch):
+    app = FastAPI()
+    app.include_router(router)
+    repository = FakeRepository()
+    user_id = uuid4()
+    audit = AsyncMock()
+    app.dependency_overrides[get_codex_gateway_repository] = lambda: repository
+    app.dependency_overrides[get_current_active_user] = lambda: _principal(user_id)
+    monkeypatch.setattr("src.routers.codex_gateway.emit_audit", audit)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/codex-gateway/keys",
+        json={
+            "name": "developer workstation",
+            "allowed_models": ["gpt-5.1-codex"],
+            "daily_limit": 100,
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["key"] == VALID_GATEWAY_KEY
+    assert body["record"]["name"] == "developer workstation"
+    assert "key_hash" not in body["record"]
+    assert repository.created == [
+        {
+            "user_id": user_id,
+            "project_id": None,
+            "name": "developer workstation",
+            "allowed_models": ["gpt-5.1-codex"],
+            "denied_models": [],
+            "daily_limit": 100,
+            "monthly_limit": None,
+        }
+    ]
+    audit.assert_awaited_once()
+
+
+def test_list_gateway_keys_never_exposes_plaintext_or_hash():
+    app = FastAPI()
+    app.include_router(router)
+    repository = FakeRepository()
+    user_id = uuid4()
+    app.dependency_overrides[get_codex_gateway_repository] = lambda: repository
+    app.dependency_overrides[get_current_active_user] = lambda: _principal(user_id)
+    client = TestClient(app)
+
+    response = client.get("/api/codex-gateway/keys")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"][0]["name"] == "developer workstation"
+    assert "key" not in body["items"][0]
+    assert "key_hash" not in body["items"][0]
+    assert repository.listed_for == [user_id]
+
+
+def test_revoke_gateway_key_is_user_scoped_and_audited(monkeypatch):
+    app = FastAPI()
+    app.include_router(router)
+    repository = FakeRepository()
+    user_id = uuid4()
+    key_id = uuid4()
+    audit = AsyncMock()
+    app.dependency_overrides[get_codex_gateway_repository] = lambda: repository
+    app.dependency_overrides[get_current_active_user] = lambda: _principal(user_id)
+    monkeypatch.setattr("src.routers.codex_gateway.emit_audit", audit)
+    client = TestClient(app)
+
+    response = client.delete(f"/api/codex-gateway/keys/{key_id}")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "revoked"
+    assert repository.revoked == [{"key_id": key_id, "user_id": user_id}]
+    audit.assert_awaited_once()
 
 
 def test_v1_responses_rejects_malformed_gateway_key_before_runtime():


### PR DESCRIPTION
## Summary
- add authenticated user-scoped Codex Gateway key create/list/revoke endpoints
- return plaintext gateway key only on create while list/revoke expose metadata only
- add audit events for key creation and revocation

## Tests
- ..\\.venv\\Scripts\\python.exe -m pytest tests/unit/repositories/test_codex_gateway_repository.py tests/unit/routers/test_codex_gateway.py -q
- ..\\.venv\\Scripts\\python.exe -m pytest tests/unit/services/test_codex_gateway_runtime.py tests/unit/routers/test_codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py tests/unit/services/test_codex_gateway_policy.py -q
- ..\\.venv\\Scripts\\python.exe -m ruff check src/routers/codex_gateway.py src/repositories/codex_gateway.py src/models/contracts/codex_gateway.py tests/unit/routers/test_codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py
- ..\\.venv\\Scripts\\python.exe -m pyright src/routers/codex_gateway.py src/repositories/codex_gateway.py src/models/contracts/codex_gateway.py tests/unit/routers/test_codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py
- pve-t340 VM via codex-vm-netbird: ./test.sh tests/unit/services/test_codex_gateway_runtime.py tests/unit/routers/test_codex_gateway.py tests/unit/repositories/test_codex_gateway_repository.py tests/unit/services/test_codex_gateway_policy.py -q (37 passed; wrapper exited nonzero due to existing tee permission warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced gateway key management functionality with endpoints to create, list, and revoke API keys under `/api/codex-gateway/keys`.
  * Keys support model allow/deny lists and optional daily/monthly usage limits.
  * Audit events logged for key creation and revocation operations.

* **Tests**
  * Added comprehensive test coverage for gateway key management endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->