### PR TITLE
Prepare Codex Gateway onboarding runbook

### DIFF
--- a/api/src/services/codex_gateway/oauth.py
+++ b/api/src/services/codex_gateway/oauth.py
@@ -38,6 +38,9 @@ def parse_codex_auth_cache(auth_cache: dict[str, Any]) -> ParsedCodexAuthCache:
         auth_cache.get("account"),
         auth_cache.get("user"),
         auth_cache.get("profile"),
+        auth_cache.get("tokens"),
+        auth_cache.get("openai"),
+        auth_cache.get("chatgpt"),
         auth_cache,
     )
 
@@ -117,18 +120,26 @@ def _find_value(sources: list[dict[str, Any]], *keys: str) -> Any:
 
 def _parse_expiry(token_sources: list[dict[str, Any]]) -> datetime | None:
     raw = _find_value(token_sources, "expires_at", "expiry", "expiration")
+    if isinstance(raw, (int, float)):
+        return _datetime_from_epoch(raw)
     if isinstance(raw, str) and raw:
+        if raw.isdigit():
+            return _datetime_from_epoch(int(raw))
         try:
             return datetime.fromisoformat(raw.replace("Z", "+00:00"))
         except ValueError:
             return None
     exp = _find_value(token_sources, "expires_at_epoch", "expires_at_unix")
     if isinstance(exp, (int, float)):
-        try:
-            return datetime.fromtimestamp(exp, tz=timezone.utc)
-        except (OverflowError, OSError, ValueError):
-            return None
+        return _datetime_from_epoch(exp)
     return None
+
+
+def _datetime_from_epoch(value: int | float) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
 
 
 def _parse_scopes(value: Any) -> list[str]:

