### PR TITLE
Harden app bundle execution mutations

### DIFF
--- a/api/shared/app_authorization.py
+++ b/api/shared/app_authorization.py
@@ -1,0 +1,30 @@
+"""Shared authorization policy for App Builder control-plane changes."""
+
+from typing import Protocol
+
+from fastapi import HTTPException, status
+
+from src.models.contracts.applications import ApplicationUpdate
+
+
+class PlatformAdminUser(Protocol):
+    is_platform_admin: bool
+
+
+def require_platform_admin(user: PlatformAdminUser) -> None:
+    """Require platform-admin privileges for App Builder mutations."""
+    if not user.is_platform_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Platform admin privileges required",
+        )
+
+
+def update_requires_platform_admin(data: ApplicationUpdate) -> bool:
+    """Return true when a metadata patch changes routing or access control."""
+    return (
+        data.slug is not None
+        or data.scope is not None
+        or data.access_level is not None
+        or data.role_ids is not None
+    )

--- a/api/shared/app_authorization.py
+++ b/api/shared/app_authorization.py
@@ -1,10 +1,13 @@
 """Shared authorization policy for App Builder control-plane changes."""
 
-from typing import Protocol
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
 
 from fastapi import HTTPException, status
 
-from src.models.contracts.applications import ApplicationUpdate
+if TYPE_CHECKING:
+    from src.models.contracts.applications import ApplicationUpdate
 
 
 class PlatformAdminUser(Protocol):

--- a/api/src/routers/app_code_files.py
+++ b/api/src/routers/app_code_files.py
@@ -40,6 +40,7 @@ from src.routers.applications import ApplicationRepository
 from src.services.app_storage import AppStorageService
 from src.services.repo_storage import RepoStorage
 from src.services.file_storage.service import get_file_storage_service
+from shared.app_authorization import require_platform_admin
 
 logger = logging.getLogger(__name__)
 
@@ -237,15 +238,6 @@ async def get_application_or_404(ctx: Context, app_id: UUID) -> Application:
 class FileMode(str, Enum):
     draft = "draft"
     live = "live"
-
-
-def require_platform_admin(user: CurrentUser) -> None:
-    """Require platform-admin privileges for app code execution mutations."""
-    if not user.is_platform_admin:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Platform admin privileges required",
-        )
 
 
 # =============================================================================
