### PR TITLE
Harden manifest git sync scope

### DIFF
--- a/api/bifrost/manifest.py
+++ b/api/bifrost/manifest.py
@@ -73,7 +73,7 @@ class ManifestWorkflow(BaseModel):
         default=None,
         description="Role display names (used by portable bundles; resolved to UUIDs on import)",
     )
-    access_level: str = Field(default="authenticated", description="role_based | authenticated | public")
+    access_level: str = Field(default="role_based", description="role_based | authenticated | public")
     endpoint_enabled: bool = Field(default=False, description="Expose as HTTP API endpoint")
     timeout_seconds: int = Field(default=1800, description="Max execution time in seconds. 0 = no timeout. Default 1800 (30 min), max 86400 (24h).")
     public_endpoint: bool = Field(default=False, description="Allow unauthenticated API access")

--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -53,6 +53,9 @@ from bifrost.manifest import (
 )
 from src.services.manifest_import import (
     ManifestResolver,
+    _collect_removed_entity_ids,
+    _filter_manifest_to_scope,
+    _safe_app_repo_path,
 )
 
 
@@ -91,6 +94,30 @@ def _walk_tree(root: Path) -> dict[str, bytes]:
             continue
         files[rel] = p.read_bytes()
     return files
+
+
+def _filter_manifest_to_work_dir(manifest: Manifest, work_dir: Path) -> None:
+    """Restrict regenerated manifest entries to entities owned by this repo."""
+    _filter_manifest_to_scope(
+        manifest,
+        path_exists=lambda path: (work_dir / path).exists(),
+        dir_exists=lambda path: (work_dir / path).is_dir(),
+    )
+
+
+def _deleted_paths_in_head(repo: GitRepo) -> set[str]:
+    """Return paths deleted by the current HEAD commit."""
+    try:
+        output = repo.git.diff_tree("--no-commit-id", "--name-status", "-r", "HEAD")
+    except Exception as exc:
+        logger.debug("Could not inspect deleted paths in HEAD: %s", exc)
+        return set()
+    deleted: set[str] = set()
+    for line in output.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) == 2 and parts[0] == "D":
+            deleted.add(parts[1])
+    return deleted
 
 
 def _three_way_merge_dicts(
@@ -701,19 +728,7 @@ class GitHubSyncService:
 
         manifest = await generate_manifest(db)
 
-        # Filter out entities whose files don't exist in work_dir.
-        # The DB may contain entities from other workspaces or deleted files;
-        # the manifest should only reference files actually present in the repo.
-        # Forms/agents carry inline content under their UUID — they have no
-        # required companion file, so they are NOT filtered by file existence.
-        manifest.workflows = {
-            k: v for k, v in manifest.workflows.items()
-            if (work_dir / v.path).exists()
-        }
-        manifest.apps = {
-            k: v for k, v in manifest.apps.items()
-            if (work_dir / v.path).is_dir()
-        }
+        _filter_manifest_to_work_dir(manifest, work_dir)
 
         # Filter configs to only include those whose integration_id is present
         # in the manifest (or has no integration_id). This prevents stale configs
@@ -838,7 +853,7 @@ class GitHubSyncService:
                 await _progress("Importing entities...")
                 all_entity_changes: list = []
                 async with self.db.begin_nested():
-                    entities_imported, entity_changes = await self._import_all_entities(
+                    entities_imported, entity_changes, removed_entity_ids = await self._import_all_entities(
                         work_dir, progress_fn=_progress,
                     )
                     all_entity_changes.extend(entity_changes)
@@ -848,7 +863,13 @@ class GitHubSyncService:
 
                 # Step 5: Clean up removed entities (gated on confirmation)
                 await _progress("Checking for removed entities...")
-                pending_deletes = await self._resolver._resolve_deletions(work_dir=work_dir, dry_run=True)
+                removed_paths = _deleted_paths_in_head(repo)
+                pending_deletes = await self._resolver._resolve_deletions(
+                    work_dir=work_dir,
+                    dry_run=True,
+                    removed_entity_ids=removed_entity_ids,
+                    removed_paths=removed_paths,
+                )
                 # Filter out "keep" entries (e.g. tables) — only actual removals need confirmation
                 pending_removals = [e for e in pending_deletes if e.action != "keep"]
                 if pending_removals and not confirm_deletes:
@@ -870,7 +891,11 @@ class GitHubSyncService:
                 if pending_removals:
                     await _progress("Deleting removed entities...")
                     async with self.db.begin_nested():
-                        deletion_changes = await self._resolver._resolve_deletions(work_dir=work_dir)
+                        deletion_changes = await self._resolver._resolve_deletions(
+                            work_dir=work_dir,
+                            removed_entity_ids=removed_entity_ids,
+                            removed_paths=removed_paths,
+                        )
                         all_entity_changes.extend(deletion_changes)
                     await self.db.commit()
 
@@ -1133,13 +1158,13 @@ class GitHubSyncService:
         self,
         work_dir: Path,
         progress_fn=None,
-    ) -> "tuple[int, list]":
+    ) -> "tuple[int, list, dict[str, set[str]]]":
         """Import entities from the working tree into the DB (incremental).
 
         Computes a diff against current DB state and only resolves changed
         entities, matching the incremental approach used by CLI push.
 
-        Returns tuple of (count of entities resolved, list of entity changes).
+        Returns tuple of (count, non-delete entity changes, explicit removed IDs).
         """
         from src.models.contracts.github import EntityChange
         from src.services.manifest_generator import generate_manifest
