### PR TITLE
Harden knowledge and file storage scoping

### DIFF
--- a/api/src/repositories/knowledge.py
+++ b/api/src/repositories/knowledge.py
@@ -445,6 +445,15 @@ class KnowledgeRepository(OrgScopedRepository[KnowledgeStore]):
     ) -> KnowledgeDocument | None:
         """Get a document by its UUID."""
         stmt = select(KnowledgeStore).where(KnowledgeStore.id == doc_id)
+
+        if self.org_id is not None:
+            stmt = stmt.where(
+                (KnowledgeStore.organization_id == self.org_id)
+                | (KnowledgeStore.organization_id.is_(None))
+            )
+        else:
+            stmt = stmt.where(KnowledgeStore.organization_id.is_(None))
+
         result = await self.session.execute(stmt)
         doc = result.scalar_one_or_none()
 

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -223,6 +223,32 @@ class SignedUrlResponse(BaseModel):
     expires_in: int = Field(default=600, description="URL expiration in seconds")
 
 
+def _authorized_signed_url_scope(
+    request: SignedUrlRequest,
+    ctx: Context,
+) -> str | None:
+    """Resolve object-store scope from auth context instead of trusting input."""
+    if request.location == "workspace":
+        return None
+
+    if ctx.user.is_system_account:
+        return request.scope
+
+    if ctx.org_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Signed URL scope requires an organization context",
+        )
+
+    authorized_scope = str(ctx.org_id)
+    if request.scope and request.scope != authorized_scope:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Signed URL scope does not match the authenticated organization",
+        )
+    return authorized_scope
+
+
 # =============================================================================
 # Basic CRUD Endpoints (SDK-focused)
 # =============================================================================
