### PR TITLE
Harden CLI config secret scoping

### DIFF
--- a/api/alembic/versions/20260524_oauth_tokens_user_delete_cascade.py
+++ b/api/alembic/versions/20260524_oauth_tokens_user_delete_cascade.py
@@ -1,0 +1,40 @@
+"""Cascade user-owned OAuth tokens on user delete.
+
+Revision ID: 20260524_oauth_user_cascade
+Revises: 20260522_codex_gateway
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260524_oauth_user_cascade"
+down_revision: str | Sequence[str] | None = "20260522_codex_gateway"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("oauth_tokens_user_id_fkey", "oauth_tokens", type_="foreignkey")
+    op.create_foreign_key(
+        "oauth_tokens_user_id_fkey",
+        "oauth_tokens",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("oauth_tokens_user_id_fkey", "oauth_tokens", type_="foreignkey")
+    op.create_foreign_key(
+        "oauth_tokens_user_id_fkey",
+        "oauth_tokens",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -743,26 +743,26 @@ Examples:
         assert password is not None
         rc, data = asyncio.run(password_login_flow(api_url, email, password))
         if rc == 0 and data is not None:
-            # Persist URL + tokens to CWD's .env so subsequent `bifrost`
-            # commands from this directory just work — no shell-eval needed.
-            # Isolation is by directory: each sandbox dir has its own .env.
+            expires_at = datetime.now(timezone.utc) + timedelta(
+                seconds=data.get("expires_in", 1800)
+            )
+            credentials.save_credentials(
+                api_url=api_url,
+                access_token=data["access_token"],
+                refresh_token=data["refresh_token"],
+                expires_at=expires_at.isoformat(),
+            )
+            # Persist only the target URL to CWD's .env. Tokens belong in the
+            # credential backend, never in a project directory.
             try:
                 _write_env_url(api_url)
-                _upsert_env_vars(
-                    {
-                        "BIFROST_ACCESS_TOKEN": data["access_token"],
-                        "BIFROST_REFRESH_TOKEN": data["refresh_token"],
-                    }
-                )
             except OSError as e:
                 print(
                     f"Warning: could not update .env in current directory: {e}",
                     file=sys.stderr,
                 )
-                # Fall back to printing so the caller can eval them.
+                # Fall back to printing the non-secret URL only.
                 print(f"BIFROST_API_URL={api_url}")
-                print(f"BIFROST_ACCESS_TOKEN={data['access_token']}")
-                print(f"BIFROST_REFRESH_TOKEN={data['refresh_token']}")
         return rc
 
     # Browser device-code flow (persistent → keychain or JSON fallback).

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -124,10 +124,8 @@ def raise_for_status_with_detail(response: httpx.Response) -> None:
 # and httpx.AsyncClient is bound to the event loop that created it.
 _thread_local = threading.local()
 
-# Auto-load only the CLI-safe .env allowlist if present (for local development).
-# Walk upward from cwd, not from this file. With pipx-installed CLIs, __file__
-# lives in the pipx venv and the default upward walk never reaches the user's
-# workspace, so a .env in the project root is silently ignored.
+# Auto-load only the CLI-safe .env allowlist when explicitly opted in for local
+# development. Arbitrary working directories must not be able to steer CLI auth.
 load_allowed_dotenv()
 
 

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -69,15 +69,18 @@ def get_credentials_path() -> Path:
 def load_allowed_dotenv(
     dotenv_path: str | os.PathLike[str] | None = None, *, override: bool = True
 ) -> None:
-    """Load the CWD ``.env`` allowlist used by the CLI.
+    """Load the explicit ``.env`` allowlist used by the CLI.
 
-    The CLI still supports project-local ``BIFROST_API_URL`` discovery, but it
+    The CLI supports opt-in project-local ``BIFROST_API_URL`` discovery, but it
     must not import credentials, proxy settings, CA bundle paths, or other
     security-sensitive process environment from an attacker-controlled CWD.
     """
     try:
         from dotenv import dotenv_values, find_dotenv
     except ImportError:
+        return
+
+    if dotenv_path is None and os.environ.get("BIFROST_LOAD_CWD_ENV") != "1":
         return
 
     path = str(dotenv_path) if dotenv_path is not None else find_dotenv(usecwd=True)

