### PR TITLE
Harden git sync manifest imports

### DIFF
--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -105,6 +105,20 @@ def _filter_manifest_to_work_dir(manifest: Manifest, work_dir: Path) -> None:
     )
 
 
+def _filter_db_manifest_to_import_scope(
+    db_manifest: Manifest,
+    incoming_manifest: Manifest,
+    work_dir: Path,
+) -> None:
+    """Restrict DB-side diff candidates to this repo/import scope."""
+    _filter_manifest_to_scope(
+        db_manifest,
+        path_exists=lambda path: (work_dir / path).exists(),
+        dir_exists=lambda path: (work_dir / path).is_dir(),
+        scope_manifest=incoming_manifest,
+    )
+
+
 def _deleted_paths_in_head(repo: GitRepo) -> set[str]:
     """Return paths deleted by the current HEAD commit."""
     try:
@@ -852,18 +866,18 @@ class GitHubSyncService:
                 # Step 4: Entity import — always full import (safe, idempotent upserts)
                 await _progress("Importing entities...")
                 all_entity_changes: list = []
+                removed_paths = _deleted_paths_in_head(repo)
                 async with self.db.begin_nested():
                     entities_imported, entity_changes, removed_entity_ids = await self._import_all_entities(
                         work_dir, progress_fn=_progress,
                     )
                     all_entity_changes.extend(entity_changes)
                     await _progress("Updating file index...")
-                    await self._update_file_index(work_dir)
+                    await self._update_file_index(work_dir, removed_paths=removed_paths)
                 await self.db.commit()
 
                 # Step 5: Clean up removed entities (gated on confirmation)
                 await _progress("Checking for removed entities...")
