### PR TITLE
Fix MCP tool org boundary checks

### DIFF
--- a/api/src/services/mcp_server/tools/code_editor.py
+++ b/api/src/services/mcp_server/tools/code_editor.py
@@ -23,10 +23,12 @@ import logging
 import re
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 from fastmcp.tools import ToolResult
 from sqlalchemy import select
 
+from src.models import Workflow
 from src.services.mcp_server.tools.db import get_tool_db
 from src.models.orm.file_index import FileIndex
 from src.services.file_storage import FileStorageService
@@ -116,6 +118,95 @@ def _require_platform_admin(context: Any) -> ToolResult | None:
     if not getattr(context, "is_platform_admin", False):
         return error_result("Platform administrator privileges are required for code editor tools.")
     return None
+
+
+def _coerce_uuid(value: Any) -> UUID | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, UUID):
+        return value
+    if isinstance(value, str):
+        return UUID(value)
+    return None
+
+
+def _resolve_org_scope(context: Any, organization_id: str | None) -> tuple[UUID | None, ToolResult | None]:
+    try:
+        context_org_id = _coerce_uuid(getattr(context, "org_id", None))
+        requested_org_id = _coerce_uuid(organization_id)
+    except ValueError:
+        return None, error_result("organization_id must be a valid UUID")
+
+    if context_org_id is not None and requested_org_id is not None and requested_org_id != context_org_id:
+        return None, error_result("Not authorized to access resources for the requested organization.")
+
+    return requested_org_id or context_org_id, None
+
+
+def _row_value(row: Any, name: str, index: int) -> Any:
+    if hasattr(row, name):
+        return getattr(row, name)
+    try:
+        return row[index]
+    except (TypeError, IndexError, KeyError):
+        return None
+
+
+async def _get_out_of_scope_workflow_paths(
+    db: Any,
+    paths: list[str],
+    scoped_org_id: UUID | None,
+) -> set[str]:
+    if scoped_org_id is None or not paths:
+        return set()
+
+    result = await db.execute(
+        select(Workflow.path, Workflow.organization_id).where(Workflow.path.in_(paths))
+    )
+    rows = result.all()
+    denied: set[str] = set()
+    for row in rows:
+        path = _row_value(row, "path", 0)
+        workflow_org_id = _coerce_uuid(_row_value(row, "organization_id", 1))
+        if workflow_org_id is not None and workflow_org_id != scoped_org_id:
+            denied.add(path)
+    return denied
+
+
+async def _ensure_workflow_path_in_scope(
+    context: Any,
+    path: str,
+    organization_id: str | None,
+) -> ToolResult | None:
+    scoped_org_id, denied = _resolve_org_scope(context, organization_id)
+    if denied:
+        return denied
+    if scoped_org_id is None:
+        return None
+
+    async with get_tool_db(context) as db:
+        denied_paths = await _get_out_of_scope_workflow_paths(db, [path], scoped_org_id)
+
+    if denied_paths:
+        return error_result("Not authorized to access workflow content for this organization.")
+    return None
+
+
+async def _filter_paths_for_org_scope(
+    context: Any,
+    paths: list[str],
+    organization_id: str | None,
+) -> tuple[list[str], ToolResult | None]:
+    scoped_org_id, denied = _resolve_org_scope(context, organization_id)
+    if denied:
+        return [], denied
+    if scoped_org_id is None or not paths:
+        return paths, None
+
+    async with get_tool_db(context) as db:
+        denied_paths = await _get_out_of_scope_workflow_paths(db, paths, scoped_org_id)
+
+    return [path for path in paths if path not in denied_paths], None
 
 
 def _normalize_line_endings(content: str) -> str:
@@ -287,10 +378,16 @@ async def list_content(
     logger.info(f"MCP list_content: path_prefix={path_prefix}")
     if denied := _require_platform_admin(context):
         return denied
+    _scoped_org_id, denied = _resolve_org_scope(context, organization_id)
+    if denied:
+        return denied
 
     try:
         repo = RepoStorage()
         paths = await repo.list(path_prefix or "")
+        paths, denied = await _filter_paths_for_org_scope(context, paths, organization_id)
+        if denied:
+            return denied
         files = [{"path": p} for p in sorted(paths)]
 
         if not files:
@@ -324,6 +421,9 @@ async def search_content(
     logger.info(f"MCP search_content: pattern={pattern}")
     if denied := _require_platform_admin(context):
         return denied
+    _scoped_org_id, denied = _resolve_org_scope(context, organization_id)
+    if denied:
+        return denied
 
     if not pattern:
         return error_result("pattern is required")
@@ -337,6 +437,18 @@ async def search_content(
 
     try:
         async with get_tool_db(context) as db:
+            denied_paths: set[str] = set()
+            scoped_org_id, _ = _resolve_org_scope(context, organization_id)
+            if scoped_org_id is not None:
+                workflow_path_result = await db.execute(
+                    select(Workflow.path, Workflow.organization_id)
+                )
+                workflow_path_rows = workflow_path_result.all()
+                for row in workflow_path_rows:
+                    workflow_org_id = _coerce_uuid(_row_value(row, "organization_id", 1))
+                    if workflow_org_id is not None and workflow_org_id != scoped_org_id:
+                        denied_paths.add(_row_value(row, "path", 0))
+
             query = select(FileIndex.path, FileIndex.content).where(
                 FileIndex.content.isnot(None),
             )
@@ -347,6 +459,8 @@ async def search_content(
             all_files = result.all()
 
             for row in all_files:
+                if row.path in denied_paths:
+                    continue
                 content = _normalize_line_endings(row.content)
                 file_lines = content.split("\n")
                 for i, line in enumerate(file_lines):
@@ -397,6 +511,8 @@ async def read_content_lines(
 
     if not path:
         return error_result("path is required")
+    if denied := await _ensure_workflow_path_in_scope(context, path, organization_id):
+        return denied
 
     content_result, metadata_result, error = await _get_content_by_path(path, context)
 
@@ -462,6 +578,8 @@ async def get_content(
 
     if not path:
         return error_result("path is required")
+    if denied := await _ensure_workflow_path_in_scope(context, path, organization_id):
+        return denied
 
     content_result, metadata_result, error = await _get_content_by_path(path, context)
 
@@ -550,6 +668,8 @@ async def patch_content(
         return error_result("path is required")
     if not old_string:
         return error_result("old_string is required")
+    if denied := await _ensure_workflow_path_in_scope(context, path, organization_id):
+        return denied
 
     content_result, metadata_result, error = await _get_content_by_path(path, context)
 
@@ -661,6 +781,8 @@ async def replace_content(
         return error_result("path is required")
     if not content:
         return error_result("content is required")
+    if denied := await _ensure_workflow_path_in_scope(context, path, organization_id):
+        return denied
 
     content = _normalize_line_endings(content)
 
@@ -714,6 +836,8 @@ async def delete_content(
 
     if not path:
         return error_result("path is required")
+    if denied := await _ensure_workflow_path_in_scope(context, path, organization_id):
+        return denied
 
     try:
         async with get_tool_db(context) as db:

--- a/api/src/services/mcp_server/tools/events.py
+++ b/api/src/services/mcp_server/tools/events.py
@@ -26,6 +26,71 @@ def _require_platform_admin(context: Any) -> ToolResult | None:
     return None
 
 
+def _coerce_uuid(value: Any) -> UUID | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, UUID):
+        return value
+    if isinstance(value, str):
+        return UUID(value)
+    return None
+
+
+def _resolve_org_scope(context: Any, organization_id: str | None = None) -> tuple[UUID | None, ToolResult | None]:
+    try:
+        context_org_id = _coerce_uuid(getattr(context, "org_id", None))
+        requested_org_id = _coerce_uuid(organization_id)
+    except ValueError:
+        return None, error_result("organization_id must be a valid UUID")
+
+    if context_org_id is not None and requested_org_id is not None and requested_org_id != context_org_id:
+        return None, error_result("Not authorized to access resources for the requested organization.")
+
+    return requested_org_id or context_org_id, None
+
+
+def _source_in_scope(source: Any, scoped_org_id: UUID | None) -> bool:
+    if scoped_org_id is None:
+        return True
+    try:
+        source_org_id = _coerce_uuid(getattr(source, "organization_id", None))
+    except ValueError:
+        return False
+    return source_org_id is None or source_org_id == scoped_org_id
+
+
+def _event_source_scope_error() -> ToolResult:
+    return error_result("Not authorized to access event resources for this organization.")
+
+
+async def _validate_workflow_reference_scope(
+    db: Any,
+    workflow_id: str | None,
+    scoped_org_id: UUID | None,
+    entity_type: str,
+) -> ToolResult | None:
+    if not workflow_id:
+        return None
+    if scoped_org_id is None:
+        return None
+
+    from src.services.cross_org_validation import (
+        CrossOrgValidationError,
+        validate_workflow_reference,
+    )
+
+    try:
+        await validate_workflow_reference(
+            db,
+            UUID(workflow_id),
+            scoped_org_id,
+            entity_type=entity_type,
+        )
+    except CrossOrgValidationError as exc:
+        return error_result(str(exc))
+    return None
+
+
 def _build_callback_url(source_id: UUID) -> str:
     """Build callback URL path from event source ID."""
     return f"/api/hooks/{source_id}"
@@ -44,6 +109,9 @@ async def list_event_sources(
     logger.info(f"MCP list_event_sources called with type={source_type}, org={organization_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context, organization_id)
+    if denied:
+        return denied
 
     try:
         # Parse source_type enum
@@ -56,7 +124,7 @@ async def list_event_sources(
                     f"Invalid source_type: {source_type}. Valid values: webhook, schedule, internal"
                 )
 
-        org_id = UUID(organization_id) if organization_id else None
+        org_id = scoped_org_id
 
         async with get_tool_db(context) as db:
             repo = EventSourceRepository(db)
@@ -132,6 +200,9 @@ async def create_event_source(
     logger.info(f"MCP create_event_source called: name={name}, type={source_type}, workflow_id={workflow_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context, organization_id)
+    if denied:
+        return denied
 
     try:
         source_type_enum = EventSourceType(source_type)
@@ -159,7 +230,15 @@ async def create_event_source(
         user_email = getattr(context, "user_email", "") or getattr(context, "email", "mcp")
 
         async with get_tool_db(context) as db:
-            org_uuid = UUID(organization_id) if organization_id else None
+            org_uuid = scoped_org_id
+
+            if denied := await _validate_workflow_reference_scope(
+                db,
+                workflow_id,
+                org_uuid,
+                "event source",
+            ):
+                return denied
 
             # Upsert logic: if workflow_id provided, check for existing matching source
             existing_source = None
@@ -349,6 +428,9 @@ async def get_event_source(
     logger.info(f"MCP get_event_source called with id={source_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context)
+    if denied:
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -360,6 +442,8 @@ async def get_event_source(
 
             if not source:
                 return error_result(f"Event source not found: {source_id}")
+            if not _source_in_scope(source, scoped_org_id):
+                return _event_source_scope_error()
 
             sub_repo = EventSubscriptionRepository(db)
             subscription_count = await sub_repo.count_by_source(source.id, active_only=True)
@@ -417,6 +501,9 @@ async def update_event_source(
     logger.info(f"MCP update_event_source called with id={source_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context)
+    if denied:
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -428,6 +515,8 @@ async def update_event_source(
 
             if not source:
                 return error_result(f"Event source not found: {source_id}")
+            if not _source_in_scope(source, scoped_org_id):
+                return _event_source_scope_error()
 
             # Update basic fields
             if name is not None:
@@ -496,6 +585,9 @@ async def delete_event_source(
     logger.info(f"MCP delete_event_source called with id={source_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context)
+    if denied:
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -507,6 +599,8 @@ async def delete_event_source(
 
             if not source:
                 return error_result(f"Event source not found: {source_id}")
+            if not _source_in_scope(source, scoped_org_id):
+                return _event_source_scope_error()
 
             # Unsubscribe webhooks
             if source.source_type == EventSourceType.WEBHOOK and source.webhook_source:
@@ -547,6 +641,9 @@ async def list_event_subscriptions(
     logger.info(f"MCP list_event_subscriptions called with source_id={source_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context)
+    if denied:
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -560,6 +657,8 @@ async def list_event_subscriptions(
 
             if not source:
                 return error_result(f"Event source not found: {source_id}")
+            if not _source_in_scope(source, scoped_org_id):
+                return _event_source_scope_error()
 
             sub_repo = EventSubscriptionRepository(db)
             subscriptions = await sub_repo.get_by_source(UUID(source_id), active_only=False)
@@ -614,6 +713,9 @@ async def create_event_subscription(
     logger.info(f"MCP create_event_subscription called: source={source_id}, workflow={workflow_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context)
+    if denied:
+        return denied
 
     if not source_id:
         return error_result("source_id is required")
@@ -631,6 +733,15 @@ async def create_event_subscription(
 
             if not source:
                 return error_result(f"Event source not found: {source_id}")
+            if not _source_in_scope(source, scoped_org_id):
+                return _event_source_scope_error()
+            if denied := await _validate_workflow_reference_scope(
+                db,
+                workflow_id,
+                _coerce_uuid(getattr(source, "organization_id", None)) or scoped_org_id,
+                "event subscription",
+            ):
+                return denied
 
             subscription = EventSubscription(
                 event_source_id=UUID(source_id),
@@ -686,6 +797,9 @@ async def update_event_subscription(
     logger.info(f"MCP update_event_subscription called: sub={subscription_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context)
+    if denied:
+        return denied
 
     if not source_id or not subscription_id:
         return error_result("source_id and subscription_id are required")
@@ -694,7 +808,10 @@ async def update_event_subscription(
         async with get_tool_db(context) as db:
             result = await db.execute(
                 select(EventSubscription)
-                .options(joinedload(EventSubscription.workflow))
+                .options(
+                    joinedload(EventSubscription.workflow),
+                    joinedload(EventSubscription.event_source),
+                )
                 .where(
                     EventSubscription.id == UUID(subscription_id),
                     EventSubscription.event_source_id == UUID(source_id),
@@ -704,6 +821,8 @@ async def update_event_subscription(
 
             if not subscription:
                 return error_result(f"Subscription not found: {subscription_id}")
+            if not _source_in_scope(subscription.event_source, scoped_org_id):
+                return _event_source_scope_error()
 
             if event_type is not None:
                 subscription.event_type = event_type
@@ -744,6 +863,9 @@ async def delete_event_subscription(
     logger.info(f"MCP delete_event_subscription called: sub={subscription_id}")
     if denied := _require_platform_admin(context):
         return denied
+    scoped_org_id, denied = _resolve_org_scope(context)
+    if denied:
+        return denied
 
     if not source_id or not subscription_id:
         return error_result("source_id and subscription_id are required")
@@ -751,7 +873,9 @@ async def delete_event_subscription(
     try:
         async with get_tool_db(context) as db:
             result = await db.execute(
-                select(EventSubscription).where(
+                select(EventSubscription)
+                .options(joinedload(EventSubscription.event_source))
+                .where(
                     EventSubscription.id == UUID(subscription_id),
                     EventSubscription.event_source_id == UUID(source_id),
                 )
@@ -760,6 +884,8 @@ async def delete_event_subscription(
 
             if not subscription:
                 return error_result(f"Subscription not found: {subscription_id}")
+            if not _source_in_scope(subscription.event_source, scoped_org_id):
+                return _event_source_scope_error()
 
             await db.delete(subscription)
             await db.flush()

--- a/api/tests/unit/services/mcp_server/test_code_editor_tools.py
+++ b/api/tests/unit/services/mcp_server/test_code_editor_tools.py
@@ -14,6 +14,8 @@ All files are accessed via their path in file_index / S3 _repo/ store.
 No entity_type or app_id parameters -- everything is path-based.
 """
 
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -44,6 +46,17 @@ def is_error_result(result: ToolResult) -> bool:
     if result.content and isinstance(result.content, str) and result.content.startswith("Error:"):
         return True
     return False
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+    def scalars(self):
+        return self
 
 
 @pytest.fixture
@@ -376,6 +389,37 @@ class TestGetContent:
         assert "error" in data
         assert "not found" in data["error"].lower()
 
+    @pytest.mark.asyncio
+    async def test_get_content_denies_out_of_scope_workflow_path(self, platform_admin_context):
+        """Org-scoped admins must not read workflow files owned by another org."""
+        from src.services.mcp_server.tools.code_editor import get_content
+
+        caller_org = uuid4()
+        other_org = uuid4()
+        platform_admin_context.org_id = caller_org
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            return_value=_RowsResult([SimpleNamespace(organization_id=other_org)])
+        )
+
+        @asynccontextmanager
+        async def fake_get_tool_db(_context):
+            yield mock_session
+
+        with patch("src.services.mcp_server.tools.code_editor.get_tool_db", fake_get_tool_db), patch(
+            "src.services.mcp_server.tools.code_editor._read_from_s3",
+            new_callable=AsyncMock,
+            return_value="secret workflow code",
+        ) as mock_read:
+            result = await get_content(
+                context=platform_admin_context,
+                path="workflows/other_org.py",
+            )
+
+        assert is_error_result(result)
+        assert "not authorized" in get_result_data(result)["error"].lower()
+        mock_read.assert_not_awaited()
+
 
 class TestPatchContent:
     """Tests for the patch_content MCP tool."""
@@ -480,6 +524,41 @@ def func2():
         data = get_result_data(result)
         assert "error" in data
         assert "old_string" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_patch_content_denies_out_of_scope_workflow_path(self, platform_admin_context):
+        """Org-scoped admins must not write files containing another org's workflows."""
+        from src.services.mcp_server.tools.code_editor import patch_content
+
+        platform_admin_context.org_id = uuid4()
+        other_org = uuid4()
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            return_value=_RowsResult([SimpleNamespace(organization_id=other_org)])
+        )
+
+        @asynccontextmanager
+        async def fake_get_tool_db(_context):
+            yield mock_session
+
+        with patch("src.services.mcp_server.tools.code_editor.get_tool_db", fake_get_tool_db), patch(
+            "src.services.mcp_server.tools.code_editor._read_from_s3",
+            new_callable=AsyncMock,
+            return_value='return {"status": "old"}',
+        ), patch(
+            "src.services.mcp_server.tools.code_editor._replace_workspace_file",
+            new_callable=AsyncMock,
+        ) as mock_write:
+            result = await patch_content(
+                context=platform_admin_context,
+                path="workflows/other_org.py",
+                old_string='return {"status": "old"}',
+                new_string='return {"status": "new"}',
+            )
+
+        assert is_error_result(result)
+        assert "not authorized" in get_result_data(result)["error"].lower()
+        mock_write.assert_not_awaited()
 
 
 class TestReplaceContent:
@@ -751,6 +830,43 @@ class TestDeleteContent:
         data = get_result_data(result)
         assert "Platform administrator privileges are required" in data["error"]
 
+    @pytest.mark.asyncio
+    async def test_delete_content_denies_out_of_scope_workflow_path(self, platform_admin_context):
+        """Deleting a file must not deactivate workflows outside the caller's org scope."""
+        from src.services.mcp_server.tools.code_editor import delete_content
+
+        platform_admin_context.org_id = uuid4()
+        other_org = uuid4()
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            return_value=_RowsResult([SimpleNamespace(organization_id=other_org)])
+        )
+
+        @asynccontextmanager
+        async def fake_get_tool_db(_context):
+            yield mock_session
+
+        with patch("src.services.mcp_server.tools.code_editor.get_tool_db", fake_get_tool_db), patch(
+            "src.services.mcp_server.tools.code_editor.RepoStorage"
+        ) as mock_repo_cls, patch(
+            "src.services.mcp_server.tools.code_editor.FileStorageService"
+        ) as mock_fs_cls:
+            mock_repo = MagicMock()
+            mock_repo.exists = AsyncMock(return_value=True)
+            mock_repo_cls.return_value = mock_repo
+            mock_fs_instance = MagicMock()
+            mock_fs_instance.delete_file = AsyncMock()
+            mock_fs_cls.return_value = mock_fs_instance
+
+            result = await delete_content(
+                context=platform_admin_context,
+                path="workflows/other_org.py",
+            )
+
+        assert is_error_result(result)
+        assert "not authorized" in get_result_data(result)["error"].lower()
+        mock_fs_instance.delete_file.assert_not_awaited()
+
 
 class TestCodeEditorAuthorization:
     """All path-based code editor MCP tools are platform-admin only."""
@@ -888,6 +1004,38 @@ async def cleanup():
             data = get_result_data(result)
             # Should have exactly 2 matches (one per "return" line), NOT 4
             assert data["total_matches"] == 2
+
+    @pytest.mark.asyncio
+    async def test_search_content_omits_out_of_scope_workflow_paths(self, platform_admin_context):
+        """Search results must not leak workflow content from another org."""
+        from src.services.mcp_server.tools.code_editor import search_content
+
+        caller_org = uuid4()
+        other_org = uuid4()
+        platform_admin_context.org_id = caller_org
+        allowed_row = SimpleNamespace(path="workflows/allowed.py", content="needle allowed")
+        denied_row = SimpleNamespace(path="workflows/denied.py", content="needle denied")
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _RowsResult([SimpleNamespace(path="workflows/denied.py", organization_id=other_org)]),
+                _RowsResult([allowed_row, denied_row]),
+            ]
+        )
+
+        @asynccontextmanager
+        async def fake_get_tool_db(_context):
+            yield mock_session
+
+        with patch("src.services.mcp_server.tools.code_editor.get_tool_db", fake_get_tool_db):
+            result = await search_content(
+                context=platform_admin_context,
+                pattern="needle",
+            )
+
+        assert not is_error_result(result)
+        matches = get_result_data(result)["matches"]
+        assert [match["path"] for match in matches] == ["workflows/allowed.py"]
 
 
 class TestFormatDeactivationResult:

--- a/api/tests/unit/services/mcp_server/test_event_tools.py
+++ b/api/tests/unit/services/mcp_server/test_event_tools.py
@@ -14,6 +14,7 @@ Tests the event source, subscription, and webhook adapter tools:
 - list_webhook_adapters
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -41,6 +42,20 @@ def get_content_text(result: ToolResult) -> str:
     if isinstance(content, list):
         return content[0].text if content else ""
     return content or ""
+
+
+class _OneResult:
+    def __init__(self, value):
+        self._value = value
+
+    def unique(self):
+        return self
+
+    def scalar_one(self):
+        return self._value
+
+    def scalar_one_or_none(self):
+        return self._value
 
 
 # ==================== Fixtures ====================
@@ -135,6 +150,18 @@ class TestListEventSources:
                 assert result.structured_content["sources"] == []
                 assert result.structured_content["count"] == 0
 
+    @pytest.mark.asyncio
+    async def test_scoped_admin_cannot_list_another_org_sources(self, context):
+        """organization_id must not widen an org-scoped admin's event access."""
+        from src.services.mcp_server.tools.events import list_event_sources
+
+        context.org_id = uuid4()
+
+        result = await list_event_sources(context, organization_id=str(uuid4()))
+
+        assert is_error_result(result)
+        assert "not authorized" in result.structured_content["error"].lower()
+
 
 class TestCreateEventSource:
     """Tests for create_event_source tool."""
@@ -158,6 +185,23 @@ class TestCreateEventSource:
         )
         assert is_error_result(result)
         assert "cron_expression is required" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_scoped_admin_cannot_create_source_for_another_org(self, context):
+        """Event creation must not accept an out-of-scope organization_id."""
+        from src.services.mcp_server.tools.events import create_event_source
+
+        context.org_id = uuid4()
+
+        result = await create_event_source(
+            context,
+            name="cross-org",
+            source_type="webhook",
+            organization_id=str(uuid4()),
+        )
+
+        assert is_error_result(result)
+        assert "not authorized" in result.structured_content["error"].lower()
 
 
 class TestGetEventSource:
@@ -193,6 +237,42 @@ class TestGetEventSource:
                 result = await get_event_source(context, source_id)
                 assert is_error_result(result)
                 assert "not found" in result.structured_content["error"]
+
+    @pytest.mark.asyncio
+    async def test_scoped_admin_cannot_get_another_org_source(self, context):
+        """Direct event source lookup must enforce the caller's org scope."""
+        from src.models.enums import EventSourceType
+        from src.services.mcp_server.tools.events import get_event_source
+
+        context.org_id = uuid4()
+        mock_source = SimpleNamespace(
+            id=uuid4(),
+            name="Other org source",
+            source_type=EventSourceType.INTERNAL,
+            organization_id=uuid4(),
+            is_active=True,
+            error_message=None,
+            created_by="admin@example.com",
+            created_at=None,
+            webhook_source=None,
+            schedule_source=None,
+        )
+        mock_source_repo = MagicMock()
+        mock_source_repo.get_by_id_with_details = AsyncMock(return_value=mock_source)
+
+        with patch("src.core.database.get_db_context") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_db.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with patch(
+                "src.repositories.events.EventSourceRepository",
+                return_value=mock_source_repo,
+            ):
+                result = await get_event_source(context, str(mock_source.id))
+
+        assert is_error_result(result)
+        assert "not authorized" in result.structured_content["error"].lower()
 
 
 class TestUpdateEventSource:
@@ -294,6 +374,38 @@ class TestDeleteEventSource:
         assert not is_error_result(result)
         mock_session.delete.assert_awaited_once_with(mock_source)
         mock_session.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_scoped_admin_cannot_delete_another_org_source(self, context):
+        """Deleting event sources must be scoped to the caller's org."""
+        from src.models.enums import EventSourceType
+        from src.services.mcp_server.tools.events import delete_event_source
+
+        context.org_id = uuid4()
+        mock_source = SimpleNamespace(
+            id=uuid4(),
+            name="Other org source",
+            source_type=EventSourceType.INTERNAL,
+            organization_id=uuid4(),
+            webhook_source=None,
+        )
+        mock_repo = MagicMock()
+        mock_repo.get_by_id_with_details = AsyncMock(return_value=mock_source)
+
+        with patch("src.core.database.get_db_context") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_db.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with patch(
+                "src.repositories.events.EventSourceRepository",
+                return_value=mock_repo,
+            ):
+                result = await delete_event_source(context, str(mock_source.id))
+
+        assert is_error_result(result)
+        assert "not authorized" in result.structured_content["error"].lower()
+        mock_session.delete.assert_not_awaited()
 
 
 # ==================== Subscription Tool Tests ====================
@@ -437,6 +549,34 @@ class TestDeleteEventSubscription:
         mock_session.execute.assert_awaited_once()
         mock_session.delete.assert_awaited_once_with(mock_subscription)
         mock_session.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_scoped_admin_cannot_delete_subscription_for_another_org_source(self, context):
+        """Subscription deletion must verify the parent event source org."""
+        from src.services.mcp_server.tools.events import delete_event_subscription
+
+        context.org_id = uuid4()
+        mock_subscription = SimpleNamespace(
+            id=uuid4(),
+            event_source=SimpleNamespace(organization_id=uuid4()),
+        )
+        mock_result = _OneResult(mock_subscription)
+
+        with patch("src.core.database.get_db_context") as mock_db:
+            mock_session = AsyncMock()
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_db.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_db.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await delete_event_subscription(
+                context,
+                str(uuid4()),
+                str(mock_subscription.id),
+            )
+
+        assert is_error_result(result)
+        assert "not authorized" in result.structured_content["error"].lower()
+        mock_session.delete.assert_not_awaited()
 
 
 # ==================== Webhook Adapter Tests ====================


### PR DESCRIPTION
## Summary
- enforce org scope before MCP code-editor reads, searches, writes, and deletes workflow-backed paths
- enforce org scope on MCP event source and subscription operations
- add focused regression tests for cross-org code editor and event tool access

## Tests
- uv run pytest api/tests/unit/services/mcp_server/test_code_editor_tools.py api/tests/unit/services/mcp_server/test_event_tools.py
- uv run pytest api/tests/unit/services/mcp_server
- uv run ruff check api/src/services/mcp_server/tools/code_editor.py api/src/services/mcp_server/tools/events.py api/tests/unit/services/mcp_server/test_code_editor_tools.py api/tests/unit/services/mcp_server/test_event_tools.py
- git diff --check