--- a/api/src/core/config_resolver.py
+++ b/api/src/core/config_resolver.py
@@ -294,7 +294,11 @@ class ConfigResolver:
             logger.warning(f"Failed to populate org cache: {e}")
 
     async def load_config_for_scope(
-        self, scope: str, db: AsyncSession | None = None
+        self,
+        scope: str,
+        db: AsyncSession | None = None,
+        *,
+        include_global_secrets: bool = False,
     ) -> dict[str, Any]:
         """
         Load all config for a scope (org_id or "GLOBAL").
@@ -307,6 +311,9 @@ class ConfigResolver:
         Args:
             scope: "GLOBAL" or organization ID
             db: Optional AsyncSession. If not provided, creates its own.
+            include_global_secrets: For org scopes, include global secret
+                fallback values. CLI-facing callers leave this false so a
+                global secret cannot be decrypted through an org fallback.
 
         Returns:
             Configuration dictionary
@@ -323,6 +330,26 @@ class ConfigResolver:
 
         # Try Redis cache first
         cached = await self._get_config_from_cache(org_id_for_cache)
+        if cached is not None:
+            if org_id_for_cache is not None and not include_global_secrets:
+                has_unscoped_secret = any(
+                    isinstance(entry, dict)
+                    and entry.get("type") == ConfigType.SECRET.value
+                    and entry.get("scope") not in {"org", "global"}
+                    for entry in cached.values()
+                )
+                if has_unscoped_secret:
+                    cached = None
+                else:
+                    cached = {
+                        key: entry
+                        for key, entry in cached.items()
+                        if not (
+                            isinstance(entry, dict)
+                            and entry.get("type") == ConfigType.SECRET.value
+                            and entry.get("scope") == "global"
+                        )
+                    }
         if cached is not None:
             logger.debug(f"Config cache hit for scope={log_safe(scope)}")
             return cached
@@ -352,6 +379,7 @@ class ConfigResolver:
                     config_dict[config.key] = {
                         "value": config.value.get("value") if isinstance(config.value, dict) else config.value,
                         "type": config.config_type.value if config.config_type else "string",
+                        "scope": "global",
                     }
             else:
                 try:
@@ -368,9 +396,15 @@ class ConfigResolver:
                     )
                 )
                 for config in global_result.scalars():
+                    if (
+                        not include_global_secrets
+                        and config.config_type == ConfigType.SECRET
+                    ):
+                        continue
                     config_dict[config.key] = {
                         "value": config.value.get("value") if isinstance(config.value, dict) else config.value,
                         "type": config.config_type.value if config.config_type else "string",
+                        "scope": "global",
                     }
 
                 # Get org-specific configs (these override global)
@@ -384,6 +418,7 @@ class ConfigResolver:
                     config_dict[config.key] = {
                         "value": config.value.get("value") if isinstance(config.value, dict) else config.value,
                         "type": config.config_type.value if config.config_type else "string",
+                        "scope": "org",
                     }
 
             # Populate cache for next time

--- a/api/src/models/orm/oauth.py
+++ b/api/src/models/orm/oauth.py
@@ -93,7 +93,7 @@ class OAuthToken(Base):
         ForeignKey("organizations.id"), default=None
     )
     provider_id: Mapped[UUID] = mapped_column(ForeignKey("oauth_providers.id"))
-    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"), default=None)
+    user_id: Mapped[UUID | None] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), default=None)
     encrypted_access_token: Mapped[bytes] = mapped_column(LargeBinary)
     encrypted_refresh_token: Mapped[bytes | None] = mapped_column(
         LargeBinary, default=None

--- a/api/src/repositories/integrations.py
+++ b/api/src/repositories/integrations.py
@@ -608,7 +608,11 @@ class IntegrationsRepository(BaseRepository[Integration]):
         return config
 
     async def get_config_for_mapping(
-        self, integration_id: UUID, org_id: UUID
+        self,
+        integration_id: UUID,
+        org_id: UUID,
+        *,
+        include_default_secrets: bool = False,
     ) -> dict:
         """
         Get merged configuration for an integration mapping.
@@ -619,6 +623,9 @@ class IntegrationsRepository(BaseRepository[Integration]):
         Args:
             integration_id: Integration UUID
             org_id: Organization UUID
+            include_default_secrets: Include integration-default secret
+                fallback values. SDK mapping reads leave this false so global
+                defaults do not leak as decrypted org config.
 
         Returns:
             dict: Merged configuration (integration defaults + org overrides)
@@ -650,7 +657,15 @@ class IntegrationsRepository(BaseRepository[Integration]):
             else:
                 val = value
 
-            if entry.config_type == ConfigType.SECRET and isinstance(val, str):
+            is_secret = entry.config_type == ConfigType.SECRET
+            if (
+                is_secret
+                and entry.organization_id is None
+                and not include_default_secrets
+            ):
+                continue
+
+            if is_secret and isinstance(val, str):
                 try:
                     val = decrypt_secret(val)
                 except Exception:
@@ -667,7 +682,12 @@ class IntegrationsRepository(BaseRepository[Integration]):
 
         return config
 