@@ -426,7 +452,8 @@ async def get_signed_url(
     from shared.file_paths import resolve_s3_key
 
     try:
-        s3_path = resolve_s3_key(request.location, request.scope, request.path)
+        scope = _authorized_signed_url_scope(request, ctx)
+        s3_path = resolve_s3_key(request.location, scope, request.path)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/api/tests/unit/repositories/test_knowledge_repository.py
+++ b/api/tests/unit/repositories/test_knowledge_repository.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from src.repositories.knowledge import KnowledgeRepository
+
+
+ORG_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+class CapturingSession:
+    def __init__(self):
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return SimpleNamespace(scalar_one_or_none=lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_filters_to_repo_org_or_global():
+    session = CapturingSession()
+    repo = KnowledgeRepository(session=session, org_id=ORG_ID)
+
+    await repo.get_by_id(UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+
+    compiled = str(session.statement.compile(compile_kwargs={"literal_binds": True}))
+    assert "knowledge_store.organization_id" in compiled
+    assert str(ORG_ID) in compiled
+    assert "IS NULL" in compiled
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_global_repo_only_reads_global_documents():
+    session = CapturingSession()
+    repo = KnowledgeRepository(session=session, org_id=None)
+
+    await repo.get_by_id(UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+
+    compiled = str(session.statement.compile(compile_kwargs={"literal_binds": True}))
+    assert "knowledge_store.organization_id IS NULL" in compiled

--- a/api/tests/unit/repositories/test_knowledge_repository.py
+++ b/api/tests/unit/repositories/test_knowledge_repository.py
@@ -27,7 +27,7 @@ async def test_get_by_id_filters_to_repo_org_or_global():
 
     compiled = str(session.statement.compile(compile_kwargs={"literal_binds": True}))
     assert "knowledge_store.organization_id" in compiled
-    assert str(ORG_ID) in compiled
+    assert (str(ORG_ID) in compiled) or (ORG_ID.hex in compiled)
     assert "IS NULL" in compiled
 
 

--- a/api/tests/unit/routers/test_files_signed_url.py
+++ b/api/tests/unit/routers/test_files_signed_url.py
@@ -5,14 +5,35 @@ Tests path validation, location/scope handling, and presigned URL generation.
 Path resolution is delegated to `shared.file_paths.resolve_s3_key`.
 """
 
+from types import SimpleNamespace
+from uuid import UUID
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
 
 from src.routers.files import (
     SignedUrlRequest,
     SignedUrlResponse,
     get_signed_url,
 )
+
+
+ORG_ID = UUID("11111111-1111-1111-1111-111111111111")
+OTHER_ORG_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _system_ctx():
+    return SimpleNamespace(
+        org_id=None,
+        user=SimpleNamespace(is_system_account=True),
+    )
+
+
+def _org_ctx(org_id=ORG_ID):
+    return SimpleNamespace(
+        org_id=org_id,
+        user=SimpleNamespace(is_system_account=False),
+    )
 
 
 class TestSignedUrlRequestModel:
@@ -67,7 +88,7 @@ class TestPathResolution:
         mock_fss_class.return_value = mock_fss
 
         req = SignedUrlRequest(path="report.pdf", scope="org-a")
-        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        result = await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert result.path == "uploads/org-a/report.pdf"
 
     @pytest.mark.asyncio
@@ -76,7 +97,7 @@ class TestPathResolution:
 
         req = SignedUrlRequest(path="report.pdf")  # default location=uploads, no scope
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+            await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
         assert "scope" in str(exc_info.value.detail).lower()
 
@@ -93,7 +114,7 @@ class TestPathResolution:
         mock_fss_class.return_value = mock_fss
 
         req = SignedUrlRequest(path="report.pdf", location="workspace")
-        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        result = await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert result.path == "_repo/report.pdf"
 
     @pytest.mark.asyncio
@@ -108,7 +129,7 @@ class TestPathResolution:
         req = SignedUrlRequest(
             path="x.bin", location="temp", scope="org-a", method="GET"
         )
-        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        result = await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert result.path == "_tmp/org-a/x.bin"
 
     @pytest.mark.asyncio
@@ -123,8 +144,32 @@ class TestPathResolution:
         req = SignedUrlRequest(
             path="q1.pdf", location="reports", scope="org-a", method="GET"
         )
-        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        result = await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert result.path == "reports/org-a/q1.pdf"
+
+    @pytest.mark.asyncio
+    @patch("src.routers.files.FileStorageService")
+    async def test_org_context_derives_scope_when_omitted(self, mock_fss_class):
+        mock_fss = MagicMock()
+        mock_fss.generate_presigned_download_url = AsyncMock(
+            return_value="https://s3/url"
+        )
+        mock_fss_class.return_value = mock_fss
+
+        req = SignedUrlRequest(path="q1.pdf", location="reports", method="GET")
+        result = await get_signed_url(req, _org_ctx(), MagicMock(), AsyncMock())
+        assert result.path == f"reports/{ORG_ID}/q1.pdf"
+
+    @pytest.mark.asyncio
+    async def test_org_context_rejects_caller_controlled_scope(self):
+        from fastapi import HTTPException
+
+        req = SignedUrlRequest(
+            path="q1.pdf", location="reports", scope=str(OTHER_ORG_ID), method="GET"
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_signed_url(req, _org_ctx(), MagicMock(), AsyncMock())
+        assert exc_info.value.status_code == 403
 
 
 class TestPathValidation:
@@ -136,7 +181,7 @@ class TestPathValidation:
 
         req = SignedUrlRequest(path="../etc/passwd", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+            await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
         assert "traversal" in str(exc_info.value.detail).lower()
 
@@ -146,7 +191,7 @@ class TestPathValidation:
 
         req = SignedUrlRequest(path="/absolute/path", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+            await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
@@ -155,7 +200,7 @@ class TestPathValidation:
 
         req = SignedUrlRequest(path="x.txt", location="_repo", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+            await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
         assert "reserved bucket prefix" in str(exc_info.value.detail)
 
@@ -165,7 +210,7 @@ class TestPathValidation:
 
         req = SignedUrlRequest(path="x.txt", location="Bad Name!", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+            await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
@@ -174,7 +219,7 @@ class TestPathValidation:
 
         req = SignedUrlRequest(path="x.txt", location="temp", scope=None)
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+            await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
         assert "scope" in str(exc_info.value.detail).lower()
 
@@ -197,7 +242,7 @@ class TestPresignedUrlGeneration:
         req = SignedUrlRequest(
             path="file.pdf", method="PUT", content_type="application/pdf", scope="org-a"
         )
-        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        result = await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert result.url == "https://s3/put-url"
         assert result.headers == {"Content-Type": "application/pdf"}
         mock_fss.presigned_upload_headers.assert_called_once_with("application/pdf")
@@ -216,7 +261,7 @@ class TestPresignedUrlGeneration:
         mock_fss_class.return_value = mock_fss
 
         req = SignedUrlRequest(path="file.pdf", method="GET", scope="org-a")
-        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        result = await get_signed_url(req, _system_ctx(), MagicMock(), AsyncMock())
         assert result.url == "https://s3/get-url"
         assert result.headers == {}
         mock_fss.generate_presigned_download_url.assert_awaited_once_with(


### PR DESCRIPTION
## Summary
- scope knowledge document UUID reads to the repository org/global boundary
- derive signed object-store URL scope from the authenticated context instead of trusting caller input
- add focused regression coverage for signed URL scope handling and knowledge repository scoping

## Verification
- python -m py_compile api/src/repositories/knowledge.py api/src/routers/files.py api/tests/unit/routers/test_files_signed_url.py api/tests/unit/repositories/test_knowledge_repository.py
- python -m pytest api/tests/unit/routers/test_files_signed_url.py api/tests/unit/repositories/test_knowledge_repository.py api/tests/unit/services/test_embed_auth.py could not complete locally because this sparse workstation env is missing backend deps (io_pika during router package import). CI should run the full environment.