@@ -1155,15 +1180,16 @@ class GitHubSyncService:
             or manifest.events
         )
         if not has_entities:
-            return 0, []
+            return 0, [], {}
 
         # Diff against current DB state to find what actually changed
         db_manifest = await generate_manifest(self.db)
         diff_changes, changed_ids = _diff_and_collect(manifest, db_manifest)
+        removed_entity_ids = _collect_removed_entity_ids(diff_changes)
 
         if not changed_ids:
             # No entity-level changes detected — nothing to import
-            return 0, []
+            return 0, [], {}
 
         # Resolve only changed entities
         await self._resolver.plan_import(
@@ -1226,7 +1252,7 @@ class GitHubSyncService:
         # Index agents from manifest
         await self._resolver._index_agents_from_manifest(manifest, _read_work_dir, changed_ids)
 
-        return count, entity_changes
+        return count, entity_changes, removed_entity_ids
 
     # -----------------------------------------------------------------
     # App preview sync
@@ -1264,10 +1290,14 @@ class GitHubSyncService:
                 logger.warning(f"Failed to sync preview for app {mapp_id}: {e}")
 
         # Process all apps concurrently
-        await asyncio.gather(*(
-            _sync_one_app(mapp.id, mapp.path)
-            for mapp in manifest.apps.values()
-        ))
+        preview_tasks = []
+        for mapp in manifest.apps.values():
+            try:
+                preview_tasks.append(_sync_one_app(mapp.id, _safe_app_repo_path(mapp)))
+            except ValueError as exc:
+                logger.warning("Skipping unsafe app preview path: %s", exc)
+
+        await asyncio.gather(*preview_tasks)
 
     # -----------------------------------------------------------------
     # Reimport from repo (no git operations)
@@ -1287,8 +1317,12 @@ class GitHubSyncService:
 
             # Import entities atomically with savepoint
             async with self.db.begin_nested():
-                count, _changes = await self._import_all_entities(work_dir)
-                await self._resolver._resolve_deletions(work_dir=work_dir)
+                count, _changes, removed_entity_ids = await self._import_all_entities(work_dir)
+                await self._resolver._resolve_deletions(
+                    work_dir=work_dir,
+                    removed_entity_ids=removed_entity_ids,
+                    removed_paths=_deleted_paths_in_head(GitRepo(str(work_dir))),
+                )
                 await self._update_file_index(work_dir)
             await self.db.commit()
 

--- a/api/src/services/manifest_generator.py
+++ b/api/src/services/manifest_generator.py
@@ -87,7 +87,7 @@ def serialize_workflow(wf: Workflow, roles: list[str] | None = None) -> Manifest
         description=wf.description,
         organization_id=str(wf.organization_id) if wf.organization_id else None,
         roles=roles or [],
-        access_level=wf.access_level or "authenticated",
+        access_level=wf.access_level or "role_based",
         endpoint_enabled=wf.endpoint_enabled or False,
         timeout_seconds=wf.timeout_seconds if wf.timeout_seconds is not None else 1800,
         public_endpoint=wf.public_endpoint or False,
@@ -252,7 +252,7 @@ def serialize_integration(
                 organization_id=str(im.organization_id) if im.organization_id else None,
                 entity_id=im.entity_id,
                 entity_name=im.entity_name,
-                oauth_token_id=str(im.oauth_token_id) if im.oauth_token_id else None,
+                oauth_token_id=None,
             )
             for im in (mappings or [])
         ],

