### PR TITLE
Harden agent MCP privilege boundaries

### DIFF
--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -169,6 +169,10 @@ async def get_current_user_optional(
     if payload is None:
         return None
 
+    if payload.get("mcp"):
+        logger.warning("Rejecting MCP-scoped bearer token on REST auth path")
+        return None
+
     # Extract user ID from token
     user_id_str = payload.get("sub")
     if not user_id_str:
@@ -437,6 +441,9 @@ async def get_current_user_ws(websocket) -> UserPrincipal | None:
     # Decode and validate token - must be an access token
     payload = decode_token(token, expected_type="access")
     if payload is None:
+        return None
+    if payload.get("mcp"):
+        logger.warning("Rejecting MCP-scoped bearer token on WebSocket auth path")
         return None
 
     user_id_str = payload.get("sub")

--- a/api/src/routers/agents.py
+++ b/api/src/routers/agents.py
@@ -56,6 +56,7 @@ async def _validate_agent_references(
     tool_ids: list[str] | None,
     delegated_agent_ids: list[str] | None,
     agent_id: UUID | None = None,  # For self-delegation check
+    target_org_id: UUID | None = None,
 ) -> None:
     """
     Validate that all referenced tools and agents exist and are valid.
@@ -88,6 +89,8 @@ async def _validate_agent_references(
                     errors.append(
                         f"tool_id '{tool_id}' references a {workflow.type}, not a tool"
                     )
+                elif workflow.organization_id is not None and workflow.organization_id != target_org_id:
+                    errors.append(f"tool_id '{tool_id}' belongs to a different organization")
             except ValueError:
                 errors.append(f"tool_id '{tool_id}' is not a valid UUID")
 
@@ -110,6 +113,8 @@ async def _validate_agent_references(
                     errors.append(f"delegated_agent_id '{delegate_id}' does not reference an existing agent")
                 elif not delegate.is_active:
                     errors.append(f"delegated_agent_id '{delegate_id}' references an inactive agent")
+                elif delegate.organization_id is not None and delegate.organization_id != target_org_id:
+                    errors.append(f"delegated_agent_id '{delegate_id}' belongs to a different organization")
             except ValueError:
                 errors.append(f"delegated_agent_id '{delegate_id}' is not a valid UUID")
 
@@ -340,6 +345,7 @@ async def create_agent(
         tool_ids=agent_data.tool_ids,
         delegated_agent_ids=agent_data.delegated_agent_ids,
         agent_id=None,
+        target_org_id=agent_data.organization_id,
     )
 
     agent_id = uuid4()
@@ -649,6 +655,7 @@ async def update_agent(
         tool_ids=agent_data.tool_ids,
         delegated_agent_ids=agent_data.delegated_agent_ids,
         agent_id=agent_id,  # For self-delegation check
+        target_org_id=agent_data.organization_id if "organization_id" in agent_data.model_fields_set else agent.organization_id,
     )
 
     # Update fields
@@ -859,6 +866,8 @@ async def promote_agent(
     if not is_admin:
         if agent.owner_user_id != user.user_id:
             raise HTTPException(403, "You can only promote your own agents")
+        if agent.organization_id != user.organization_id:
+            raise HTTPException(403, "You can only promote agents in your own organization")
         if not await _user_has_permission(db, user.user_id, "can_promote_agent"):
             raise HTTPException(403, "You do not have permission to promote agents")
 

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -1191,7 +1191,7 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
 
         # Check if this is a delegation tool call
         if tool_call.name.startswith("delegate_to_") and agent:
-            return await self._execute_delegation(tool_call, agent)
+            return await self._execute_delegation(tool_call, agent, conversation)
 
         # Check if this is a system tool call
         if agent and tool_call.name in (agent.system_tools or []):
@@ -1551,6 +1551,7 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
         self,
         tool_call: ToolCallRequest,
         agent: Agent,
+        conversation: Conversation | None = None,
     ) -> ToolResult:
         """Execute a delegation to another agent via AutonomousAgentExecutor."""
         start_time = time.time()
@@ -1594,11 +1595,23 @@ IMPORTANT: When the user's request can be fulfilled using one of your tools, you
             redis_client = await get_shared_redis()
             sub_executor = AutonomousAgentExecutor(self._session_factory, redis_client=redis_client)
             try:
+                user = conversation.user if conversation else None
+                caller = None
+                if user is not None:
+                    caller = {
+                        "user_id": str(user.id),
+                        "email": user.email,
+                        "name": user.name,
+                        "is_platform_admin": bool(user.is_superuser),
+                    }
+                run_kwargs: dict[str, Any] = {
+                    "agent": delegated_agent,
+                    "input_data": {"task": task, "_delegated_from": agent.name},
+                }
+                if caller is not None:
+                    run_kwargs["_caller"] = caller
                 sub_result = await asyncio.wait_for(
-                    sub_executor.run(
-                        agent=delegated_agent,
-                        input_data={"task": task, "_delegated_from": agent.name},
-                    ),
+                    sub_executor.run(**run_kwargs),
                     timeout=DELEGATION_TIMEOUT_SECONDS,
                 )
             except asyncio.TimeoutError:

--- a/api/src/services/execution/autonomous_agent_executor.py
+++ b/api/src/services/execution/autonomous_agent_executor.py
@@ -24,7 +24,6 @@ from sqlalchemy.orm import selectinload
 
 from src.models.orm.agents import Agent
 from src.models.orm.agent_runs import AgentRun, AgentRunStep
-from src.core.constants import SYSTEM_USER_ID, SYSTEM_USER_EMAIL
 from src.core.cache.keys import agent_run_steps_stream_key
 from src.core.pubsub import publish_agent_run_step
 from src.core.system_agents import is_privileged_agent_management_tool
@@ -83,6 +82,7 @@ class AutonomousAgentExecutor:
         # event-trigger), in which case dispatch resolves to the
         # service token only.
         self._caller_user_id: UUID | None = None
+        self._caller_context: dict[str, Any] | None = None
         # Buffers for Redis-first pattern (flushed to DB after run completes)
         self._pending_steps: list[dict[str, Any]] = []
         self._pending_ai_usage: list[dict[str, Any]] = []
@@ -130,6 +130,7 @@ class AutonomousAgentExecutor:
                 )
                 caller_user_id = None
         self._caller_user_id = caller_user_id
+        self._caller_context = _caller.copy() if _caller else None
 
         # Short-circuit if agent is paused. Runs already past this point continue
         # normally — this check only gates new runs at entry.
@@ -461,11 +462,11 @@ class AutonomousAgentExecutor:
             workflow_id=str(workflow_id),
             workflow_name=tool_call.name,
             parameters=tool_call.arguments or {},
-            user_id=SYSTEM_USER_ID,
-            user_email=SYSTEM_USER_EMAIL,
-            user_name=agent.name,
+            user_id=str(self._caller_user_id) if self._caller_user_id else str(agent.id),
+            user_email=str(self._caller_context.get("email", "")) if self._caller_context else (getattr(agent, "created_by", None) or f"agent:{agent.id}"),
+            user_name=str(self._caller_context.get("name", "")) if self._caller_context else agent.name,
             org_id=str(agent.organization_id) if agent.organization_id else None,
-            is_platform_admin=False,
+            is_platform_admin=bool(self._caller_context.get("is_platform_admin", False)) if self._caller_context else False,
             is_agent=True,
         )
 
@@ -663,6 +664,7 @@ class AutonomousAgentExecutor:
                     agent=target_agent,
                     input_data={"task": task, "_delegated_from": agent.name},
                     run_id=sub_run_id,
+                    _caller=self._caller_context,
                 ),
                 timeout=DELEGATION_TIMEOUT_SECONDS,
             )
@@ -719,11 +721,11 @@ class AutonomousAgentExecutor:
             # Brief DB session scoped to the tool call
             async with self._session_factory() as db:
                 context = MCPContext(
-                    user_id=SYSTEM_USER_ID,
+                    user_id=str(self._caller_user_id) if self._caller_user_id else str(agent.id),
                     org_id=str(agent.organization_id) if agent.organization_id else None,
-                    is_platform_admin=False,
-                    user_email=SYSTEM_USER_EMAIL,
-                    user_name=agent.name,
+                    is_platform_admin=bool(self._caller_context.get("is_platform_admin", False)) if self._caller_context else False,
+                    user_email=str(self._caller_context.get("email", "")) if self._caller_context else (getattr(agent, "created_by", None) or f"agent:{agent.id}"),
+                    user_name=str(self._caller_context.get("name", "")) if self._caller_context else agent.name,
                     session=db,
                 )
 

--- a/api/src/services/mcp_server/auth.py
+++ b/api/src/services/mcp_server/auth.py
@@ -220,6 +220,19 @@ class BifrostAuthProvider:
 
         # Store OAuth state in Redis for callback
         r = await get_shared_redis()
+        client_data_json = await r.get(_mcp_client_key(client_id))
+        if not client_data_json:
+            return JSONResponse(
+                {"error": "invalid_client", "error_description": "Unknown MCP client"},
+                status_code=400,
+            )
+        client_data = json.loads(client_data_json)
+        if redirect_uri not in client_data.get("redirect_uris", []):
+            return JSONResponse(
+                {"error": "invalid_request", "error_description": "redirect_uri is not registered for this client"},
+                status_code=400,
+            )
+
         oauth_data = {
             "client_id": client_id,
             "redirect_uri": redirect_uri,
@@ -389,6 +402,11 @@ class BifrostAuthProvider:
                     {"error": "invalid_grant", "error_description": "redirect_uri mismatch"},
                     status_code=400
                 )
+            if client_id != auth_code_data["client_id"]:
+                return JSONResponse(
+                    {"error": "invalid_grant", "error_description": "client_id mismatch"},
+                    status_code=400
+                )
 
             # Validate PKCE code_verifier
             code_challenge = auth_code_data["code_challenge"]
@@ -423,10 +441,12 @@ class BifrostAuthProvider:
                     "name": user.name,
                     "is_superuser": user.is_superuser,
                     "org_id": str(user.organization_id) if user.organization_id else None,
-                                        "type": "access",
+                    "mcp": True,
+                    "scope": "mcp:access",
+                    "type": "access",
                 }
                 access_token = create_access_token(data=token_data)
-                refresh_token, _jti = create_refresh_token(data={"sub": str(user.id)})
+                refresh_token, _jti = create_refresh_token(data={"sub": str(user.id), "mcp": True})
 
             logger.info(f"MCP OAuth: Token issued for user {auth_code_data['email']}")
 
@@ -451,7 +471,7 @@ class BifrostAuthProvider:
             from src.core.security import decode_token
 
             payload = decode_token(refresh_token, expected_type="refresh")
-            if payload is None:
+            if payload is None or not payload.get("mcp"):
                 return JSONResponse(
                     {"error": "invalid_grant", "error_description": "Invalid refresh token"},
                     status_code=400
@@ -476,10 +496,12 @@ class BifrostAuthProvider:
                     "name": user.name,
                     "is_superuser": user.is_superuser,
                     "org_id": str(user.organization_id) if user.organization_id else None,
-                                        "type": "access",
+                    "mcp": True,
+                    "scope": "mcp:access",
+                    "type": "access",
                 }
                 access_token = create_access_token(data=token_data)
-                new_refresh_token, _jti = create_refresh_token(data={"sub": str(user.id)})
+                new_refresh_token, _jti = create_refresh_token(data={"sub": str(user.id), "mcp": True})
 
             return JSONResponse({
                 "access_token": access_token,

--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -96,6 +96,7 @@ class MCPToolAccessService:
         accessible_agents = await self._get_accessible_agents(
             user_roles=user_roles,
             is_superuser=is_superuser,
+            user_id=user_id,
             org_id=org_id,
         )
 
@@ -204,7 +205,7 @@ class MCPToolAccessService:
             logger.warning(f"User denied org-scoped access to agent {agent_id}")
             return None
 
-        if not self._check_agent_access(agent, user_roles, is_superuser):
+        if not self._check_agent_access(agent, user_roles, is_superuser, user_id=user_id):
             logger.warning(f"User denied access to agent {agent_id}")
             return None
 
@@ -343,6 +344,7 @@ class MCPToolAccessService:
         agent: Agent,
         user_roles: list[str],
         is_superuser: bool,
+        user_id: UUID | str | None = None,
     ) -> bool:
         """Check if user has access to a specific agent (same rules as _get_accessible_agents)."""
         if agent.access_level == AgentAccessLevel.AUTHENTICATED:
@@ -354,12 +356,19 @@ class MCPToolAccessService:
                 return is_superuser
             return is_superuser or bool(set(user_roles) & agent_role_names)
 
+        if agent.access_level == AgentAccessLevel.PRIVATE:
+            owner_id = getattr(agent, "owner_user_id", None)
+            if is_superuser:
+                return True
+            return owner_id is not None and user_id is not None and str(owner_id) == str(user_id)
+
         return False
 
     async def _get_accessible_agents(
         self,
         user_roles: list[str],
         is_superuser: bool,
+        user_id: UUID | str | None = None,
         org_id: UUID | str | None = None,
     ) -> list[Agent]:
         """
@@ -400,18 +409,8 @@ class MCPToolAccessService:
                 # Any authenticated user can access
                 accessible_agents.append(agent)
 
-            elif agent.access_level == AgentAccessLevel.ROLE_BASED:
-                # Get role names from agent's roles
-                agent_role_names = {role.name for role in agent.roles}
-
-                if not agent_role_names:
-                    # ROLE_BASED with no roles = only superusers can access
-                    if is_superuser:
-                        accessible_agents.append(agent)
-                elif is_superuser or (user_role_set & agent_role_names):
-                    # User has at least one matching role, or is a platform
-                    # admin (superuser bypass — issue #244)
-                    accessible_agents.append(agent)
+            elif self._check_agent_access(agent, list(user_role_set), is_superuser, user_id=user_id):
+                accessible_agents.append(agent)
 
             # Note: PUBLIC agents are not included for MCP access
             # as MCP requires authentication

--- a/api/src/services/mcp_server/tools/_http_bridge.py
+++ b/api/src/services/mcp_server/tools/_http_bridge.py
@@ -65,7 +65,11 @@ def _token_from_context(context: "MCPContext") -> str:
 
         token = get_access_token()
         if token is not None and getattr(token, "token", None):
-            return token.token
+            from src.core.security import decode_token
+
+            payload = decode_token(token.token, expected_type="access")
+            if payload is not None and not payload.get("mcp"):
+                return token.token
     except Exception:
         # Not in a FastMCP HTTP request — fall through to minting.
         pass

--- a/api/src/services/mcp_server/tools/agents.py
+++ b/api/src/services/mcp_server/tools/agents.py
@@ -53,6 +53,11 @@ def _ensure_can_manage_agent_privileges(
     return None
 
 
+def _reference_in_agent_scope(reference_org_id: Any, agent_org_id: UUID | None) -> bool:
+    """Return whether a referenced tool/agent may be linked to this agent."""
+    return reference_org_id is None or reference_org_id == agent_org_id
+
+
 # ==================== SCHEMA TOOL ====================
 
 
@@ -397,8 +402,11 @@ async def create_agent(
                         )
                         workflow = result.scalar_one_or_none()
                         if workflow:
+                            if not _reference_in_agent_scope(workflow.organization_id, effective_org_id):
+                                return error_result(
+                                    f"Tool workflow '{tool_id}' belongs to a different organization."
+                            )
                             tools.append(workflow)
-                            db.add(AgentTool(agent_id=agent_id, workflow_id=workflow.id))
                         else:
                             logger.warning(f"Tool workflow not found or inactive: {tool_id}")
                     except ValueError:
@@ -420,15 +428,23 @@ async def create_agent(
                         )
                         delegate = result.scalar_one_or_none()
                         if delegate:
+                            if not _reference_in_agent_scope(delegate.organization_id, effective_org_id):
+                                return error_result(
+                                    f"Delegated agent '{delegate_id}' belongs to a different organization."
+                            )
                             delegated_agents.append(delegate)
-                            db.add(AgentDelegation(
-                                parent_agent_id=agent_id,
-                                child_agent_id=delegate.id,
-                            ))
                         else:
                             logger.warning(f"Delegate agent not found or inactive: {delegate_id}")
                     except ValueError:
                         logger.warning(f"Invalid delegate agent ID: {delegate_id}")
+
+            for workflow in tools:
+                db.add(AgentTool(agent_id=agent_id, workflow_id=workflow.id))
+            for delegate in delegated_agents:
+                db.add(AgentDelegation(
+                    parent_agent_id=agent_id,
+                    child_agent_id=delegate.id,
+                ))
 
             await db.flush()
 
@@ -603,9 +619,6 @@ async def update_agent(
             # Update tool relationships if provided
             tools: list[Workflow] = []
             if tool_ids is not None:
-                await db.execute(
-                    delete(AgentTool).where(AgentTool.agent_id == uuid_id)
-                )
                 for tool_id in tool_ids:
                     try:
                         workflow_uuid = UUID(tool_id)
@@ -617,18 +630,23 @@ async def update_agent(
                         )
                         workflow = result.scalar_one_or_none()
                         if workflow:
+                            if not _reference_in_agent_scope(workflow.organization_id, agent.organization_id):
+                                return error_result(
+                                    f"Tool workflow '{tool_id}' belongs to a different organization."
+                            )
                             tools.append(workflow)
-                            db.add(AgentTool(agent_id=uuid_id, workflow_id=workflow.id))
                     except ValueError:
                         logger.warning(f"Invalid tool ID: {tool_id}")
+                await db.execute(
+                    delete(AgentTool).where(AgentTool.agent_id == uuid_id)
+                )
+                for workflow in tools:
+                    db.add(AgentTool(agent_id=uuid_id, workflow_id=workflow.id))
                 updates_made.append("tool_ids")
 
             # Update delegation relationships if provided
             delegated_agents: list[Agent] = []
             if delegated_agent_ids is not None:
-                await db.execute(
-                    delete(AgentDelegation).where(AgentDelegation.parent_agent_id == uuid_id)
-                )
                 for delegate_id in delegated_agent_ids:
                     try:
                         delegate_uuid = UUID(delegate_id)
@@ -642,13 +660,21 @@ async def update_agent(
                         )
                         delegate = result.scalar_one_or_none()
                         if delegate:
+                            if not _reference_in_agent_scope(delegate.organization_id, agent.organization_id):
+                                return error_result(
+                                    f"Delegated agent '{delegate_id}' belongs to a different organization."
+                            )
                             delegated_agents.append(delegate)
-                            db.add(AgentDelegation(
-                                parent_agent_id=uuid_id,
-                                child_agent_id=delegate.id,
-                            ))
                     except ValueError:
                         logger.warning(f"Invalid delegate agent ID: {delegate_id}")
+                await db.execute(
+                    delete(AgentDelegation).where(AgentDelegation.parent_agent_id == uuid_id)
+                )
+                for delegate in delegated_agents:
+                    db.add(AgentDelegation(
+                        parent_agent_id=uuid_id,
+                        child_agent_id=delegate.id,
+                    ))
                 updates_made.append("delegated_agent_ids")
 
             if not updates_made:

--- a/api/src/services/mcp_server/tools/workflow.py
+++ b/api/src/services/mcp_server/tools/workflow.py
@@ -310,6 +310,9 @@ async def register_workflow(context: Any, path: str, function_name: str, organiz
     Takes a file path and function name, validates the function has a
     @workflow/@tool/@data_provider decorator, and registers it in the system.
     """
+    if not getattr(context, "is_platform_admin", False):
+        return error_result("Only platform admins can register workflows via MCP.")
+
     import ast
     from uuid import UUID, uuid4
 

--- a/api/tests/unit/routers/test_agents_user_created.py
+++ b/api/tests/unit/routers/test_agents_user_created.py
@@ -33,6 +33,7 @@ def make_user(
     user.email = email
     user.organization_id = organization_id or uuid4()
     user.is_superuser = is_superuser
+    user.is_platform_admin = is_superuser
     user.roles = roles or []
     return user
 
@@ -265,3 +266,46 @@ class TestPromoteAgentPermission:
 
         result = await _user_has_permission(mock_session, user_id, "can_promote_agent")
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_promote_agent_outside_own_org(self):
+        """A promote-capable user cannot promote a private agent in another tenant."""
+        from fastapi import HTTPException
+        from src.models.contracts.agents import AgentPromoteRequest
+        from src.routers.agents import promote_agent
+
+        user_id = uuid4()
+        user_org_id = uuid4()
+        foreign_org_id = uuid4()
+        agent = make_agent(
+            owner_user_id=user_id,
+            access_level=AgentAccessLevel.PRIVATE,
+            organization_id=foreign_org_id,
+        )
+        user = make_user(user_id=user_id, organization_id=user_org_id)
+
+        agent_lookup = MagicMock()
+        agent_lookup.scalar_one_or_none.return_value = agent
+        permission_lookup = MagicMock()
+        permission_lookup.scalars.return_value.all.return_value = [
+            {"can_promote_agent": True}
+        ]
+        reload_lookup = MagicMock()
+        reload_lookup.scalar_one.return_value = agent
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            side_effect=[agent_lookup, permission_lookup, reload_lookup]
+        )
+        mock_session.flush = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc:
+            await promote_agent(
+                agent.id,
+                AgentPromoteRequest(access_level=AgentAccessLevel.AUTHENTICATED),
+                mock_session,
+                user,
+            )
+
+        assert exc.value.status_code == 403
+        assert "own organization" in exc.value.detail

--- a/api/tests/unit/services/test_autonomous_agent_executor.py
+++ b/api/tests/unit/services/test_autonomous_agent_executor.py
@@ -58,6 +58,35 @@ def mock_agent():
 
 class TestAutonomousAgentExecutor:
     @pytest.mark.asyncio
+    async def test_workflow_tool_uses_agent_identity_not_system_user(
+        self, mock_session, mock_agent
+    ):
+        """Autonomous workflow tools should not silently inherit system identity."""
+        workflow_id = uuid4()
+        executor = AutonomousAgentExecutor(mock_session)
+        executor._tool_workflow_id_map["do_work"] = workflow_id
+
+        response = MagicMock()
+        response.status.value = "Success"
+        response.result = {"ok": True}
+
+        with patch(
+            "src.services.execution.service.execute_tool",
+            new_callable=AsyncMock,
+            return_value=response,
+        ) as mock_execute:
+            result = await executor._execute_tool(
+                ToolCallRequest(id="tc1", name="do_work", arguments={}),
+                mock_agent,
+            )
+
+        assert result == '{"ok": true}'
+        kwargs = mock_execute.await_args.kwargs
+        assert kwargs["user_id"] == str(mock_agent.id)
+        assert kwargs["user_email"] != "system@internal.gobifrost.com"
+        assert kwargs["is_platform_admin"] is False
+
+    @pytest.mark.asyncio
     @patch("src.services.execution.autonomous_agent_executor.get_llm_client")
     @patch("src.services.execution.autonomous_agent_executor.resolve_agent_tools")
     async def test_run_returns_structured_result(self, mock_resolve_tools, mock_get_llm, mock_session, mock_agent):

--- a/api/tests/unit/services/test_mcp_agent_scope.py
+++ b/api/tests/unit/services/test_mcp_agent_scope.py
@@ -276,6 +276,27 @@ class TestCheckAgentAccess:
         assert MCPToolAccessService._check_agent_access(agent, [], False) is False
         assert MCPToolAccessService._check_agent_access(agent, [], True) is False
 
+    def test_private_agent_requires_owner_for_non_superuser(self):
+        """PRIVATE agents are visible to their owner only in MCP agent-scoped mode."""
+        from src.models.enums import AgentAccessLevel
+        from src.services.mcp_server.tool_access import MCPToolAccessService
+
+        owner_id = uuid4()
+        agent = MagicMock()
+        agent.access_level = AgentAccessLevel.PRIVATE
+        agent.owner_user_id = owner_id
+        agent.roles = []
+
+        assert MCPToolAccessService._check_agent_access(
+            agent, [], False, user_id=owner_id
+        ) is True
+        assert MCPToolAccessService._check_agent_access(
+            agent, [], False, user_id=uuid4()
+        ) is False
+        assert MCPToolAccessService._check_agent_access(
+            agent, [], True, user_id=uuid4()
+        ) is True
+
 
 # =============================================================================
 # ToolFilterMiddleware agent-scoped behavior tests

--- a/api/tests/unit/services/test_mcp_auth.py
+++ b/api/tests/unit/services/test_mcp_auth.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi.security import HTTPAuthorizationCredentials
 
 from src.core.security import create_access_token
 from src.services.mcp_server.auth import (
@@ -167,6 +168,34 @@ class TestProtectedResourceMetadata:
         assert "https://test.example.com" in metadata["authorization_servers"]
         assert "mcp:access" in metadata["scopes_supported"]
         assert "header" in metadata["bearer_methods_supported"]
+
+
+class TestMcpBoundTokens:
+    """MCP OAuth tokens must not be reusable as first-party REST API tokens."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_access_token_is_rejected_by_rest_auth(self):
+        from src.core.auth import get_current_user_optional
+
+        token = create_access_token({
+            "sub": str(uuid4()),
+            "email": "user@org.local",
+            "name": "Regular User",
+            "is_superuser": False,
+            "org_id": str(uuid4()),
+            "mcp": True,
+            "scope": "mcp:access",
+        })
+        request = MagicMock()
+        request.cookies = {}
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer",
+            credentials=token,
+        )
+
+        user = await get_current_user_optional(request, credentials, MagicMock())
+
+        assert user is None
 
 
 class TestCheckMcpAccess:

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -1237,6 +1237,20 @@ class TestRegisterWorkflow:
     """Tests for the register_workflow MCP tool."""
 
     @pytest.mark.asyncio
+    async def test_non_admin_cannot_register_workflow(self, org_user_context):
+        """register_workflow cannot bypass platform-admin REST authorization."""
+        from src.services.mcp_server.tools.workflow import register_workflow
+
+        result = await register_workflow(
+            org_user_context,
+            "workflows/test.py",
+            "my_function",
+        )
+        data = result.structured_content
+        assert "error" in data
+        assert "Only platform admins" in data["error"]
+
+    @pytest.mark.asyncio
     async def test_rejects_missing_path(self, platform_admin_context):
         """register_workflow MCP tool rejects missing path."""
         from src.services.mcp_server.tools.workflow import register_workflow


### PR DESCRIPTION
## Summary
- restrict MCP OAuth and workflow/agent tools to authorized admin/org contexts
- prevent private/cross-tenant agent promotion and unscoped link creation
- keep delegated agent/workflow execution from silently inheriting system privileges

## Verification
- focused pytest suite: 160 passed
- ruff check on touched files
- pyright full API check: 0 errors
- git diff --check