### PR TITLE
Harden Codex Gateway key authentication

### DIFF
--- a/api/src/repositories/codex_gateway.py
+++ b/api/src/repositories/codex_gateway.py
@@ -2,14 +2,17 @@
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
+import hmac
 import secrets
 from typing import Any, TypeGuard
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.core.security import encrypt_secret, get_password_hash, verify_password
+from src.config import get_settings
+from src.core.security import encrypt_secret
 from src.models.orm.codex_gateway import (
     CodexGatewayKey,
     CodexGatewayRequestLog,
@@ -32,6 +35,8 @@ CODEX_GATEWAY_KEY_MAX_LENGTH = 256
 CODEX_GATEWAY_KEY_BODY_CHARS = frozenset(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
 )
+CODEX_GATEWAY_KEY_HASH_PREFIX = "sha256:"
+MAX_ACTIVE_GATEWAY_KEYS_PER_USER = 10
 
 
 def is_plausible_gateway_key(value: str | None) -> TypeGuard[str]:
@@ -52,6 +57,10 @@ class CodexGatewayKeyMaterial:
     plaintext_key: str
 
 
+class CodexGatewayKeyLimitError(Exception):
+    """Raised when a user has reached the active gateway key quota."""
+
+
 class CodexGatewayRepository:
     """Repository for gateway keys, upstream accounts, and request logs."""
 
@@ -65,16 +74,23 @@ class CodexGatewayRepository:
 
     @staticmethod
     def hash_gateway_key(plaintext_key: str) -> str:
-        """Hash a gateway key for storage."""
-        return get_password_hash(plaintext_key)
+        """Return the indexed keyed digest for a gateway key."""
+        digest = hmac.new(
+            get_settings().secret_key.encode("utf-8"),
+            plaintext_key.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"{CODEX_GATEWAY_KEY_HASH_PREFIX}{digest}"
 
     @staticmethod
     def verify_gateway_key(plaintext_key: str, key_hash: str) -> bool:
-        """Verify a gateway key without leaking hash parsing failures."""
-        try:
-            return verify_password(plaintext_key, key_hash)
-        except Exception:
+        """Verify a gateway key digest in constant time."""
+        if not key_hash.startswith(CODEX_GATEWAY_KEY_HASH_PREFIX):
             return False
+        return hmac.compare_digest(
+            CodexGatewayRepository.hash_gateway_key(plaintext_key),
+            key_hash,
+        )
 
     async def create_gateway_key(
         self,
@@ -87,6 +103,19 @@ class CodexGatewayRepository:
         daily_limit: int | None = None,
         monthly_limit: int | None = None,
     ) -> CodexGatewayKeyMaterial:
+        result = await self.session.execute(
+            select(func.count())
+            .select_from(CodexGatewayKey)
+            .where(CodexGatewayKey.user_id == user_id)
+            .where(CodexGatewayKey.status == "active")
+            .where(CodexGatewayKey.revoked_at.is_(None))
+        )
+        active_key_count = int(result.scalar_one() or 0)
+        if active_key_count >= MAX_ACTIVE_GATEWAY_KEYS_PER_USER:
+            raise CodexGatewayKeyLimitError(
+                f"At most {MAX_ACTIVE_GATEWAY_KEYS_PER_USER} active Codex Gateway keys are allowed per user"
+            )
+
         plaintext_key = self.generate_gateway_key()
         record = CodexGatewayKey(
             user_id=user_id,
@@ -109,18 +138,21 @@ class CodexGatewayRepository:
         if not is_plausible_gateway_key(plaintext_key):
             return None
 
+        key_hash = self.hash_gateway_key(plaintext_key)
         result = await self.session.execute(
             select(CodexGatewayKey)
             .where(CodexGatewayKey.status == "active")
             .where(CodexGatewayKey.revoked_at.is_(None))
+            .where(CodexGatewayKey.key_hash == key_hash)
         )
-        candidates = result.scalars().all()
-        for candidate in candidates:
-            if candidate.status != "active" or candidate.revoked_at is not None:
-                continue
-            if self.verify_gateway_key(plaintext_key, candidate.key_hash):
-                return candidate
-        return None
+        candidate = result.scalar_one_or_none()
+        if candidate is None:
+            return None
+        if candidate.status != "active" or candidate.revoked_at is not None:
+            return None
+        if not self.verify_gateway_key(plaintext_key, candidate.key_hash):
+            return None
+        return candidate
 
     async def list_gateway_keys_for_user(self, user_id: UUID) -> list[CodexGatewayKey]:
         result = await self.session.execute(

--- a/api/src/repositories/codex_gateway.py
+++ b/api/src/repositories/codex_gateway.py
@@ -18,6 +18,7 @@ from src.models.orm.codex_gateway import (
     CodexGatewayRequestLog,
     CodexGatewayUpstreamAccount,
 )
+from src.models.orm.users import User
 
 
 SENSITIVE_METADATA_KEYS = {
@@ -103,6 +104,12 @@ class CodexGatewayRepository:
         daily_limit: int | None = None,
         monthly_limit: int | None = None,
     ) -> CodexGatewayKeyMaterial:
+        lock_result = await self.session.execute(
+            select(User.id).where(User.id == user_id).with_for_update()
+        )
+        if lock_result.scalar_one_or_none() is None:
+            raise ValueError("Cannot create Codex Gateway key for unknown user")
+
         result = await self.session.execute(
             select(func.count())
             .select_from(CodexGatewayKey)

--- a/api/src/routers/codex_gateway.py
+++ b/api/src/routers/codex_gateway.py
@@ -24,6 +24,7 @@ from src.models.contracts.codex_gateway import (
     OpenAICompatibleError,
 )
 from src.repositories.codex_gateway import (
+    CodexGatewayKeyLimitError,
     CodexGatewayRepository,
     is_plausible_gateway_key,
 )
@@ -107,15 +108,21 @@ async def create_gateway_key(
     ],
     db: DbSession,
 ) -> CodexGatewayKeyCreateResponse:
-    material = await repository.create_gateway_key(
-        user_id=current_user.user_id,
-        project_id=payload.project_id,
-        name=payload.name,
-        allowed_models=payload.allowed_models,
-        denied_models=payload.denied_models,
-        daily_limit=payload.daily_limit,
-        monthly_limit=payload.monthly_limit,
-    )
+    try:
+        material = await repository.create_gateway_key(
+            user_id=current_user.user_id,
+            project_id=payload.project_id,
+            name=payload.name,
+            allowed_models=payload.allowed_models,
+            denied_models=payload.denied_models,
+            daily_limit=payload.daily_limit,
+            monthly_limit=payload.monthly_limit,
+        )
+    except CodexGatewayKeyLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
     await emit_audit(
         db,
         "codex_gateway.key.create",

--- a/api/tests/unit/repositories/test_codex_gateway_repository.py
+++ b/api/tests/unit/repositories/test_codex_gateway_repository.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -6,8 +5,10 @@ import pytest
 
 from src.core.security import decrypt_secret
 from src.repositories.codex_gateway import (
+    CodexGatewayKeyLimitError,
     CodexGatewayKeyMaterial,
     CodexGatewayRepository,
+    MAX_ACTIVE_GATEWAY_KEYS_PER_USER,
 )
 
 VALID_GATEWAY_KEY = f"bfck_{'a' * 43}"
@@ -27,6 +28,9 @@ class _Result:
         self._values = values or []
 
     def scalar_one_or_none(self):
+        return self._one
+
+    def scalar_one(self):
         return self._one
 
     def scalars(self):
@@ -53,6 +57,7 @@ async def test_create_gateway_key_hashes_secret_and_returns_key_material(
 ):
     user_id = uuid4()
     project_id = uuid4()
+    mock_session.execute.return_value = _Result(one=0)
 
     result = await repository.create_gateway_key(
         user_id=user_id,
@@ -67,30 +72,67 @@ async def test_create_gateway_key_hashes_secret_and_returns_key_material(
     assert result.record.user_id == user_id
     assert result.record.project_id == project_id
     assert result.record.key_hash != result.plaintext_key
-    assert result.record.key_hash.startswith("$")
+    assert result.record.key_hash.startswith("sha256:")
     assert result.record.allowed_models == ["gpt-5.1-codex"]
     assert result.record.daily_limit == 100
+    mock_session.execute.assert_called_once()
     mock_session.add.assert_called_once()
     mock_session.flush.assert_called_once()
     mock_session.refresh.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_lookup_gateway_key_uses_hash_and_ignores_revoked_keys(
+async def test_create_gateway_key_enforces_active_key_quota(
+    repository,
+    mock_session,
+):
+    mock_session.execute.return_value = _Result(one=MAX_ACTIVE_GATEWAY_KEYS_PER_USER)
+
+    with pytest.raises(CodexGatewayKeyLimitError):
+        await repository.create_gateway_key(
+            user_id=uuid4(),
+            project_id=None,
+            name="extra key",
+        )
+
+    mock_session.add.assert_not_called()
+    mock_session.flush.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_gateway_key_uses_indexed_hash(
     repository,
     mock_session,
 ):
     plaintext = VALID_GATEWAY_KEY
     key_hash = repository.hash_gateway_key(plaintext)
     active_record = MagicMock(key_hash=key_hash, revoked_at=None, status="active")
-    revoked_record = MagicMock(
-        key_hash=key_hash, revoked_at=datetime.now(timezone.utc), status="revoked"
-    )
-    mock_session.execute.return_value = _Result(values=[revoked_record, active_record])
+    mock_session.execute.return_value = _Result(one=active_record)
 
     result = await repository.get_active_gateway_key_by_plaintext(plaintext)
 
     assert result is active_record
+    mock_session.execute.assert_called_once()
+    statement = mock_session.execute.call_args.args[0]
+    compiled = str(statement.compile(compile_kwargs={"literal_binds": False}))
+    assert "codex_gateway_keys.key_hash" in compiled
+
+
+@pytest.mark.asyncio
+async def test_lookup_gateway_key_rejects_legacy_bcrypt_hash_without_scan(
+    repository,
+    mock_session,
+):
+    legacy_record = MagicMock(
+        key_hash="$2b$12$legacybcryptvalue",
+        revoked_at=None,
+        status="active",
+    )
+    mock_session.execute.return_value = _Result(one=legacy_record)
+
+    result = await repository.get_active_gateway_key_by_plaintext(VALID_GATEWAY_KEY)
+
+    assert result is None
     mock_session.execute.assert_called_once()
 
 

--- a/api/tests/unit/repositories/test_codex_gateway_repository.py
+++ b/api/tests/unit/repositories/test_codex_gateway_repository.py
@@ -57,7 +57,7 @@ async def test_create_gateway_key_hashes_secret_and_returns_key_material(
 ):
     user_id = uuid4()
     project_id = uuid4()
-    mock_session.execute.return_value = _Result(one=0)
+    mock_session.execute.side_effect = [_Result(one=user_id), _Result(one=0)]
 
     result = await repository.create_gateway_key(
         user_id=user_id,
@@ -75,7 +75,10 @@ async def test_create_gateway_key_hashes_secret_and_returns_key_material(
     assert result.record.key_hash.startswith("sha256:")
     assert result.record.allowed_models == ["gpt-5.1-codex"]
     assert result.record.daily_limit == 100
-    mock_session.execute.assert_called_once()
+    assert mock_session.execute.await_count == 2
+    lock_statement = mock_session.execute.await_args_list[0].args[0]
+    compiled_lock = str(lock_statement.compile(compile_kwargs={"literal_binds": False}))
+    assert "FOR UPDATE" in compiled_lock
     mock_session.add.assert_called_once()
     mock_session.flush.assert_called_once()
     mock_session.refresh.assert_called_once()
@@ -86,15 +89,39 @@ async def test_create_gateway_key_enforces_active_key_quota(
     repository,
     mock_session,
 ):
-    mock_session.execute.return_value = _Result(one=MAX_ACTIVE_GATEWAY_KEYS_PER_USER)
+    user_id = uuid4()
+    mock_session.execute.side_effect = [
+        _Result(one=user_id),
+        _Result(one=MAX_ACTIVE_GATEWAY_KEYS_PER_USER),
+    ]
 
     with pytest.raises(CodexGatewayKeyLimitError):
         await repository.create_gateway_key(
-            user_id=uuid4(),
+            user_id=user_id,
             project_id=None,
             name="extra key",
         )
 
+    assert mock_session.execute.await_count == 2
+    mock_session.add.assert_not_called()
+    mock_session.flush.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_gateway_key_fails_for_unknown_user_before_insert(
+    repository,
+    mock_session,
+):
+    mock_session.execute.return_value = _Result(one=None)
+
+    with pytest.raises(ValueError):
+        await repository.create_gateway_key(
+            user_id=uuid4(),
+            project_id=None,
+            name="orphan key",
+        )
+
+    mock_session.execute.assert_awaited_once()
     mock_session.add.assert_not_called()
     mock_session.flush.assert_not_called()
 


### PR DESCRIPTION
## Summary
- store newly issued Codex Gateway keys as indexed HMAC-SHA256 digests instead of bcrypt hashes
- authenticate gateway keys by exact digest lookup instead of scanning active keys
- cap users at 10 active gateway keys and return 429 when the quota is reached

## Security
Addresses the Codex Security findings for public Codex Gateway key-scan DoS and unbounded gateway key creation. Existing legacy bcrypt gateway keys fail closed on this path and should be rotated.

## Verification
- python -m ruff check api/src/repositories/codex_gateway.py api/src/routers/codex_gateway.py api/tests/unit/repositories/test_codex_gateway_repository.py
- pytest tests/unit/repositories/test_codex_gateway_repository.py tests/unit/services/test_codex_gateway_runtime.py -q

Note: collecting tests/unit/routers/test_codex_gateway.py in the local workstation Python env is blocked by missing aio_pika.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced per-user active gateway key quota limit (maximum 10 keys).
  * HTTP 429 Too Many Requests response when exceeding the key quota.
  * Enhanced gateway key security with improved hashing and validation mechanisms.

* **Tests**
  * Updated tests to verify new gateway key quota enforcement and hashing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->