--- a/api/src/services/manifest_import.py
+++ b/api/src/services/manifest_import.py
@@ -211,6 +211,118 @@ def _collect_changed_ids(incoming: "Manifest", current: "Manifest") -> set[str]:
     return ids
 
 
+def _collect_removed_entity_ids(changes: list[dict[str, str]]) -> dict[str, set[str]]:
+    """Return entity IDs that the manifest diff explicitly removed.
+
+    Destructive sync must be driven by the diff, not by broad absence from a
+    partial or mismatched manifest. The returned map is keyed by manifest
+    entity_type, for example ``{"workflows": {"..."}}``.
+    """
+    removed: dict[str, set[str]] = {}
+    for change in changes:
+        if change.get("action") != "delete":
+            continue
+        entity_type = change.get("entity_type")
+        entity_id = change.get("id")
+        if not entity_type or not entity_id:
+            continue
+        removed.setdefault(entity_type, set()).add(entity_id)
+    return removed
+
+
+def _safe_app_repo_path(mapp) -> str:
+    """Return a normalized app source path or raise on unsafe manifest input."""
+    from pathlib import PurePosixPath
+
+    raw_path = (mapp.path or "").strip().replace("\\", "/").rstrip("/")
+    if not raw_path:
+        slug = mapp.slug
+        if not slug:
+            raise ValueError(f"App {mapp.id} has no slug or path")
+        raw_path = f"apps/{slug}"
+
+    path = PurePosixPath(raw_path)
+    parts = path.parts
+    if (
+        path.is_absolute()
+        or len(parts) != 2
+        or parts[0] != "apps"
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ValueError(
+            f"App {mapp.id} path must be exactly apps/<slug>, got {mapp.path!r}"
+        )
+
+    slug = mapp.slug or parts[1]
+    if parts[1] != slug:
+        raise ValueError(
+            f"App {mapp.id} path {raw_path!r} does not match slug {slug!r}"
+        )
+
+    return f"apps/{slug}"
+
+
+def _filter_manifest_to_scope(
+    manifest: "Manifest",
+    path_exists: Callable[[str], bool],
+    dir_exists: Callable[[str], bool],
+) -> None:
+    """Restrict a DB manifest to the source paths owned by the current repo."""
+    manifest.workflows = {
+        k: v for k, v in manifest.workflows.items()
+        if path_exists(v.path)
+    }
+    present_workflow_ids = {v.id for v in manifest.workflows.values()}
+    present_workflow_paths = {v.path for v in manifest.workflows.values()}
+
+    def _form_in_scope(mform) -> bool:
+        workflow_refs = {
+            getattr(mform, "workflow_id", None),
+            getattr(mform, "launch_workflow_id", None),
+        }
+        if workflow_refs & present_workflow_ids:
+            return True
+        path_refs = {
+            getattr(mform, "workflow_path", None),
+            getattr(mform, "launch_workflow_path", None),
+        }
+        return bool(path_refs & present_workflow_paths)
+
+    manifest.forms = {
+        k: v for k, v in manifest.forms.items()
+        if _form_in_scope(v)
+    }
+
+    scoped_agents = {
+        k: v for k, v in manifest.agents.items()
+        if set(getattr(v, "tool_ids", []) or []) & present_workflow_ids
+    }
+    while True:
+        present_agent_ids = {v.id for v in scoped_agents.values()}
+        next_agents = {
+            k: v for k, v in manifest.agents.items()
+            if (
+                k in scoped_agents
+                or set(getattr(v, "delegated_agent_ids", []) or []) & present_agent_ids
+            )
+        }
+        if next_agents.keys() == scoped_agents.keys():
+            break
+        scoped_agents = next_agents
+    manifest.agents = scoped_agents
+
+    safe_apps = {}
+    for k, app in manifest.apps.items():
+        try:
+            app_path = _safe_app_repo_path(app)
+        except ValueError as exc:
+            logger.warning("Skipping unsafe app manifest path: %s", exc)
+            continue
+        if dir_exists(app_path):
+            safe_apps[k] = app.model_copy(update={"path": app_path})
+    manifest.apps = safe_apps
+
+
 # =============================================================================
 # Inline-content helpers
 # =============================================================================
@@ -580,6 +692,15 @@ async def import_manifest_from_repo(
 
     # 4. Compute diff against current DB state
     db_manifest = await generate_manifest(db)
+    all_repo_paths = set(await repo.list(""))
+    _filter_manifest_to_scope(
+        db_manifest,
+        path_exists=lambda path: path in all_repo_paths,
+        dir_exists=lambda path: any(
+            repo_path.startswith(path.rstrip("/") + "/")
+            for repo_path in all_repo_paths
+        ),
+    )
     entity_changes, changed_ids = _diff_and_collect(manifest, db_manifest)
 
     # 4a. Dry-run: return diff without writing
@@ -602,7 +723,8 @@ async def import_manifest_from_repo(
         return result
 
     # Check if diff has any deletes (to skip _resolve_deletions later)
-    has_deletes = any(c["action"] == "delete" for c in entity_changes)
+    removed_entity_ids = _collect_removed_entity_ids(entity_changes)
+    has_deletes = bool(removed_entity_ids)
 
     # Helper: read a file from S3, returning None on failure
     async def _read_or_none(path: str) -> bytes | None:
@@ -621,7 +743,10 @@ async def import_manifest_from_repo(
             deletion_changes = []
             if delete_removed_entities and has_deletes:
                 deletion_changes = await resolver._resolve_deletions(
-                    manifest=manifest, repo=repo, dry_run=False,
+                    manifest=manifest,
+                    repo=repo,
+                    dry_run=False,
+                    removed_entity_ids=removed_entity_ids,
                 )
 
             await resolver.plan_import(manifest, repo=repo, dry_run=False, changed_ids=changed_ids)
@@ -1562,12 +1687,22 @@ class ManifestResolver:
                     resolved_list.append(item)
             data[field_name] = resolved_list
 
-    async def _resolve_deletions(self, work_dir: Path | None = None, manifest: "Manifest | None" = None, repo: "RepoStorage | None" = None, dry_run: bool = False) -> list:
+    async def _resolve_deletions(
+        self,
+        work_dir: Path | None = None,
+        manifest: "Manifest | None" = None,
+        repo: "RepoStorage | None" = None,
+        dry_run: bool = False,
+        removed_entity_ids: dict[str, set[str]] | None = None,
+        removed_paths: set[str] | None = None,
+    ) -> list:
         """Compute delete/deactivate ops for entities removed from the manifest.
 
         Optimized: pushes filtering to SQL with NOT IN clauses, returning only
         stale entity IDs. Executes bulk deletes inline instead of generating
-        individual Delete/Deactivate ops.
+        individual Delete/Deactivate ops. Fail closed: only entity IDs that
+        were explicitly removed by the manifest diff are eligible for
+        destructive action.
 
         Deletion strategy per entity type:
         - Workflows, Forms, Agents, Apps: hard-delete (existing behavior)
@@ -1673,15 +1808,24 @@ class ManifestResolver:
 
         entity_changes: list[EntityChange] = []
         now = datetime.now(timezone.utc)
+        removed_entity_ids = removed_entity_ids or {}
+        removed_paths = removed_paths or set()
+
+        def _removed_uuids(entity_type: str) -> list[UUID]:
+            return [UUID(eid) for eid in removed_entity_ids.get(entity_type, set())]
 
         # Helper: query stale IDs (+ names when available) and bulk-delete
         async def _bulk_delete(model: type, base_filter: list, present: list[UUID], entity_type: str) -> int:
             """Find IDs not in present list and delete them. Returns count."""
+            candidates = _removed_uuids(entity_type)
+            if not candidates:
+                return 0
             has_name = "name" in model.__table__.columns  # type: ignore[attr-defined]
             if has_name:
                 q = select(model.id, model.name).where(*base_filter)  # type: ignore[attr-defined]
             else:
                 q = select(model.id).where(*base_filter)  # type: ignore[attr-defined]
+            q = q.where(model.id.in_(candidates))  # type: ignore[attr-defined]
             if present:
                 q = q.where(model.id.notin_(present))  # type: ignore[attr-defined]
             result = await self.db.execute(q)
@@ -1707,11 +1851,15 @@ class ManifestResolver:
 
         # Helper: query stale IDs and soft-delete (deactivate)
         async def _bulk_deactivate(model: type, base_filter: list, present: list[UUID], entity_type: str) -> int:
+            candidates = _removed_uuids(entity_type)
+            if not candidates:
+                return 0
             has_name = "name" in model.__table__.columns  # type: ignore[attr-defined]
             if has_name:
                 q = select(model.id, model.name).where(*base_filter)  # type: ignore[attr-defined]
             else:
                 q = select(model.id).where(*base_filter)  # type: ignore[attr-defined]
+            q = q.where(model.id.in_(candidates))  # type: ignore[attr-defined]
             if present:
                 q = q.where(model.id.notin_(present))  # type: ignore[attr-defined]
             result = await self.db.execute(q)
@@ -1737,13 +1885,19 @@ class ManifestResolver:
                 )
             return len(stale_ids)
 
-        # Delete workflows synced from git that are no longer present
-        await _bulk_delete(
-            Workflow,
-            [Workflow.is_active == True, Workflow.path.isnot(None)],  # noqa: E712
-            present_wf_uuids,
-            "workflows",
-        )
+        # Delete workflows only when both the manifest diff removed the entity
+        # and git recorded the backing file deletion in this repo.
+        if removed_paths:
+            await _bulk_delete(
+                Workflow,
+                [
+                    Workflow.is_active == True,  # noqa: E712
+                    Workflow.path.isnot(None),
+                    Workflow.path.in_(removed_paths),
+                ],
+                present_wf_uuids,
+                "workflows",
+            )
 
         # Delete integrations not in manifest
         await _bulk_delete(
@@ -1755,7 +1909,11 @@ class ManifestResolver:
 
         # Delete configs not in manifest (skip integration-schema-linked configs —
         # those are user-set values managed by IntegrationConfigSchema cascade)
-        cfg_q = select(Config.id).where(Config.config_schema_id.is_(None))
+        removed_config_uuids = _removed_uuids("configs")
+        cfg_q = select(Config.id).where(
+            Config.config_schema_id.is_(None),
+            Config.id.in_(removed_config_uuids),
+        )
         if present_config_uuids:
             cfg_q = cfg_q.where(Config.id.notin_(present_config_uuids))
         cfg_result = await self.db.execute(cfg_q)
@@ -1774,7 +1932,8 @@ class ManifestResolver:
                 )
 
         # Tables not in manifest (data preserved — report as "keep")
-        table_q = select(Table.id, Table.name)
+        removed_table_uuids = _removed_uuids("tables")
+        table_q = select(Table.id, Table.name).where(Table.id.in_(removed_table_uuids))
         if present_table_uuids:
             table_q = table_q.where(Table.id.notin_(present_table_uuids))
         table_result = await self.db.execute(table_q)
@@ -2055,7 +2214,9 @@ class ManifestResolver:
             )
             await self.db.execute(op_stmt)
 
-        # Sync mappings: upsert by (integration_id, organization_id) to preserve oauth_token_id
+        # Sync mappings: upsert by (integration_id, organization_id).
+        # OAuth tokens are user/environment-owned and are never trusted from
+        # manifest input; existing linked tokens are preserved in place.
         if cache is not None:
             existing_m_by_org: dict[str | None, IntegrationMapping] = dict(cache["integ_mappings"].get(integ_id, {}))
         else:
@@ -2076,15 +2237,13 @@ class ManifestResolver:
                 existing_m = existing_m_by_org[org_key]
                 existing_m.entity_id = mapping.entity_id
                 existing_m.entity_name = mapping.entity_name
-                if mapping.oauth_token_id is not None:
-                    existing_m.oauth_token_id = UUID(mapping.oauth_token_id)
             else:
                 m_stmt = insert(IntegrationMapping).values(
                     integration_id=integ_id,
                     organization_id=UUID(mapping.organization_id) if mapping.organization_id else None,
                     entity_id=mapping.entity_id,
                     entity_name=mapping.entity_name,
-                    oauth_token_id=UUID(mapping.oauth_token_id) if mapping.oauth_token_id else None,
+                    oauth_token_id=None,
                 )
                 await self.db.execute(m_stmt)
 
@@ -2170,24 +2329,17 @@ class ManifestResolver:
         """Resolve an app from manifest into SyncOps (metadata only).
         Uses prefetch cache for slug lookup.
         """
-        from pathlib import PurePosixPath
         from uuid import UUID
 
         from src.models.orm.app_roles import AppRole
         from src.models.orm.applications import Application
         from src.services.sync_ops import SyncOp, SyncRoles, Upsert  # noqa: F401
 
-        # repo_path is now the directory directly (no /app.yaml to strip)
-        repo_path = mapp.path.rstrip("/") if mapp.path else None
-
-        # Slug from manifest entry, or derive from repo_path leaf
-        slug = mapp.slug or (PurePosixPath(repo_path).name if repo_path else None)
+        repo_path = _safe_app_repo_path(mapp)
+        slug = mapp.slug or repo_path.rsplit("/", 1)[1]
         if not slug:
             logger.warning(f"App {mapp.id} has no slug or path, skipping")
             return []
-
-        if not repo_path:
-            repo_path = f"apps/{slug}"
 
         app_id = UUID(mapp.id)
         org_id = UUID(mapp.organization_id) if mapp.organization_id else None

--- a/api/tests/unit/services/test_github_sync.py
+++ b/api/tests/unit/services/test_github_sync.py
@@ -13,6 +13,67 @@ from src.models.contracts.github import (
 from src.services.github_sync import SyncError
 
 
+def test_manifest_regeneration_filters_inline_forms_and_agents_to_repo_scope(tmp_path):
+    """Inline forms/agents should not leak when their workflows are outside this repo."""
+    from bifrost.manifest import Manifest, ManifestAgent, ManifestForm, ManifestWorkflow
+    from src.services.github_sync import _filter_manifest_to_work_dir
+
+    local_wf_id = "11111111-1111-1111-1111-111111111111"
+    other_wf_id = "22222222-2222-2222-2222-222222222222"
+    local_form_id = "33333333-3333-3333-3333-333333333333"
+    other_form_id = "44444444-4444-4444-4444-444444444444"
+    local_agent_id = "55555555-5555-5555-5555-555555555555"
+    other_agent_id = "66666666-6666-6666-6666-666666666666"
+
+    (tmp_path / "workflows").mkdir()
+    (tmp_path / "workflows" / "local.py").write_text("from bifrost import workflow\n")
+
+    manifest = Manifest(
+        workflows={
+            local_wf_id: ManifestWorkflow(
+                id=local_wf_id,
+                path="workflows/local.py",
+                function_name="local",
+            ),
+            other_wf_id: ManifestWorkflow(
+                id=other_wf_id,
+                path="workflows/other.py",
+                function_name="other",
+            ),
+        },
+        forms={
+            local_form_id: ManifestForm(
+                id=local_form_id,
+                name="Local",
+                workflow_id=local_wf_id,
+            ),
+            other_form_id: ManifestForm(
+                id=other_form_id,
+                name="Other",
+                workflow_id=other_wf_id,
+            ),
+        },
+        agents={
+            local_agent_id: ManifestAgent(
+                id=local_agent_id,
+                name="Local Agent",
+                tool_ids=[local_wf_id],
+            ),
+            other_agent_id: ManifestAgent(
+                id=other_agent_id,
+                name="Other Agent",
+                tool_ids=[other_wf_id],
+            ),
+        },
+    )
+
+    _filter_manifest_to_work_dir(manifest, tmp_path)
+
+    assert set(manifest.workflows) == {local_wf_id}
+    assert set(manifest.forms) == {local_form_id}
+    assert set(manifest.agents) == {local_agent_id}
+
+
 class TestWorkflowReference:
     """Tests for WorkflowReference model."""
 

--- a/api/tests/unit/services/test_manifest_jit.py
+++ b/api/tests/unit/services/test_manifest_jit.py
@@ -89,6 +89,7 @@ async def test_reimport_regenerates_manifest_and_reindexes_workflows():
          patch.object(service, '_import_all_entities', return_value=(5, [], set())), \
          patch.object(service, '_update_file_index'), \
          patch.object(service, '_sync_app_previews'), \
+         patch("src.services.github_sync.GitRepo"), \
          patch("src.services.github_sync._deleted_paths_in_head", return_value=set()):
 
         result = await service.reimport_from_repo()

--- a/api/tests/unit/services/test_manifest_jit.py
+++ b/api/tests/unit/services/test_manifest_jit.py
@@ -86,9 +86,10 @@ async def test_reimport_regenerates_manifest_and_reindexes_workflows():
 
     with patch.object(service, '_regenerate_manifest_to_dir') as mock_regen, \
          patch.object(service, '_reindex_registered_workflows') as mock_reindex, \
-         patch.object(service, '_import_all_entities', return_value=(5, [])), \
+         patch.object(service, '_import_all_entities', return_value=(5, [], set())), \
          patch.object(service, '_update_file_index'), \
-         patch.object(service, '_sync_app_previews'):
+         patch.object(service, '_sync_app_previews'), \
+         patch("src.services.github_sync._deleted_paths_in_head", return_value=set()):
 
         result = await service.reimport_from_repo()
 

--- a/api/tests/unit/test_manifest.py
+++ b/api/tests/unit/test_manifest.py
@@ -115,6 +115,21 @@ workflows:
     assert "organization_id" not in wf  # default is None
 
 
+def test_workflow_manifest_default_is_role_based():
+    """Omitting access_level must not widen workflow execution access."""
+    from bifrost.manifest import parse_manifest
+
+    manifest = parse_manifest("""
+workflows:
+  wf1:
+    id: "11111111-1111-1111-1111-111111111111"
+    path: workflows/wf1.py
+    function_name: wf1
+""")
+
+    assert manifest.workflows["wf1"].access_level == "role_based"
+
+
 def test_validate_manifest_broken_ref(sample_manifest):
     """Detect broken cross-references."""
     from bifrost.manifest import parse_manifest, validate_manifest

--- a/api/tests/unit/test_manifest_generator.py
+++ b/api/tests/unit/test_manifest_generator.py
@@ -361,3 +361,25 @@ async def test_generate_manifest_access_levels(mock_db):
     assert manifest.apps[str(app.id)].access_level == "role_based"
 
 
+def test_serialize_integration_does_not_export_oauth_token_ids():
+    """OAuth token IDs are environment-owned and must not become portable state."""
+    from src.services.manifest_generator import serialize_integration
+
+    integ = MagicMock()
+    integ.id = uuid4()
+    integ.name = "Tokenless"
+    integ.entity_id = None
+    integ.entity_id_name = None
+    integ.default_entity_id = None
+    integ.list_entities_data_provider_id = None
+
+    mapping = MagicMock()
+    mapping.organization_id = uuid4()
+    mapping.entity_id = "tenant-1"
+    mapping.entity_name = "Tenant 1"
+    mapping.oauth_token_id = uuid4()
+
+    manifest_integration = serialize_integration(integ, mappings=[mapping])
+
+    assert manifest_integration.mappings[0].oauth_token_id is None
+

--- a/api/tests/unit/test_manifest_import.py
+++ b/api/tests/unit/test_manifest_import.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from bifrost.manifest import (
+    ManifestApp,
     ManifestPolicy,
     ManifestTable,
 )
@@ -167,3 +168,108 @@ class TestManifestImportPolicyValidationContract:
         assert mtable.policies is not None
         # No exception parsing the manifest. The gate must run at write time.
         assert mtable.policies[0].when == {"has_role": "support"}
+
+
+class TestManifestDestructiveScope:
+    """Pin fail-closed import boundaries for destructive git-sync behavior."""
+
+    def test_removed_entity_ids_include_only_explicit_delete_diffs(self):
+        from src.services.manifest_import import _collect_removed_entity_ids
+
+        removed = _collect_removed_entity_ids([
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "action": "delete",
+                "entity_type": "workflows",
+                "name": "deleted",
+            },
+            {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "action": "update",
+                "entity_type": "forms",
+                "name": "updated",
+            },
+        ])
+
+        assert removed == {
+            "workflows": {"11111111-1111-1111-1111-111111111111"},
+        }
+
+    def test_scope_filter_prevents_unrelated_absent_workflow_delete_diff(self):
+        from bifrost.manifest import Manifest, ManifestWorkflow
+        from src.services.manifest_import import (
+            _collect_removed_entity_ids,
+            _diff_and_collect,
+            _filter_manifest_to_scope,
+        )
+
+        local_id = "11111111-1111-1111-1111-111111111111"
+        unrelated_id = "22222222-2222-2222-2222-222222222222"
+        incoming = Manifest(workflows={
+            local_id: ManifestWorkflow(
+                id=local_id,
+                path="workflows/local.py",
+                function_name="local",
+            ),
+        })
+        current = Manifest(workflows={
+            local_id: ManifestWorkflow(
+                id=local_id,
+                path="workflows/local.py",
+                function_name="local",
+            ),
+            unrelated_id: ManifestWorkflow(
+                id=unrelated_id,
+                path="workflows/other-workspace.py",
+                function_name="other",
+            ),
+        })
+
+        _filter_manifest_to_scope(
+            current,
+            path_exists=lambda path: path == "workflows/local.py",
+            dir_exists=lambda path: False,
+        )
+        changes, _changed_ids = _diff_and_collect(incoming, current)
+
+        assert _collect_removed_entity_ids(changes) == {}
+
+
+class TestManifestAppPathSafety:
+    """Manifest app paths must stay inside one app source directory."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "README.md",
+            ".bifrost/apps.yaml",
+            "../apps/customer",
+            "apps/customer/../other",
+            "/apps/customer",
+            "apps/customer/src",
+        ],
+    )
+    def test_rejects_non_app_or_escaped_app_paths(self, path):
+        from src.services.manifest_import import _safe_app_repo_path
+
+        mapp = ManifestApp(
+            id="11111111-1111-1111-1111-111111111111",
+            name="Customer",
+            slug="customer",
+            path=path,
+        )
+
+        with pytest.raises(ValueError):
+            _safe_app_repo_path(mapp)
+
+    def test_accepts_slug_matched_apps_directory(self):
+        from src.services.manifest_import import _safe_app_repo_path
+
+        mapp = ManifestApp(
+            id="11111111-1111-1111-1111-111111111111",
+            name="Customer",
+            slug="customer",
+            path="apps/customer",
+        )
+
+        assert _safe_app_repo_path(mapp) == "apps/customer"


### PR DESCRIPTION
## Summary
- constrain manifest/git-sync deletes to explicit same-workspace evidence
- prevent manifest OAuth token IDs and paths from crossing workspace/app boundaries
- keep standalone manifest import conservative while preserving git-deleted path sync behavior

## Verification
- ./test.sh tests/unit/test_manifest.py tests/unit/test_manifest_import.py tests/unit/test_manifest_generator.py tests/unit/services/test_github_sync.py: 140 passed
- ./test.sh tests/e2e/platform/test_git_sync_local.py::TestDeleteConfirmation: 2 passed
- ruff check on touched Python files
- git diff --check

Note: pyright was not available in the host/test-runner environment for this slice.