--- a/api/tests/unit/routers/test_codex_gateway.py
+++ b/api/tests/unit/routers/test_codex_gateway.py
@@ -457,6 +457,15 @@ def test_import_codex_auth_cache_stores_tokens_without_returning_them(monkeypatc
     assert oauth_upsert["access_token"] == "access-token-secret"
     assert oauth_upsert["refresh_token"] == "refresh-token-secret"
     audit.assert_awaited_once()
+    audit_details = audit.await_args.kwargs["details"]
+    assert audit_details == {
+        "provider": "chatgpt_codex",
+        "upstream_workspace_id": "workspace-midtown",
+        "has_refresh_token": True,
+    }
+    assert "dev@example.test" not in str(audit_details)
+    assert "access-token-secret" not in str(audit_details)
+    assert "refresh-token-secret" not in str(audit_details)
 
 
 def test_disconnect_codex_oauth_revokes_user_account_and_audits(monkeypatch):

--- a/api/tests/unit/services/test_codex_gateway_oauth.py
+++ b/api/tests/unit/services/test_codex_gateway_oauth.py
@@ -1,5 +1,6 @@
 """Tests for Codex Gateway OAuth onboarding helpers."""
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -75,6 +76,47 @@ def test_parse_codex_auth_cache_searches_later_token_sources():
     assert parsed.upstream_subject == "chatgpt-user-123"
     assert parsed.upstream_email == "dev@example.test"
     assert parsed.access_token_expires_at is not None
+
+
+def test_parse_codex_auth_cache_accepts_codex_auth_tokens_metadata_shape():
+    parsed = parse_codex_auth_cache(
+        {
+            "tokens": {
+                "access_token": "access-token-secret",
+                "refresh_token": "refresh-token-secret",
+                "account_id": "chatgpt-account-from-token-block",
+                "email": "coworker@example.test",
+                "workspace_id": "workspace-midtown",
+                "expires_at": 1770000000,
+                "scope": ["openid", "profile", "offline_access"],
+            }
+        }
+    )
+
+    assert parsed.upstream_subject == "chatgpt-account-from-token-block"
+    assert parsed.upstream_email == "coworker@example.test"
+    assert parsed.upstream_workspace_id == "workspace-midtown"
+    assert parsed.access_token_expires_at == datetime.fromtimestamp(
+        1770000000,
+        tz=timezone.utc,
+    )
+    assert parsed.scopes == ["openid", "profile", "offline_access"]
+
+
+def test_parse_codex_auth_cache_accepts_numeric_expiry_string():
+    parsed = parse_codex_auth_cache(
+        {
+            "tokens": {
+                "access_token": "access-token-secret",
+                "expires_at": "1770000000",
+            }
+        }
+    )
+
+    assert parsed.access_token_expires_at == datetime.fromtimestamp(
+        1770000000,
+        tz=timezone.utc,
+    )
 
 
 def test_parse_codex_auth_cache_ignores_invalid_epoch_expiry():

--- a/docs/runbooks/codex-gateway-onboarding.md
+++ b/docs/runbooks/codex-gateway-onboarding.md
@@ -39,7 +39,9 @@ issuing gateway keys.
    bifrost api POST /api/codex-gateway/oauth/connect '{}'
    ```
 
-   The response should prefer:
+   The response is a `CodexGatewayOAuthConnectResponse`. Use its
+   `client_command` value as the recommended user command. The expected
+   `preferred_method` is `device_code`, and the expected `client_command` is:
 
    ```text
    codex login --device-auth
@@ -107,4 +109,3 @@ The response should show `connected: false`.
 | Status stays disconnected after import | Confirm the request was made as the same Bifrost user being onboarded. |
 | Another user cannot see the connection | Expected. Upstream Codex accounts are user-scoped. |
 | A token appears in output | Stop onboarding and treat it as a security bug. |
-

--- a/docs/runbooks/codex-gateway-onboarding.md
+++ b/docs/runbooks/codex-gateway-onboarding.md
@@ -1,0 +1,110 @@
+# Codex Gateway User Onboarding
+
+This runbook is for onboarding a Bifrost user to Bifrost Codex Gateway with the
+user's own ChatGPT/Codex identity. Do not use a shared upstream ChatGPT account
+unless it is intentionally labeled and governed as a service account.
+
+## Goal
+
+The target mapping is:
+
+```text
+Bifrost user -> Bifrost session/key -> same user's ChatGPT/Codex account
+```
+
+If that mapping is ambiguous, stop and fix the identity or token state before
+issuing gateway keys.
+
+## Requirements
+
+- The user can sign in to ChatGPT/Codex with their own account.
+- Device-code sign-in is allowed for the ChatGPT Business workspace.
+- The user has access to the Codex CLI on their workstation.
+- The Bifrost platform is reachable over the private/dev endpoint.
+
+## Connect
+
+1. Sign in to the Bifrost instance as the user being onboarded.
+2. Confirm the gateway route is available:
+
+   ```powershell
+   bifrost api GET /api/codex-gateway/oauth/status
+   ```
+
+   A new user should see `connected: false`.
+
+3. Ask Bifrost for the preferred connect method:
+
+   ```powershell
+   bifrost api POST /api/codex-gateway/oauth/connect '{}'
+   ```
+
+   The response should prefer:
+
+   ```text
+   codex login --device-auth
+   ```
+
+4. On the user's workstation, run:
+
+   ```powershell
+   codex login --device-auth
+   ```
+
+5. After Codex login succeeds, import the user's Codex auth cache into the
+   Bifrost token vault by sending the cache JSON as `auth_cache`:
+
+   ```powershell
+   $authCache = Get-Content "$env:USERPROFILE\.codex\auth.json" -Raw | ConvertFrom-Json
+   bifrost api POST /api/codex-gateway/oauth/import-auth-cache (@{ auth_cache = $authCache } | ConvertTo-Json -Depth 20)
+   ```
+
+6. Verify the connection:
+
+   ```powershell
+   bifrost api GET /api/codex-gateway/oauth/status
+   ```
+
+   The response should show `connected: true` and safe account metadata only.
+   It must not include access tokens, refresh tokens, ID tokens, or raw cache
+   content.
+
+## Disconnect
+
+Disconnect a user's upstream Codex account during offboarding, account rotation,
+or a failed onboarding attempt:
+
+```powershell
+bifrost api DELETE /api/codex-gateway/oauth
+```
+
+Then verify:
+
+```powershell
+bifrost api GET /api/codex-gateway/oauth/status
+```
+
+The response should show `connected: false`.
+
+## Security Notes
+
+- Treat `auth.json` like a password. Do not paste it into tickets, chat, issue
+  comments, or logs.
+- Import only over HTTPS/private-network access to the Bifrost platform.
+- Bifrost encrypts imported token material at rest and never returns upstream
+  tokens in API responses.
+- Audit events record provider/workspace metadata and refresh-token presence,
+  not raw upstream tokens or raw upstream email.
+- If a user loses ChatGPT/Codex entitlement, disconnect and reconnect after the
+  entitlement is restored.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `/oauth/status` returns `404` | The platform API image does not include the Codex Gateway OAuth routes yet. |
+| Import returns `400` | Confirm the JSON body is `{ "auth_cache": <auth-json-object> }` and contains an access or refresh token. |
+| Status stays disconnected after import | Confirm the request was made as the same Bifrost user being onboarded. |
+| Another user cannot see the connection | Expected. Upstream Codex accounts are user-scoped. |
+| A token appears in output | Stop onboarding and treat it as a security bug. |
+


### PR DESCRIPTION
## Summary
- Accept Codex auth-cache metadata when account identity lives in the token block.
- Parse numeric and numeric-string token expiry values.
- Add a Codex Gateway user onboarding runbook for device-code login, auth-cache import, verification, disconnect, and token-safety handling.
- Assert OAuth import audit details exclude raw upstream email and token material.

## Verification
- `..\.venv\Scripts\python.exe -m pytest tests\unit\services\test_codex_gateway_oauth.py -q`
- `..\.venv\Scripts\python.exe -m pytest tests\unit\services\test_codex_gateway_oauth.py tests\unit\routers\test_codex_gateway.py tests\e2e\api\test_codex_gateway_oauth.py -q` (21 passed, 3 skipped locally)
- `..\.venv\Scripts\python.exe -m pytest tests\unit\services\test_codex_gateway_oauth.py tests\unit\repositories\test_codex_gateway_repository.py tests\unit\routers\test_codex_gateway.py tests\unit\services\test_codex_gateway_runtime.py tests\unit\services\test_codex_gateway_policy.py tests\unit\test_dto_flags.py -q` (98 passed)
- `..\.venv\Scripts\python.exe -m ruff check src\services\codex_gateway\oauth.py tests\unit\services\test_codex_gateway_oauth.py tests\unit\routers\test_codex_gateway.py`
- `..\.venv\Scripts\python.exe -m pyright src\services\codex_gateway\oauth.py tests\unit\services\test_codex_gateway_oauth.py tests\unit\routers\test_codex_gateway.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced authentication metadata handling to support additional token-based configurations.
  * Improved timestamp expiry parsing with support for numeric formats (epoch seconds).
  * Enhanced audit logging with sensitive data protection—email and tokens excluded from audit records.

* **Documentation**
  * Added Codex Gateway user onboarding runbook covering connection workflows, offboarding, and troubleshooting guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->