-    async def get_integration_defaults(self, integration_id: UUID) -> dict[str, Any]:
+    async def get_integration_defaults(
+        self,
+        integration_id: UUID,
+        *,
+        include_secrets: bool = False,
+    ) -> dict[str, Any]:
         """
         Get integration-level config defaults (org_id=NULL).
 
@@ -675,6 +695,8 @@ class IntegrationsRepository(BaseRepository[Integration]):
 
         Args:
             integration_id: Integration UUID
+            include_secrets: Include decrypted default secret values. Leave
+                false when serving org-scoped fallback responses.
 
         Returns:
             dict: Integration-level config defaults
@@ -698,6 +720,9 @@ class IntegrationsRepository(BaseRepository[Integration]):
             else:
                 val = value
 
+            if entry.config_type == ConfigType.SECRET and not include_secrets:
+                continue
+
             if entry.config_type == ConfigType.SECRET and isinstance(val, str):
                 try:
                     val = decrypt_secret(val)
@@ -709,7 +734,11 @@ class IntegrationsRepository(BaseRepository[Integration]):
 
         return config
 
-    async def get_provider_org_token(self, provider_id: UUID) -> Any:
+    async def get_provider_org_token(
+        self,
+        provider_id: UUID,
+        organization_id: UUID | None,
+    ) -> Any:
         """
         Get org-level OAuth token for a provider (user_id=NULL).
 
@@ -718,16 +747,21 @@ class IntegrationsRepository(BaseRepository[Integration]):
 
         Args:
             provider_id: OAuthProvider UUID
+            organization_id: Owning organization, or None for global tokens
 
         Returns:
             OAuthToken or None if not found
         """
         from src.models.orm.oauth import OAuthToken
 
-        result = await self.session.execute(
-            select(OAuthToken).where(
-                OAuthToken.provider_id == provider_id,
-                OAuthToken.user_id.is_(None),
-            )
+        stmt = select(OAuthToken).where(
+            OAuthToken.provider_id == provider_id,
+            OAuthToken.user_id.is_(None),
         )
+        if organization_id is None:
+            stmt = stmt.where(OAuthToken.organization_id.is_(None))
+        else:
+            stmt = stmt.where(OAuthToken.organization_id == organization_id)
+
+        result = await self.session.execute(stmt)
         return result.scalars().first()

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -362,14 +362,14 @@ async def update_dev_context(
 
 
 async def _get_cli_org_id(
-    user_id: UUID,
+    current_user: Any,
     scope: str | None,
     db: AsyncSession,
 ) -> str | None:
     """Get the organization ID for CLI config operations.
 
     Args:
-        user_id: Current user's ID
+        current_user: Current authenticated user
         scope: Organization scope - can be:
             - None: Use execution context default org
             - org UUID string: Target specific organization