-                removed_paths = _deleted_paths_in_head(repo)
                 pending_deletes = await self._resolver._resolve_deletions(
                     work_dir=work_dir,
                     dry_run=True,
@@ -1184,6 +1198,7 @@ class GitHubSyncService:
 
         # Diff against current DB state to find what actually changed
         db_manifest = await generate_manifest(self.db)
+        _filter_db_manifest_to_import_scope(db_manifest, manifest, work_dir)
         diff_changes, changed_ids = _diff_and_collect(manifest, db_manifest)
         removed_entity_ids = _collect_removed_entity_ids(diff_changes)
 
@@ -1386,7 +1401,11 @@ class GitHubSyncService:
                 return repo
             raise SyncError(f"Failed to clone {self.repo_url}: {e}") from e
 
-    async def _update_file_index(self, work_dir: Path) -> None:
+    async def _update_file_index(
+        self,
+        work_dir: Path,
+        removed_paths: set[str] | None = None,
+    ) -> None:
         """Update file_index from all files in the working tree, remove stale entries.
 
         Optimized: prefetches existing (path, content_hash) pairs in one query,
@@ -1446,8 +1465,12 @@ class GitHubSyncService:
         if pending_upserts:
             logger.info(f"File index: upserted {len(pending_upserts)} changed files, skipped {len(files) - len(pending_upserts)} unchanged")
 
-        # Remove file_index entries that no longer exist in the repo
+        # Remove file_index entries only when git explicitly deleted those
+        # paths in this sync. A partial checkout/import must not turn absence
+        # from the current working tree into global file-index deletion.
         stale_paths = set(existing_hashes.keys()) - repo_paths
+        if removed_paths is not None:
+            stale_paths &= removed_paths
         if stale_paths:
             await self.db.execute(
                 delete(FileIndex).where(FileIndex.path.in_(stale_paths))

--- a/api/src/services/manifest_import.py
+++ b/api/src/services/manifest_import.py
@@ -115,8 +115,10 @@ def _diff_and_collect(
                 entity = cur
             else:
                 assert inc is not None and cur is not None
-                # Compare serialized form
-                if inc.model_dump(mode="json", by_alias=True) == cur.model_dump(mode="json", by_alias=True):
+                # Compare serialized form. Environment-owned fields such as
+                # OAuth token links must not make a portable manifest look
+                # different or trigger an import update.
+                if _dump_for_diff(attr, inc) == _dump_for_diff(attr, cur):
                     continue  # No change
                 action = "update"
                 entity = inc
@@ -153,6 +155,15 @@ def _diff_and_collect(
     changes.sort(key=lambda c: (c["entity_type"], _ACTION_ORDER.get(c["action"], 9), c["name"]))
 
     return changes, changed_ids
+
+
+def _dump_for_diff(attr: str, entity: object) -> dict:
+    """Return a manifest entity dump with environment-owned fields stripped."""
+    data = entity.model_dump(mode="json", by_alias=True)
+    if attr == "integrations":
+        for mapping in data.get("mappings") or []:
+            mapping["oauth_token_id"] = None
+    return data
 
 
 def _diff_list_entities(
@@ -262,10 +273,138 @@ def _safe_app_repo_path(mapp) -> str:
     return f"apps/{slug}"
 
 
+def _manifest_org_scope(manifest: "Manifest") -> set[str]:
+    """Collect org IDs explicitly declared or referenced by a manifest."""
+    org_ids = {org.id for org in manifest.organizations}
+
+    def _add_entity_orgs(values) -> None:
+        for entity in values:
+            org_id = getattr(entity, "organization_id", None)
+            if org_id:
+                org_ids.add(org_id)
+
+    _add_entity_orgs(manifest.workflows.values())
+    _add_entity_orgs(manifest.forms.values())
+    _add_entity_orgs(manifest.agents.values())
+    _add_entity_orgs(manifest.apps.values())
+    _add_entity_orgs(manifest.configs.values())
+    _add_entity_orgs(manifest.tables.values())
+    _add_entity_orgs(manifest.events.values())
+    _add_entity_orgs(manifest.mcp_servers.values())
+
+    for integration in manifest.integrations.values():
+        for mapping in integration.mappings:
+            if mapping.organization_id:
+                org_ids.add(mapping.organization_id)
+
+    for server in manifest.mcp_servers.values():
+        for connection in server.connections.values():
+            if connection.organization_id:
+                org_ids.add(connection.organization_id)
+
+    return org_ids
+
+
+def _entity_in_org_scope(entity: object, scoped_org_ids: set[str]) -> bool:
+    org_id = getattr(entity, "organization_id", None)
+    return bool(org_id and org_id in scoped_org_ids)
+
+
+def _filter_non_file_entities_to_scope(
+    manifest: "Manifest",
+    scope_manifest: "Manifest",
+) -> None:
+    """Restrict DB manifest sections that are not directly backed by files.
+
+    File-backed entities are scoped by repo path in ``_filter_manifest_to_scope``.
+    Integrations, configs, tables, events, roles, orgs, and MCP templates need
+    an explicit org/entity scope; otherwise a partial manifest can turn mere
+    absence into a global delete diff.
+    """
+    scoped_org_ids = _manifest_org_scope(scope_manifest)
+    scoped_role_ids = {role.id for role in scope_manifest.roles}
+    scoped_integration_ids = {
+        integration.id for integration in scope_manifest.integrations.values()
+    }
+    scoped_config_ids = {config.id for config in scope_manifest.configs.values()}
+    scoped_table_ids = {table.id for table in scope_manifest.tables.values()}
+    scoped_event_ids = {event.id for event in scope_manifest.events.values()}
+    scoped_mcp_server_ids = {
+        server.id for server in scope_manifest.mcp_servers.values()
+    }
+
+    manifest.organizations = [
+        org for org in manifest.organizations
+        if scope_manifest.organizations and org.id in scoped_org_ids
+    ]
+    manifest.roles = [
+        role for role in manifest.roles
+        if scope_manifest.roles and role.id in scoped_role_ids
+    ]
+
+    manifest.integrations = {
+        key: integration
+        for key, integration in manifest.integrations.items()
+        if scope_manifest.integrations
+        if (
+            integration.id in scoped_integration_ids
+            or any(
+                mapping.organization_id in scoped_org_ids
+                for mapping in integration.mappings
+                if mapping.organization_id
+            )
+        )
+    }
+    scoped_integration_ids |= {
+        integration.id for integration in manifest.integrations.values()
+    }
+
+    manifest.configs = {
+        key: config
+        for key, config in manifest.configs.items()
+        if scope_manifest.configs
+        if (
+            config.id in scoped_config_ids
+            or _entity_in_org_scope(config, scoped_org_ids)
+            or (
+                config.integration_id is not None
+                and config.integration_id in scoped_integration_ids
+            )
+        )
+    }
+    manifest.tables = {
+        key: table
+        for key, table in manifest.tables.items()
+        if scope_manifest.tables
+        if table.id in scoped_table_ids or _entity_in_org_scope(table, scoped_org_ids)
+    }
+    manifest.events = {
+        key: event
+        for key, event in manifest.events.items()
+        if scope_manifest.events
+        if event.id in scoped_event_ids or _entity_in_org_scope(event, scoped_org_ids)
+    }
+
+    manifest.mcp_servers = {
+        key: server
+        for key, server in manifest.mcp_servers.items()
+        if scope_manifest.mcp_servers
+        if (
+            server.id in scoped_mcp_server_ids
+            or _entity_in_org_scope(server, scoped_org_ids)
+            or any(
+                connection.organization_id in scoped_org_ids
+                for connection in server.connections.values()
+            )
+        )
+    }
+
+
 def _filter_manifest_to_scope(
     manifest: "Manifest",
     path_exists: Callable[[str], bool],
     dir_exists: Callable[[str], bool],
+    scope_manifest: "Manifest | None" = None,
 ) -> None:
     """Restrict a DB manifest to the source paths owned by the current repo."""
     manifest.workflows = {
@@ -321,6 +460,18 @@ def _filter_manifest_to_scope(
         if dir_exists(app_path):
             safe_apps[k] = app.model_copy(update={"path": app_path})
     manifest.apps = safe_apps
+
+    if scope_manifest is not None:
+        _filter_non_file_entities_to_scope(manifest, scope_manifest)
+
+
+def _manifest_access_level(access_level: str | None, roles: list[str] | None) -> str | None:
+    """Use role_based when a manifest declares roles but omits access_level."""
+    if access_level is not None:
+        return access_level
+    if roles:
+        return "role_based"
+    return None
 
 
 # =============================================================================
@@ -700,6 +851,7 @@ async def import_manifest_from_repo(
             repo_path.startswith(path.rstrip("/") + "/")
             for repo_path in all_repo_paths
         ),
+        scope_manifest=manifest,
     )
     entity_changes, changed_ids = _diff_and_collect(manifest, db_manifest)
 
@@ -1116,7 +1268,8 @@ class ManifestResolver:
                     from src.services.app_storage import AppStorageService
 
                     _synced, errors = await AppStorageService().sync_preview_compiled(
-                        mapp.id, mapp.path,
+                        mapp.id,
+                        _safe_app_repo_path(mapp),
                     )
                     if errors:
                         logger.warning(f"App {mapp.name} compile warnings: {errors}")
@@ -1783,7 +1936,7 @@ class ManifestResolver:
         ]
         present_app_uuids = [
             UUID(mapp.id) for mapp in manifest.apps.values()
-            if _dir_exists(mapp.path)
+            if _dir_exists(_safe_app_repo_path(mapp))
         ]
 
         present_integ_uuids = [UUID(m.id) for m in manifest.integrations.values()]
@@ -2248,12 +2401,12 @@ class ManifestResolver:
                 await self.db.execute(m_stmt)
 
         for org_key, existing_m in existing_m_by_org.items():
-            if org_key not in manifest_org_ids:
-                await self.db.execute(
-                    sa_delete(IntegrationMapping).where(
-                        IntegrationMapping.id == existing_m.id
-                    )
-                )
+            if org_key in manifest_org_ids:
+                continue
+            logger.info(
+                "Preserving integration mapping %s outside manifest org scope",
+                existing_m.id,
+            )
 
         # Return empty list — all operations executed directly above
         return []
@@ -2355,8 +2508,9 @@ class ManifestResolver:
             "organization_id": org_id,
             "dependencies": mapp.dependencies or None,
         }
-        if mapp.access_level is not None:
-            app_values["access_level"] = mapp.access_level
+        access_level = _manifest_access_level(mapp.access_level, getattr(mapp, "roles", None))
+        if access_level is not None:
+            app_values["access_level"] = access_level
 
         ops: list[SyncOp] = []
 
@@ -2844,8 +2998,12 @@ class ManifestResolver:
                 "created_by": "git-sync",
                 "organization_id": org_id,
             }
-            if mform.access_level is not None:
-                form_values["access_level"] = mform.access_level
+            access_level = _manifest_access_level(
+                mform.access_level,
+                getattr(mform, "roles", None),
+            )
+            if access_level is not None:
+                form_values["access_level"] = access_level
             ops.append(Upsert(
                 model=Form,
                 id=form_id,
@@ -2895,8 +3053,12 @@ class ManifestResolver:
                 "max_iterations": data.get("max_iterations"),
                 "max_token_budget": data.get("max_token_budget"),
             }
-            if magent.access_level is not None:
-                agent_values["access_level"] = magent.access_level
+            access_level = _manifest_access_level(
+                magent.access_level,
+                getattr(magent, "roles", None),
+            )
+            if access_level is not None:
+                agent_values["access_level"] = access_level
             ops.append(Upsert(
                 model=Agent,
                 id=agent_id,

--- a/api/tests/unit/services/test_github_sync_boundaries.py
+++ b/api/tests/unit/services/test_github_sync_boundaries.py
@@ -1,0 +1,64 @@
+"""Focused git-sync boundary tests."""
+
+import pytest
+
+
+def _import_github_sync_service(monkeypatch):
+    """Import github_sync without requiring GitPython in host-only test runs."""
+    import sys
+    import types
+
+    fake_git = types.ModuleType("git")
+    fake_git.Repo = object
+    monkeypatch.setitem(sys.modules, "git", fake_git)
+
+    from src.services.github_sync import GitHubSyncService
+
+    return GitHubSyncService
+
+
+class _Rows:
+    def all(self):
+        return [
+            ("workflows/old.py", "old-hash"),
+            ("workflows/other-workspace.py", "other-hash"),
+        ]
+
+
+class _FakeDb:
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _Rows()
+
+
+@pytest.mark.asyncio
+async def test_file_index_cleanup_requires_explicit_git_deleted_paths(tmp_path, monkeypatch):
+    GitHubSyncService = _import_github_sync_service(monkeypatch)
+    service = object.__new__(GitHubSyncService)
+    service.db = _FakeDb()
+
+    await GitHubSyncService._update_file_index(
+        service,
+        tmp_path,
+        removed_paths=set(),
+    )
+
+    assert len(service.db.statements) == 1
+
+
+@pytest.mark.asyncio
+async def test_file_index_cleanup_deletes_only_explicit_git_deleted_paths(tmp_path, monkeypatch):
+    GitHubSyncService = _import_github_sync_service(monkeypatch)
+    service = object.__new__(GitHubSyncService)
+    service.db = _FakeDb()
+
+    await GitHubSyncService._update_file_index(
+        service,
+        tmp_path,
+        removed_paths={"workflows/old.py"},
+    )
+
+    assert len(service.db.statements) == 2

--- a/api/tests/unit/test_manifest_diff.py
+++ b/api/tests/unit/test_manifest_diff.py
@@ -1,7 +1,7 @@
 """Tests for manifest diff logic (_diff_and_collect).
 
 Validates round-trip fidelity (YAML → parse → diff should show no changes),
-correct detection of add/update/delete, and interaction with UI-managed fields
+correct detection of add/update/delete, and safe handling for UI-managed fields
 like oauth_token_id that are set in the platform UI but not in local YAML.
 """
 import copy
@@ -281,13 +281,14 @@ class TestRoundTripFidelity:
         )
         assert changed_ids == set()
 
-    def test_ui_managed_fields_cause_diff(self, kitchen_sink_manifest: Manifest):
+    def test_ui_managed_oauth_token_id_does_not_cause_diff(self, kitchen_sink_manifest: Manifest):
         """Local manifest without oauth_token_id vs DB manifest with it set.
 
-        Documents whether this causes a false-positive "update" in the diff.
         This is the scenario: user defines integration in YAML without
         oauth_token_id, then connects OAuth in the UI. On next startup,
         local YAML has oauth_token_id=None, DB has it populated.
+        The token link is environment-owned and must not trigger a manifest
+        import update.
         """
         # "Local" manifest: no oauth_token_id
         local = copy.deepcopy(kitchen_sink_manifest)
@@ -298,15 +299,8 @@ class TestRoundTripFidelity:
 
         changes, changed_ids = _diff_and_collect(local, db_side)
 
-        # Document current behavior — this test tells us if the diff catches it
-        integration_changes = [c for c in changes if c["entity_type"] == "integrations"]
-        # We expect this IS flagged as update (the field differs), which is
-        # the root cause of false positives. If this assertion passes, the
-        # hypothesis is confirmed.
-        assert len(integration_changes) == 1, (
-            "Expected oauth_token_id mismatch to cause a diff"
-        )
-        assert integration_changes[0]["action"] == "update"
+        assert changes == []
+        assert changed_ids == set()
 
     def test_secret_config_round_trip(self, kitchen_sink_manifest: Manifest):
         """Config with config_type=secret, value=None on both sides → no diff."""

--- a/api/tests/unit/test_manifest_import.py
+++ b/api/tests/unit/test_manifest_import.py
@@ -9,9 +9,15 @@ import pytest
 from pydantic import ValidationError
 
 from bifrost.manifest import (
+    Manifest,
     ManifestApp,
+    ManifestConfig,
+    ManifestEventSource,
+    ManifestIntegration,
+    ManifestIntegrationMapping,
     ManifestPolicy,
     ManifestTable,
+    ManifestWorkflow,
 )
 from src.models.contracts.policies import TablePolicies
 
@@ -233,6 +239,171 @@ class TestManifestDestructiveScope:
         changes, _changed_ids = _diff_and_collect(incoming, current)
 
         assert _collect_removed_entity_ids(changes) == {}
+
+    def test_scope_filter_does_not_delete_non_file_sections_when_manifest_omits_them(self):
+        from src.services.manifest_import import (
+            _collect_removed_entity_ids,
+            _diff_and_collect,
+            _filter_manifest_to_scope,
+        )
+
+        org_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        workflow_id = "11111111-1111-1111-1111-111111111111"
+        integration_id = "22222222-2222-2222-2222-222222222222"
+        config_id = "33333333-3333-3333-3333-333333333333"
+        table_id = "44444444-4444-4444-4444-444444444444"
+        event_id = "55555555-5555-5555-5555-555555555555"
+        incoming = Manifest(workflows={
+            workflow_id: ManifestWorkflow(
+                id=workflow_id,
+                path="workflows/local.py",
+                function_name="local",
+                organization_id=org_id,
+            ),
+        })
+        current = Manifest(
+            workflows={
+                workflow_id: ManifestWorkflow(
+                    id=workflow_id,
+                    path="workflows/local.py",
+                    function_name="local",
+                    organization_id=org_id,
+                ),
+            },
+            integrations={
+                integration_id: ManifestIntegration(
+                    id=integration_id,
+                    mappings=[
+                        ManifestIntegrationMapping(
+                            organization_id=org_id,
+                            entity_id="tenant-1",
+                        ),
+                    ],
+                ),
+            },
+            configs={
+                config_id: ManifestConfig(
+                    id=config_id,
+                    key="api_url",
+                    organization_id=org_id,
+                ),
+            },
+            tables={
+                table_id: ManifestTable(
+                    id=table_id,
+                    name="tickets",
+                    organization_id=org_id,
+                ),
+            },
+            events={
+                event_id: ManifestEventSource(
+                    id=event_id,
+                    name="tickets",
+                    source_type="webhook",
+                    organization_id=org_id,
+                ),
+            },
+        )
+
+        _filter_manifest_to_scope(
+            current,
+            path_exists=lambda path: path == "workflows/local.py",
+            dir_exists=lambda path: False,
+            scope_manifest=incoming,
+        )
+        changes, _changed_ids = _diff_and_collect(incoming, current)
+
+        assert _collect_removed_entity_ids(changes) == {}
+
+    def test_scope_filter_limits_non_file_deletes_to_declared_org_scope(self):
+        from src.services.manifest_import import (
+            _collect_removed_entity_ids,
+            _diff_and_collect,
+            _filter_manifest_to_scope,
+        )
+
+        org_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        org_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        kept_config = "11111111-1111-1111-1111-111111111111"
+        removed_config = "22222222-2222-2222-2222-222222222222"
+        unrelated_config = "33333333-3333-3333-3333-333333333333"
+        incoming = Manifest(configs={
+            kept_config: ManifestConfig(
+                id=kept_config,
+                key="api_url",
+                organization_id=org_a,
+            ),
+        })
+        current = Manifest(configs={
+            kept_config: ManifestConfig(
+                id=kept_config,
+                key="api_url",
+                organization_id=org_a,
+            ),
+            removed_config: ManifestConfig(
+                id=removed_config,
+                key="old_api_url",
+                organization_id=org_a,
+            ),
+            unrelated_config: ManifestConfig(
+                id=unrelated_config,
+                key="other_org_api_url",
+                organization_id=org_b,
+            ),
+        })
+
+        _filter_manifest_to_scope(
+            current,
+            path_exists=lambda path: False,
+            dir_exists=lambda path: False,
+            scope_manifest=incoming,
+        )
+        changes, _changed_ids = _diff_and_collect(incoming, current)
+
+        assert _collect_removed_entity_ids(changes) == {
+            "configs": {removed_config},
+        }
+
+    def test_oauth_token_id_is_ignored_for_manifest_diff(self):
+        from src.services.manifest_import import _diff_and_collect
+
+        integration_id = "11111111-1111-1111-1111-111111111111"
+        incoming = Manifest(integrations={
+            integration_id: ManifestIntegration(
+                id=integration_id,
+                mappings=[
+                    ManifestIntegrationMapping(
+                        organization_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        entity_id="tenant-1",
+                        oauth_token_id="22222222-2222-2222-2222-222222222222",
+                    ),
+                ],
+            ),
+        })
+        current = Manifest(integrations={
+            integration_id: ManifestIntegration(
+                id=integration_id,
+                mappings=[
+                    ManifestIntegrationMapping(
+                        organization_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        entity_id="tenant-1",
+                        oauth_token_id="33333333-3333-3333-3333-333333333333",
+                    ),
+                ],
+            ),
+        })
+
+        changes, changed_ids = _diff_and_collect(incoming, current)
+
+        assert changes == []
+        assert changed_ids == set()
+
+    def test_roles_default_to_role_based_when_access_level_is_omitted(self):
+        from src.services.manifest_import import _manifest_access_level
+
+        assert _manifest_access_level(None, ["role-id"]) == "role_based"
+        assert _manifest_access_level(None, []) is None
+        assert _manifest_access_level("authenticated", ["role-id"]) == "authenticated"
 
 
 class TestManifestAppPathSafety:


### PR DESCRIPTION
## Summary
- scope manifest delete diffs to repo-owned paths and explicitly declared org/entity sections
- ignore manifest OAuth token IDs during diff/import and preserve existing environment-owned mappings
- constrain app preview/import paths to safe app roots and gate file-index cleanup on Git-deleted paths
- add focused regression tests for destructive sync/import boundaries

## Verification
- ruff check api/src/services/github_sync.py api/src/services/manifest_import.py api/tests/unit/test_manifest_import.py api/tests/unit/test_manifest_diff.py api/tests/unit/services/test_github_sync_boundaries.py
- python -m pytest api/tests/unit/test_manifest_import.py api/tests/unit/test_manifest_diff.py api/tests/unit/services/test_github_sync_boundaries.py -q
- git diff --check

Note: ./test.sh stack up was attempted, but Docker Desktop was not running on this workstation.