@@ -573,11 +565,9 @@ async def get_bundle_manifest(
     from src.core.cache import get_shared_redis
 
     # A manifest is "stale" when it's missing the schema_version field or has
-    # an older value. We treat stale manifests the same as missing manifests:
-    # run auto-migration against _repo/<app>/, then rebuild. This is how a
-    # deploy that bumps SCHEMA_VERSION transparently heals every app (preview
-    # AND live) — the first viewer after deploy pays the migrate+rebuild
-    # cost, subsequent views are cached.
+    # an older value. Preview manifests can auto-migrate and rebuild from draft
+    # source. Live manifests fail closed with 409 and require publishing the app
+    # to rebuild the live bundle.
     manifest_bytes: bytes | None = None
     try:
         manifest_bytes = await app_storage.read_file(

--- a/api/src/routers/app_code_files.py
+++ b/api/src/routers/app_code_files.py
@@ -239,6 +239,15 @@ class FileMode(str, Enum):
     live = "live"
 
 
+def require_platform_admin(user: CurrentUser) -> None:
+    """Require platform-admin privileges for app code execution mutations."""
+    if not user.is_platform_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Platform admin privileges required",
+        )
+
+
 # =============================================================================
 # S3-backed App File Endpoints
 # =============================================================================
@@ -377,6 +386,7 @@ async def write_app_file(
     Validates the path, then writes via FileStorageService (which handles
     S3 _repo/ storage, file_index update, pubsub, and preview sync).
     """
+    require_platform_admin(user)
     app = await get_application_or_404(ctx, app_id)
 
     # Validate path conventions
@@ -416,13 +426,14 @@ async def delete_app_file(
     file_path: str = Path(..., description="Relative file path (can contain slashes)"),
     *,
     ctx: Context,
-    _user: CurrentUser,
+    user: CurrentUser,
 ) -> None:
     """Delete a file at the given path.
 
     Deletes via FileStorageService (which handles S3 _repo/ deletion,
     file_index cleanup, pubsub, and preview sync).
     """
+    require_platform_admin(user)
     app = await get_application_or_404(ctx, app_id)
     prefix = app.repo_prefix
     full_path = f"{prefix}{file_path}"
@@ -589,6 +600,15 @@ async def get_bundle_manifest(
                 needs_rebuild = True
 
     if needs_rebuild:
+        if storage_mode == "live":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "Live bundle manifest is missing or stale. "
+                    "Publish the application to rebuild the live bundle."
+                ),
+            )
+
         repo_prefix = app.repo_prefix
         # Serialize migrate+rebuild across concurrent first-viewers so two
         # requests don't double-migrate or race on writes. Hold the lock
@@ -751,12 +771,13 @@ async def put_dependencies(
     app_id: UUID = Path(..., description="Application UUID"),
     *,
     ctx: Context,
-    _user: CurrentUser,
+    user: CurrentUser,
 ) -> dict[str, str]:
     """Replace the app's npm dependencies.
 
     Validates every package name and version, enforces the max-dependency limit.
     """
+    require_platform_admin(user)
     app = await get_application_or_404(ctx, app_id)
 
     # Validate

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -43,6 +43,10 @@ from src.models.contracts.applications import (
 from src.models.orm.app_roles import AppRole
 from src.models.orm.applications import Application
 from src.repositories.org_scoped import OrgScopedRepository
+from shared.app_authorization import (
+    require_platform_admin,
+    update_requires_platform_admin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,25 +72,6 @@ async def ensure_no_stale_app_source(session: AsyncSession, slug: str) -> None:
     )
     if existing.first() is not None:
         raise ValueError(stale_app_source_error(slug))
-
-
-def require_platform_admin(user: CurrentUser) -> None:
-    """Require platform-admin privileges for application control-plane changes."""
-    if not user.is_platform_admin:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Platform admin privileges required",
-        )
-
-
-def update_requires_platform_admin(data: ApplicationUpdate) -> bool:
-    """Return true when a metadata patch changes routing or access control."""
-    return (
-        data.slug is not None
-        or data.scope is not None
-        or data.access_level is not None
-        or data.role_ids is not None
-    )
 
 
 class AppValidationIssue(BaseModel):

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -70,6 +70,25 @@ async def ensure_no_stale_app_source(session: AsyncSession, slug: str) -> None:
         raise ValueError(stale_app_source_error(slug))
 
 
+def require_platform_admin(user: CurrentUser) -> None:
+    """Require platform-admin privileges for application control-plane changes."""
+    if not user.is_platform_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Platform admin privileges required",
+        )
+
+
+def update_requires_platform_admin(data: ApplicationUpdate) -> bool:
+    """Return true when a metadata patch changes routing or access control."""
+    return (
+        data.slug is not None
+        or data.scope is not None
+        or data.access_level is not None
+        or data.role_ids is not None
+    )
+
+
 class AppValidationIssue(BaseModel):
     severity: str  # "error" or "warning"
     file: str
@@ -816,6 +835,9 @@ async def update_application(
     user: CurrentUser,
 ) -> ApplicationPublic:
     """Update application metadata and access control by ID."""
+    if update_requires_platform_admin(data):
+        require_platform_admin(user)
+
     repo = ApplicationRepository(
         ctx.db,
         ctx.org_id,

--- a/api/tests/unit/routers/test_app_execution_hardening.py
+++ b/api/tests/unit/routers/test_app_execution_hardening.py
@@ -35,6 +35,29 @@ async def test_non_admin_cannot_update_app_slug() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "update",
+    [
+        ApplicationUpdate(scope="global"),
+        ApplicationUpdate(access_level="role_based"),
+        ApplicationUpdate(role_ids=[uuid4()]),
+    ],
+)
+async def test_non_admin_cannot_update_app_control_plane_fields(
+    update: ApplicationUpdate,
+) -> None:
+    with pytest.raises(HTTPException) as exc:
+        await applications.update_application(
+            uuid4(),
+            update,
+            ctx=SimpleNamespace(),
+            user=_user(is_platform_admin=False),
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_non_admin_cannot_update_browser_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fail_if_lookup_runs(*args, **kwargs):  # pragma: no cover - assertion helper
         raise AssertionError("dependency mutation should fail before app lookup")
@@ -62,6 +85,24 @@ async def test_non_admin_cannot_write_app_code(monkeypatch: pytest.MonkeyPatch) 
     with pytest.raises(HTTPException) as exc:
         await app_code_files.write_app_file(
             app_code_files.AppFileUpdate(source="export default function Page() { return null }"),
+            uuid4(),
+            "pages/index.tsx",
+            ctx=SimpleNamespace(),
+            user=_user(is_platform_admin=False),
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_delete_app_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_if_lookup_runs(*args, **kwargs):  # pragma: no cover - assertion helper
+        raise AssertionError("code deletion should fail before app lookup")
+
+    monkeypatch.setattr(app_code_files, "get_application_or_404", fail_if_lookup_runs)
+
+    with pytest.raises(HTTPException) as exc:
+        await app_code_files.delete_app_file(
             uuid4(),
             "pages/index.tsx",
             ctx=SimpleNamespace(),

--- a/api/tests/unit/routers/test_app_execution_hardening.py
+++ b/api/tests/unit/routers/test_app_execution_hardening.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from src.models.contracts.applications import ApplicationUpdate
+from src.routers import app_code_files, applications
+from src.routers.app_code_files import FileMode
+from src.services.app_bundler import BundleManifest, BundleResult, SCHEMA_VERSION
+
+
+def _user(*, is_platform_admin: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        is_platform_admin=is_platform_admin,
+        user_id=uuid4(),
+        email="user@example.com",
+        name="User",
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_update_app_slug() -> None:
+    with pytest.raises(HTTPException) as exc:
+        await applications.update_application(
+            uuid4(),
+            ApplicationUpdate(slug="new-slug"),
+            ctx=SimpleNamespace(),
+            user=_user(is_platform_admin=False),
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_update_browser_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_if_lookup_runs(*args, **kwargs):  # pragma: no cover - assertion helper
+        raise AssertionError("dependency mutation should fail before app lookup")
+
+    monkeypatch.setattr(app_code_files, "get_application_or_404", fail_if_lookup_runs)
+
+    with pytest.raises(HTTPException) as exc:
+        await app_code_files.put_dependencies(
+            {"date-fns": "4.1.0"},
+            uuid4(),
+            ctx=SimpleNamespace(),
+            user=_user(is_platform_admin=False),
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_write_app_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_if_lookup_runs(*args, **kwargs):  # pragma: no cover - assertion helper
+        raise AssertionError("code mutation should fail before app lookup")
+
+    monkeypatch.setattr(app_code_files, "get_application_or_404", fail_if_lookup_runs)
+
+    with pytest.raises(HTTPException) as exc:
+        await app_code_files.write_app_file(
+            app_code_files.AppFileUpdate(source="export default function Page() { return null }"),
+            uuid4(),
+            "pages/index.tsx",
+            ctx=SimpleNamespace(),
+            user=_user(is_platform_admin=False),
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_live_stale_manifest_fails_closed_without_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app_id = uuid4()
+    app = SimpleNamespace(
+        id=app_id,
+        repo_prefix="apps/hardened/",
+        dependencies={"date-fns": "4.1.0"},
+        organization_id=None,
+    )
+
+    async def fake_get_app(*args, **kwargs):
+        return app
+
+    class FakeStorage:
+        async def read_file(self, app_id_arg: str, mode: str, rel_path: str) -> bytes:
+            assert app_id_arg == str(app_id)
+            assert mode == "live"
+            assert rel_path == "manifest.json"
+            return b'{"schema_version": 0, "entry": "old.js", "css": null}'
+
+    async def fail_if_builds(*args, **kwargs):  # pragma: no cover - assertion helper
+        raise AssertionError("live viewer must not rebuild from draft source")
+
+    monkeypatch.setattr(app_code_files, "get_application_or_404", fake_get_app)
+    monkeypatch.setattr(app_code_files, "AppStorageService", FakeStorage)
+    monkeypatch.setattr("src.services.app_bundler.build_with_migrate", fail_if_builds)
+
+    with pytest.raises(HTTPException) as exc:
+        await app_code_files.get_bundle_manifest(
+            app_id,
+            mode=FileMode.live,
+            ctx=SimpleNamespace(),
+            _user=_user(is_platform_admin=False),
+        )
+
+    assert exc.value.status_code == 409
+    assert "Publish the application" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_preview_stale_manifest_can_rebuild(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_id = uuid4()
+    app = SimpleNamespace(
+        id=app_id,
+        repo_prefix="apps/hardened/",
+        dependencies={"date-fns": "4.1.0"},
+        organization_id=None,
+    )
+
+    async def fake_get_app(*args, **kwargs):
+        return app
+
+    class FakeStorage:
+        async def read_file(self, app_id_arg: str, mode: str, rel_path: str) -> bytes:
+            assert app_id_arg == str(app_id)
+            assert mode == "preview"
+            assert rel_path == "manifest.json"
+            return b'{"schema_version": 0, "entry": "old.js", "css": null}'
+
+    class FakeRedis:
+        async def set(self, *args, **kwargs) -> bool:
+            return True
+
+        async def delete(self, *args, **kwargs) -> None:
+            return None
+
+    async def fake_get_redis() -> FakeRedis:
+        return FakeRedis()
+
+    async def fake_build_with_migrate(
+        app_id_arg: str,
+        repo_prefix: str,
+        mode: str,
+        *,
+        dependencies: dict[str, str],
+    ):
+        assert app_id_arg == str(app_id)
+        assert repo_prefix == "apps/hardened/"
+        assert mode == "preview"
+        assert dependencies == {"date-fns": "4.1.0"}
+        return (
+            BundleResult(
+                success=True,
+                manifest=BundleManifest(
+                    entry="entry-new.js",
+                    css=None,
+                    outputs=["entry-new.js"],
+                    duration_ms=1,
+                    warnings=[],
+                    dependencies=dependencies,
+                ),
+            ),
+            False,
+        )
+
+    monkeypatch.setattr(app_code_files, "get_application_or_404", fake_get_app)
+    monkeypatch.setattr(app_code_files, "AppStorageService", FakeStorage)
+    monkeypatch.setattr("src.core.cache.get_shared_redis", fake_get_redis)
+    monkeypatch.setattr("src.services.app_bundler.build_with_migrate", fake_build_with_migrate)
+
+    manifest = await app_code_files.get_bundle_manifest(
+        app_id,
+        mode=FileMode.draft,
+        ctx=SimpleNamespace(),
+        _user=_user(is_platform_admin=False),
+    )
+
+    assert manifest["entry"] == "entry-new.js"
+    assert manifest["mode"] == "preview"
+    assert manifest["dependencies"] == {"date-fns": "4.1.0"}
+    assert SCHEMA_VERSION >= 1

--- a/api/tests/unit/routers/test_app_execution_hardening.py
+++ b/api/tests/unit/routers/test_app_execution_hardening.py
@@ -58,6 +58,62 @@ async def test_non_admin_cannot_update_app_control_plane_fields(
 
 
 @pytest.mark.asyncio
+async def test_admin_update_app_slug_proceeds_past_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRepo:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def update_application(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(applications, "ApplicationRepository", FakeRepo)
+
+    with pytest.raises(HTTPException) as exc:
+        await applications.update_application(
+            uuid4(),
+            ApplicationUpdate(slug="new-slug"),
+            ctx=SimpleNamespace(
+                db=None,
+                org_id=uuid4(),
+                user=SimpleNamespace(email="admin@example.com"),
+            ),
+            user=_user(is_platform_admin=True),
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_admin_can_update_non_sensitive_app_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRepo:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def update_application(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(applications, "ApplicationRepository", FakeRepo)
+
+    with pytest.raises(HTTPException) as exc:
+        await applications.update_application(
+            uuid4(),
+            ApplicationUpdate(title="Renamed App"),
+            ctx=SimpleNamespace(
+                db=None,
+                org_id=uuid4(),
+                user=SimpleNamespace(email="user@example.com"),
+            ),
+            user=_user(is_platform_admin=False),
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_non_admin_cannot_update_browser_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fail_if_lookup_runs(*args, **kwargs):  # pragma: no cover - assertion helper
         raise AssertionError("dependency mutation should fail before app lookup")


### PR DESCRIPTION
## Summary
- require platform-admin privileges before mutating app code files or browser dependency maps
- require platform-admin privileges for app slug/access-control metadata changes
- fail closed for missing or stale live bundle manifests instead of rebuilding live bundles from draft source

## Tests
- C:\Users\ThomasBray\src\MTG-Thomas\mtg-bifrost\bifrost\.venv\Scripts\python.exe -m pytest api/tests/unit/routers/test_app_execution_hardening.py api/tests/unit/test_app_bundler.py -q
- C:\Users\ThomasBray\src\MTG-Thomas\mtg-bifrost\bifrost\.venv\Scripts\python.exe -m ruff check api/src/routers/app_code_files.py api/src/routers/applications.py api/tests/unit/routers/test_app_execution_hardening.py api/tests/unit/test_app_bundler.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform-admin privileges now required for app code mutations (create, update, delete) and dependency updates.
  * Added access control gating for application routing and control-plane updates.

* **Bug Fixes**
  * Bundle manifest endpoint in live mode now returns a 409 CONFLICT for missing or stale manifests, requiring explicit application publish instead of automatic rebuild.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->