@@ -385,6 +385,36 @@ async def _get_cli_org_id(
             value flows into raw SQL and surfaces as a downstream
             asyncpg type error (500).
     """
+    user_id = current_user.user_id
+    user_org_id = current_user.organization_id
+    is_superuser = bool(current_user.is_superuser)
+
+    if not is_superuser:
+        if user_org_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="CLI scope requires an organization",
+            )
+        if scope and scope != "global":
+            try:
+                requested_org_id = UUID(scope)
+            except ValueError:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"scope must be 'global', a UUID, or null; got {scope!r}",
+                ) from None
+            if requested_org_id != user_org_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Cannot access another organization's CLI scope",
+                )
+        elif scope == "global":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only superusers can access global CLI scope",
+            )
+        return str(user_org_id)
+
     # "global" scope means no org resolution
     if scope == "global":
         return None
@@ -424,7 +454,7 @@ async def cli_get_config(
     """Get a config value via CLI API."""
     from src.core.config_resolver import ConfigResolver
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     scope = org_id or "GLOBAL"
 
     resolver = ConfigResolver()
@@ -479,7 +509,7 @@ async def cli_set_config(
     from src.models import Config as ConfigModel
     from src.models.enums import ConfigType as ConfigTypeEnum
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
     now = datetime.now(timezone.utc)
 
@@ -505,6 +535,7 @@ async def cli_set_config(
     stmt = select(ConfigModel).where(
         ConfigModel.key == request.key,
         ConfigModel.organization_id == org_uuid,
+        ConfigModel.integration_id.is_(None),
     )
     result = await db.execute(stmt)
     existing = result.scalar_one_or_none()
@@ -551,7 +582,7 @@ async def cli_list_config(
     """List all config values via CLI API."""
     from src.core.config_resolver import ConfigResolver
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     scope = org_id or "GLOBAL"
 
     resolver = ConfigResolver()
@@ -597,12 +628,13 @@ async def cli_delete_config(
     """Delete a config value via CLI API."""
     from src.models import Config as ConfigModel
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     stmt = select(ConfigModel).where(
         ConfigModel.key == request.key,
         ConfigModel.organization_id == org_uuid,
+        ConfigModel.integration_id.is_(None),
     )
     result = await db.execute(stmt)
     config = result.scalar_one_or_none()
@@ -651,7 +683,7 @@ async def sdk_integrations_get(
     from src.services.oauth_provider import resolve_url_template
     from src.core.security import decrypt_secret
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     try:
@@ -682,7 +714,10 @@ async def sdk_integrations_get(
             if integration and integration.oauth_provider:
                 token = mapping.oauth_token
                 if not token:
-                    token = await repo.get_provider_org_token(integration.oauth_provider.id)
+                    token = await repo.get_provider_org_token(
+                        integration.oauth_provider.id,
+                        org_uuid,
+                    )
                 response_data["oauth"] = await _build_oauth_data(
                     integration.oauth_provider, token, entity_id, resolve_url_template, decrypt_secret,
                     oauth_scope=request.oauth_scope,
@@ -698,7 +733,10 @@ async def sdk_integrations_get(
             return None
 
         entity_id = integration.default_entity_id or integration.entity_id
-        config = await repo.get_integration_defaults(integration.id)
+        config = await repo.get_integration_defaults(
+            integration.id,
+            include_secrets=org_uuid is None,
+        )
 
         secret_keys = [s.key for s in integration.config_schema if s.type == "secret"]
         response_data = {
@@ -712,7 +750,10 @@ async def sdk_integrations_get(
 
         # Build OAuth data if provider exists
         if integration.oauth_provider:
-            token = await repo.get_provider_org_token(integration.oauth_provider.id)
+            token = await repo.get_provider_org_token(
+                integration.oauth_provider.id,
+                org_uuid,
+            )
             response_data["oauth"] = await _build_oauth_data(
                 integration.oauth_provider, token, entity_id, resolve_url_template, decrypt_secret,
                 oauth_scope=request.oauth_scope,
@@ -1107,7 +1148,7 @@ async def sdk_integrations_refresh_token(
         refresh_oauth_token_http,
     )
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     try:
@@ -1887,7 +1928,7 @@ async def cli_ai_complete(
             from src.core.cache import get_shared_redis
 
             redis_client = await get_shared_redis()
-            org_id = await _get_cli_org_id(current_user.user_id, request.org_id, db)
+            org_id = await _get_cli_org_id(current_user, request.org_id, db)
             await record_ai_usage(
                 session=db,
                 redis_client=redis_client,
@@ -1975,7 +2016,7 @@ async def cli_ai_stream(
                         from src.core.cache import get_shared_redis
 
                         redis_client = await get_shared_redis()
-                        org_id = await _get_cli_org_id(user_id, org_id_str, db)
+                        org_id = await _get_cli_org_id(current_user, org_id_str, db)
                         await record_ai_usage(
                             session=db,
                             redis_client=redis_client,
@@ -2064,7 +2105,7 @@ async def cli_knowledge_store(
     from src.services.embeddings import get_embedding_client
 
     try:
-        org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+        org_id = await _get_cli_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         # Generate embedding
@@ -2114,7 +2155,7 @@ async def cli_knowledge_store_many(
     from src.services.embeddings import get_embedding_client
 
     try:
-        org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+        org_id = await _get_cli_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         # Extract contents for batch embedding
@@ -2171,7 +2212,7 @@ async def cli_knowledge_search(
     from src.services.embeddings import get_embedding_client
 
     try:
-        org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+        org_id = await _get_cli_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         # Generate query embedding
@@ -2230,7 +2271,7 @@ async def cli_knowledge_delete(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+        org_id = await _get_cli_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2266,7 +2307,7 @@ async def cli_knowledge_delete_namespace(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user.user_id, scope, db)
+        org_id = await _get_cli_org_id(current_user, scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2302,7 +2343,7 @@ async def cli_knowledge_list_namespaces(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user.user_id, scope, db)
+        org_id = await _get_cli_org_id(current_user, scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2341,7 +2382,7 @@ async def cli_knowledge_get(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user.user_id, scope, db)
+        org_id = await _get_cli_org_id(current_user, scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2537,7 +2578,7 @@ async def cli_create_table(
     """Create a new table via SDK."""
     from src.models.orm.tables import Table
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     # Check if table exists in the same scope.
@@ -2597,7 +2638,7 @@ async def cli_list_tables(
     from src.models.orm.tables import Table
     from sqlalchemy import or_
 
-    org_id = await _get_cli_org_id(current_user.user_id, request.scope, db)
+    org_id = await _get_cli_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     # Build query with cascade scoping (org + global)

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -4,9 +4,8 @@ The check must:
 
 * Skip silently for source/dev installs (``__version__`` of ``"unknown"`` or
   ``"0.0.0+source"``).
-* Resolve the API URL via ``credentials._resolve_url`` so a project
-  ``.env`` (loaded by python-dotenv before the call) is honored alongside
-  the keyring/JSON store. We use ``_resolve_url`` (not
+* Resolve the API URL via ``credentials._resolve_url`` so the opt-in project
+  ``.env`` allowlist is honored alongside the keyring/JSON store. We use ``_resolve_url`` (not
   ``get_credentials``) because the version check only needs the URL — a
   logged-out CLI with ``BIFROST_API_URL`` set in ``.env`` should still get
   checked, even though it has no tokens yet.
@@ -34,10 +33,10 @@ def _isolate_version_check_state():
 
     * The memoized ``_persistent_backend`` global in ``bifrost.credentials``,
       which downstream credentials tests rely on being unset.
-    * ``BIFROST_API_URL`` written to ``os.environ`` by ``python-dotenv`` in
-      the dotenv-resolution test — monkeypatch doesn't track it because
-      the allowlisted dotenv loader writes to os.environ directly. Subsequent SDK credentials
-      tests assume the env var is unset and resolve via the JSON store.
+    * ``BIFROST_API_URL`` written to ``os.environ`` by the allowlisted dotenv
+      loader — monkeypatch doesn't track it because the loader writes to
+      os.environ directly. Subsequent SDK credentials tests assume the env var
+      is unset and resolve via the JSON store.
     """
     import os
 
@@ -47,6 +46,7 @@ def _isolate_version_check_state():
     yield
     _reset_persistent_backend_for_tests()
     os.environ.pop("BIFROST_API_URL", None)
+    os.environ.pop("BIFROST_LOAD_CWD_ENV", None)
 
 
 def _patch_version(monkeypatch, value: str) -> None:
@@ -298,7 +298,7 @@ class TestUrlResolution:
             assert url == "https://from-credentials.example/api/version"
 
     def test_loads_dotenv_before_resolving(self, monkeypatch, tmp_path):
-        """A project ``.env`` containing BIFROST_API_URL is honored.
+        """An opted-in project ``.env`` containing BIFROST_API_URL is honored.
 
         ``_check_cli_version`` runs before the rest of the CLI imports
         ``bifrost.client`` (which is where the dotenv allowlist is normally
@@ -316,6 +316,7 @@ class TestUrlResolution:
         # Make sure the env var isn't already set in the test process so we
         # know the value got there via dotenv, not inheritance.
         monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.setenv("BIFROST_LOAD_CWD_ENV", "1")
 
         _patch_version(monkeypatch, "1.2.3")
         from bifrost import cli
@@ -341,13 +342,37 @@ class TestUrlResolution:
         assert "BIFROST_ACCESS_TOKEN" not in os.environ
         assert "HTTPS_PROXY" not in os.environ
 
+    def test_does_not_load_cwd_dotenv_without_opt_in(self, monkeypatch, tmp_path):
+        """A CWD-local ``.env`` cannot silently steer the CLI version check."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("BIFROST_API_URL=https://from-dotenv.example\n")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.delenv("BIFROST_LOAD_CWD_ENV", raising=False)
+
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials.get_persistent_backend"
+        ) as get_backend, patch("httpx.get") as urlopen:
+            backend = get_backend.return_value
+            backend.list_urls.return_value = []
+            backend.get.return_value = None
+            cli._check_cli_version()
+
+        urlopen.assert_not_called()
+        assert "BIFROST_API_URL" not in os.environ
+
     def test_cwd_dotenv_overrides_stale_env_url(self, monkeypatch, tmp_path):
-        """The current project's ``.env`` wins over a stale inherited URL."""
+        """The opted-in project ``.env`` wins over a stale inherited URL."""
         env_file = tmp_path / ".env"
         env_file.write_text("BIFROST_API_URL=https://from-current-dotenv.example\n")
 
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("BIFROST_API_URL", "https://from-old-env.example")
+        monkeypatch.setenv("BIFROST_LOAD_CWD_ENV", "1")
 
         _patch_version(monkeypatch, "1.2.3")
         from bifrost import cli

--- a/api/tests/unit/core/test_config_resolver.py
+++ b/api/tests/unit/core/test_config_resolver.py
@@ -69,3 +69,50 @@ class TestConfigResolverWithSession:
 
         assert "test_key" in result
         mock_session.execute.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_load_config_for_org_scope_omits_global_secrets(self, resolver):
+        """Org-scoped CLI config fallback must not inherit global secrets."""
+        from src.models.enums import ConfigType
+
+        org_id = str(uuid4())
+        resolver._get_config_from_cache = AsyncMock(return_value=None)
+        resolver._set_config_cache = AsyncMock()
+
+        global_secret = MagicMock()
+        global_secret.key = "api_key"
+        global_secret.value = {"value": "encrypted-global-secret"}
+        global_secret.config_type = ConfigType.SECRET
+
+        global_plain = MagicMock()
+        global_plain.key = "base_url"
+        global_plain.value = {"value": "https://example.test"}
+        global_plain.config_type = ConfigType.STRING
+
+        org_secret = MagicMock()
+        org_secret.key = "org_api_key"
+        org_secret.value = {"value": "encrypted-org-secret"}
+        org_secret.config_type = ConfigType.SECRET
+
+        def _result(entries):
+            scalars = MagicMock()
+            scalars.__iter__ = MagicMock(return_value=iter(entries))
+            result = MagicMock()
+            result.scalars.return_value = scalars
+            return result
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _result([global_secret, global_plain]),
+                _result([org_secret]),
+            ]
+        )
+
+        result = await resolver.load_config_for_scope(f"ORG:{org_id}", db=mock_session)
+
+        assert "api_key" not in result
+        assert result["base_url"]["value"] == "https://example.test"
+        assert result["base_url"]["scope"] == "global"
+        assert result["org_api_key"]["value"] == "encrypted-org-secret"
+        assert result["org_api_key"]["scope"] == "org"

