### PR TITLE
Harden CLI OAuth secret contracts

### DIFF
--- a/api/src/models/contracts/cli.py
+++ b/api/src/models/contracts/cli.py
@@ -332,7 +332,7 @@ class SDKIntegrationsRefreshTokenResponse(BaseModel):
     refreshed: bool = Field(default=True, description="True when the token refresh succeeded")
     expires_at: str | None = Field(None, description="Token expiration (ISO format)")
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
 
 
 # ==================== SDK AI MODELS ====================

--- a/api/tests/unit/models/test_cli_security_contract.py
+++ b/api/tests/unit/models/test_cli_security_contract.py
@@ -1,0 +1,35 @@
+"""Security contract tests for CLI-facing SDK models."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.contracts.cli import SDKIntegrationsRefreshTokenResponse
+
+
+def test_refresh_token_response_contract_excludes_token_material():
+    """The refresh endpoint response must contain status metadata only."""
+    response = SDKIntegrationsRefreshTokenResponse(
+        refreshed=True,
+        expires_at="2026-03-02T00:00:00+00:00",
+    )
+
+    payload = response.model_dump()
+
+    assert payload == {
+        "refreshed": True,
+        "expires_at": "2026-03-02T00:00:00+00:00",
+    }
+    assert "access_token" not in payload
+    assert "refresh_token" not in payload
+    assert "client_secret" not in payload
+
+
+@pytest.mark.parametrize("field_name", ["access_token", "refresh_token", "client_secret"])
+def test_refresh_token_response_rejects_accidental_secret_fields(field_name):
+    """Accidental secret fields should fail validation instead of being ignored."""
+    with pytest.raises(ValidationError):
+        SDKIntegrationsRefreshTokenResponse(
+            refreshed=True,
+            expires_at=None,
+            **{field_name: "secret-value"},
+        )

--- a/api/tests/unit/routers/test_cli_config_secret.py
+++ b/api/tests/unit/routers/test_cli_config_secret.py
@@ -89,6 +89,55 @@ class TestConfigGetDecryptsSecrets:
         assert result.config_type == "string"
 
 
+class TestConfigGetScopeAuthorization:
+    """Verify unauthorized scopes cannot reach secret config resolution."""
+
+    @pytest.mark.asyncio
+    async def test_regular_user_global_scope_denied_before_secret_lookup(self):
+        """config/get must not resolve or decrypt global secrets for regular users."""
+        from fastapi import HTTPException
+        from src.routers.cli import cli_get_config
+        from src.models.contracts.cli import CLIConfigGetRequest
+
+        mock_user = MagicMock()
+        mock_user.user_id = "test-user-id"
+        mock_user.organization_id = "11111111-1111-1111-1111-111111111111"
+        mock_user.is_superuser = False
+
+        request = CLIConfigGetRequest(key="api_key", scope="global")
+
+        with patch("src.core.config_resolver.ConfigResolver") as resolver_class:
+            with pytest.raises(HTTPException) as exc:
+                await cli_get_config(request=request, current_user=mock_user, db=AsyncMock())
+
+        assert exc.value.status_code == 403
+        resolver_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_regular_user_other_org_scope_denied_before_secret_lookup(self):
+        """config/get must not resolve or decrypt another org's secrets."""
+        from fastapi import HTTPException
+        from src.routers.cli import cli_get_config
+        from src.models.contracts.cli import CLIConfigGetRequest
+
+        mock_user = MagicMock()
+        mock_user.user_id = "test-user-id"
+        mock_user.organization_id = "11111111-1111-1111-1111-111111111111"
+        mock_user.is_superuser = False
+
+        request = CLIConfigGetRequest(
+            key="api_key",
+            scope="22222222-2222-2222-2222-222222222222",
+        )
+
+        with patch("src.core.config_resolver.ConfigResolver") as resolver_class:
+            with pytest.raises(HTTPException) as exc:
+                await cli_get_config(request=request, current_user=mock_user, db=AsyncMock())
+
+        assert exc.value.status_code == 403
+        resolver_class.assert_not_called()
+
+
 class TestConfigListMasksSecrets:
     """Verify that cli_list_config always masks secret values with [SECRET]."""
 

--- a/api/tests/unit/routers/test_cli_get_org_id.py
+++ b/api/tests/unit/routers/test_cli_get_org_id.py
@@ -128,6 +128,38 @@ async def test_regular_user_uses_own_org_for_none_scope():
 
 
 @pytest.mark.asyncio
+async def test_regular_user_can_request_own_org_explicitly():
+    """Non-superusers may target their own organization explicitly."""
+    db = AsyncMock()
+    org_id = uuid4()
+
+    result = await _get_cli_org_id(
+        _user(organization_id=org_id, is_superuser=False),
+        str(org_id),
+        db,
+    )
+
+    assert result == str(org_id)
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_regular_user_without_org_rejected():
+    """Non-superuser JWTs without org scope cannot read CLI config."""
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await _get_cli_org_id(
+            _user(organization_id=None, is_superuser=False),
+            None,
+            db,
+        )
+
+    assert exc.value.status_code == 403
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_regular_user_cannot_request_another_org():
     """Non-superusers cannot use the CLI scope parameter to read another org."""
     db = AsyncMock()


### PR DESCRIPTION
## Summary
- reject accidental token fields on the CLI OAuth refresh response contract
- add regression coverage for refresh responses without token material
- add CLI config scope tests proving regular users cannot reach global or other-org secret lookup

## Verification
- git diff --check
- python -m ruff check api/src/models/contracts/cli.py api/tests/unit/routers/test_cli_config_secret.py api/tests/unit/routers/test_cli_get_org_id.py api/tests/unit/models/test_cli_security_contract.py
- pve-t340 VM 101: bash ./test.sh tests/unit/models/test_cli_security_contract.py tests/unit/routers/test_cli_get_org_id.py tests/unit/routers/test_cli_config_secret.py tests/unit/routers/test_cli_auto_refresh.py tests/unit/routers/test_cli_refresh_token.py