--- a/api/tests/unit/models/test_oauth_token_user_fk.py
+++ b/api/tests/unit/models/test_oauth_token_user_fk.py
@@ -1,0 +1,14 @@
+"""Regression tests for OAuth token ownership semantics."""
+
+
+def test_oauth_token_user_fk_cascades_on_user_delete():
+    """User-owned OAuth tokens must not become org-owned tokens after user delete."""
+    from src.models.orm.oauth import OAuthToken
+
+    user_fk = next(
+        fk
+        for fk in OAuthToken.__table__.foreign_keys
+        if fk.parent.name == "user_id"
+    )
+
+    assert user_fk.ondelete == "CASCADE"

--- a/api/tests/unit/repositories/test_integrations_repository.py
+++ b/api/tests/unit/repositories/test_integrations_repository.py
@@ -5,7 +5,7 @@ Tests the database operations for integration management and mapping.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 from src.models.contracts.integrations import (
@@ -165,6 +165,67 @@ class TestIntegrationsRepository:
         assert result == mock_integration
         assert result.name == "Test Integration"
         mock_session.execute.assert_called_once()
+
+    async def test_get_config_for_mapping_skips_default_secrets(
+        self, repository, mock_session
+    ):
+        """Org mapping config must not receive decrypted global secret defaults."""
+        from src.models.enums import ConfigType
+
+        integration_id = uuid4()
+        org_id = uuid4()
+
+        default_secret = MagicMock()
+        default_secret.key = "api_key"
+        default_secret.value = {"value": "encrypted-global-secret"}
+        default_secret.config_type = ConfigType.SECRET
+        default_secret.organization_id = None
+
+        default_plain = MagicMock()
+        default_plain.key = "base_url"
+        default_plain.value = {"value": "https://example.test"}
+        default_plain.config_type = ConfigType.STRING
+        default_plain.organization_id = None
+
+        org_secret = MagicMock()
+        org_secret.key = "org_api_key"
+        org_secret.value = {"value": "encrypted-org-secret"}
+        org_secret.config_type = ConfigType.SECRET
+        org_secret.organization_id = org_id
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [default_secret, default_plain, org_secret]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        with patch("src.repositories.integrations.decrypt_secret", return_value="org-secret"):
+            result = await repository.get_config_for_mapping(integration_id, org_id)
+
+        assert "api_key" not in result
+        assert result["base_url"] == "https://example.test"
+        assert result["org_api_key"] == "org-secret"
+
+    async def test_get_provider_org_token_filters_by_organization(
+        self, repository, mock_session
+    ):
+        """Org-owned token fallback must not match a user-null token from another org."""
+        provider_id = uuid4()
+        org_id = uuid4()
+        expected_token = MagicMock()
+
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = expected_token
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_provider_org_token(provider_id, org_id)
+
+        assert result == expected_token
+        statement = mock_session.execute.call_args.args[0]
+        compiled = statement.compile()
+        assert org_id in compiled.params.values()
 
     async def test_list_integrations(self, repository, mock_session, mock_integration):
         """Test listing all non-deleted integrations."""

--- a/api/tests/unit/routers/test_cli_get_org_id.py
+++ b/api/tests/unit/routers/test_cli_get_org_id.py
@@ -8,6 +8,7 @@ either the literal ``"global"``, a valid UUID, or null/absent.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -17,11 +18,19 @@ from fastapi import HTTPException
 from src.routers.cli import _get_cli_org_id
 
 
+def _user(*, user_id=None, organization_id=None, is_superuser=True):
+    return SimpleNamespace(
+        user_id=user_id or uuid4(),
+        organization_id=organization_id,
+        is_superuser=is_superuser,
+    )
+
+
 @pytest.mark.asyncio
 async def test_global_returns_none():
     """``scope='global'`` short-circuits to ``None`` without DB access."""
     db = AsyncMock()
-    result = await _get_cli_org_id(uuid4(), "global", db)
+    result = await _get_cli_org_id(_user(is_superuser=True), "global", db)
     assert result is None
     db.execute.assert_not_called()
 
@@ -31,7 +40,7 @@ async def test_valid_uuid_passthrough():
     """A valid UUID scope is returned verbatim."""
     db = AsyncMock()
     target = str(uuid4())
-    result = await _get_cli_org_id(uuid4(), target, db)
+    result = await _get_cli_org_id(_user(is_superuser=True), target, db)
     assert result == target
     db.execute.assert_not_called()
 
@@ -41,7 +50,7 @@ async def test_garbage_scope_raises_422():
     """Non-UUID, non-'global' scope raises 422 (not a downstream 500)."""
     db = AsyncMock()
     with pytest.raises(HTTPException) as exc:
-        await _get_cli_org_id(uuid4(), "not-a-uuid", db)
+        await _get_cli_org_id(_user(is_superuser=True), "not-a-uuid", db)
     assert exc.value.status_code == 422
     assert "uuid" in exc.value.detail.lower() or "scope" in exc.value.detail.lower()
 
@@ -61,7 +70,7 @@ async def test_none_scope_uses_developer_context():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=FakeResult())
 
-    result = await _get_cli_org_id(uuid4(), None, db)
+    result = await _get_cli_org_id(_user(is_superuser=True), None, db)
     assert result == str(expected)
 
 
@@ -75,7 +84,7 @@ async def test_none_scope_no_developer_context_returns_none():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=FakeResult())
 
-    result = await _get_cli_org_id(uuid4(), None, db)
+    result = await _get_cli_org_id(_user(is_superuser=True), None, db)
     assert result is None
 
 
@@ -84,7 +93,7 @@ async def test_uppercase_uuid_accepted():
     """UUID validation is case-insensitive (Python's ``UUID`` parses both)."""
     db = AsyncMock()
     upper = str(uuid4()).upper()
-    result = await _get_cli_org_id(uuid4(), upper, db)
+    result = await _get_cli_org_id(_user(is_superuser=True), upper, db)
     assert result == upper
 
 
@@ -98,5 +107,51 @@ async def test_empty_string_treated_as_none():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=FakeResult())
 
-    result = await _get_cli_org_id(uuid4(), "", db)
+    result = await _get_cli_org_id(_user(is_superuser=True), "", db)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_regular_user_uses_own_org_for_none_scope():
+    """Non-superusers cannot fall through to global config."""
+    db = AsyncMock()
+    org_id = uuid4()
+
+    result = await _get_cli_org_id(
+        _user(organization_id=org_id, is_superuser=False),
+        None,
+        db,
+    )
+
+    assert result == str(org_id)
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_regular_user_cannot_request_another_org():
+    """Non-superusers cannot use the CLI scope parameter to read another org."""
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await _get_cli_org_id(
+            _user(organization_id=uuid4(), is_superuser=False),
+            str(uuid4()),
+            db,
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_regular_user_cannot_request_global_scope():
+    """Global config scope is reserved for superusers."""
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await _get_cli_org_id(
+            _user(organization_id=uuid4(), is_superuser=False),
+            "global",
+            db,
+        )
+
+    assert exc.value.status_code == 403

--- a/api/tests/unit/test_cli_login_ephemeral.py
+++ b/api/tests/unit/test_cli_login_ephemeral.py
@@ -4,10 +4,9 @@ Two login modes:
   * Browser device-code (default) — token stored in keychain (or JSON
     fallback). On success, login also writes BIFROST_API_URL=<url> to the
     CWD .env so subsequent CLI commands in this folder target this stack.
-  * Password-grant (when --email and --password are passed) — URL +
-    access + refresh tokens written to .env in CWD so subsequent CLI
-    commands from that directory inherit the session. Tokens are NOT
-    written to the OS keychain. Refuses MFA-enabled instances.
+  * Password-grant (when --email and --password are passed) — tokens are
+    written to the credential backend and only the URL is written to the
+    CWD .env. Refuses MFA-enabled instances.
 """
 
 from bifrost import cli
@@ -65,15 +64,25 @@ class TestPasswordLoginFlagParsing:
 
 
 class TestPasswordLoginSuccess:
-    def test_writes_three_vars_to_env_and_warning_to_stderr(
+    def test_writes_url_only_to_env_and_credentials_to_backend(
         self, capsys, monkeypatch, tmp_path,
     ):
+        from bifrost import credentials as creds_mod
+
         stub = _stub_post({
             "access_token": "at_value",
             "refresh_token": "rt_value",
             "expires_in": 1800,
         })
         monkeypatch.setattr("httpx.AsyncClient", stub)
+        monkeypatch.setattr(
+            creds_mod,
+            "get_credentials_path",
+            lambda: tmp_path / "credentials.json",
+        )
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+        creds_mod._reset_persistent_backend_for_tests()
         monkeypatch.chdir(tmp_path)
 
         rc = cli.handle_login([
@@ -85,21 +94,23 @@ class TestPasswordLoginSuccess:
 
         env_text = (tmp_path / ".env").read_text()
         assert "BIFROST_API_URL=http://localhost:38421" in env_text
-        assert "BIFROST_ACCESS_TOKEN=at_value" in env_text
-        assert "BIFROST_REFRESH_TOKEN=rt_value" in env_text
+        assert "BIFROST_ACCESS_TOKEN" not in env_text
+        assert "BIFROST_REFRESH_TOKEN" not in env_text
+
+        saved = creds_mod.get_credentials("http://localhost:38421")
+        assert saved is not None
+        assert saved["access_token"] == "at_value"
+        assert saved["refresh_token"] == "rt_value"
 
         # Warning to stderr
         captured = capsys.readouterr()
         assert "MFA" in captured.err
         assert "ephemeral" in captured.err.lower()
 
-    def test_does_not_write_to_keychain(self, capsys, monkeypatch, tmp_path):
-        """Password-grant must not touch the persistent (keychain/JSON) store.
+    def test_does_not_write_tokens_to_cwd_env(self, capsys, monkeypatch, tmp_path):
+        """Password-grant tokens must not be stored in a project directory."""
+        from bifrost import credentials as creds_mod
 
-        The session is per-directory via .env; persistence is intentionally
-        excluded so a password-grant login on a dev machine doesn't end up
-        in the long-lived auth list visible to `bifrost auth list`.
-        """
         stub = _stub_post({
             "access_token": "at",
             "refresh_token": "rt",
@@ -110,6 +121,9 @@ class TestPasswordLoginSuccess:
             "bifrost.credentials.get_credentials_path",
             lambda: tmp_path / "credentials.json",
         )
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+        creds_mod._reset_persistent_backend_for_tests()
         monkeypatch.chdir(tmp_path)
 
         cli.handle_login([
@@ -118,10 +132,10 @@ class TestPasswordLoginSuccess:
             "--url", "http://localhost:38421",
         ])
 
-        # No keychain / JSON-fallback record was written.
-        assert not (tmp_path / "credentials.json").exists()
-        # .env IS written (that's the new contract).
-        assert (tmp_path / ".env").exists()
+        env_text = (tmp_path / ".env").read_text()
+        assert "BIFROST_API_URL=http://localhost:38421" in env_text
+        assert "BIFROST_ACCESS_TOKEN" not in env_text
+        assert "BIFROST_REFRESH_TOKEN" not in env_text
 
 
 class TestPasswordLoginMfaRefusal:
@@ -152,12 +166,22 @@ class TestPasswordLoginMfaRefusal:
 
 class TestPasswordLoginUsesBifrostApiUrl:
     def test_falls_back_to_env_var_for_url(self, capsys, monkeypatch, tmp_path):
+        from bifrost import credentials as creds_mod
+
         stub = _stub_post({
             "access_token": "at",
             "refresh_token": "rt",
             "expires_in": 1800,
         })
         monkeypatch.setattr("httpx.AsyncClient", stub)
+        monkeypatch.setattr(
+            creds_mod,
+            "get_credentials_path",
+            lambda: tmp_path / "credentials.json",
+        )
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+        creds_mod._reset_persistent_backend_for_tests()
         monkeypatch.setenv("BIFROST_API_URL", "http://localhost:38421")
         monkeypatch.chdir(tmp_path)
 

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -71,6 +71,28 @@ class TestEnvBackend:
 
 
 class TestDotenvAllowlist:
+    def test_load_allowed_dotenv_ignores_cwd_without_opt_in(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text("BIFROST_API_URL=https://from-cwd.example\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("BIFROST_LOAD_CWD_ENV", raising=False)
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+
+        creds_mod.load_allowed_dotenv()
+
+        assert "BIFROST_API_URL" not in os.environ
+
+    def test_load_allowed_dotenv_imports_cwd_only_with_opt_in(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text("BIFROST_API_URL=https://from-cwd.example\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("BIFROST_LOAD_CWD_ENV", "1")
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+
+        creds_mod.load_allowed_dotenv()
+
+        assert os.environ["BIFROST_API_URL"] == "https://from-cwd.example"
+
     def test_load_allowed_dotenv_only_imports_api_url(self, tmp_path, monkeypatch):
         env_file = tmp_path / ".env"
         env_file.write_text(


### PR DESCRIPTION
## Summary
- deny non-superusers arbitrary org/global CLI config scopes
- avoid decrypted secret fallback leaks in org-scoped config reads
- make CWD .env credential loading opt-in and avoid project .env token writes
- cascade user-owned OAuth tokens on user deletion to prevent deleted-user promotion

## Verification
- focused ./test.sh unit suite: 98 passed
- ruff check via Docker test-runner
- targeted pyright: 0 errors
- python -m alembic heads in API container