### PR TITLE
fix: prevent org-scoped OAuth lookups from returning global tokens

### DIFF
--- a/api/src/repositories/integrations.py
+++ b/api/src/repositories/integrations.py
@@ -762,9 +762,7 @@ class IntegrationsRepository(BaseRepository[Integration]):
                     OAuthToken.user_id.is_(None),
                 ).order_by(OAuthToken.created_at.desc(), OAuthToken.id.desc())
             )
-            token = result.scalars().first()
-            if token:
-                return token
+            return result.scalars().first()
 
         result = await self.session.execute(
             select(OAuthToken).where(

--- a/api/src/services/oauth_scope_resolution.py
+++ b/api/src/services/oauth_scope_resolution.py
@@ -35,7 +35,7 @@ async def get_oauth_provider_for_scope(
 async def get_oauth_token_for_scope(
     db: AsyncSession, provider_id: UUID, org_uuid: UUID | None
 ) -> OAuthToken | None:
-    """Load an org-level OAuth token, falling back to the global provider token."""
+    """Load an OAuth token for the caller scope without crossing org/global boundaries."""
     if org_uuid is not None:
         result = await db.execute(
             select(OAuthToken)
@@ -46,9 +46,7 @@ async def get_oauth_token_for_scope(
             )
             .order_by(OAuthToken.created_at.desc(), OAuthToken.id.desc())
         )
-        token = result.scalars().first()
-        if token:
-            return token
+        return result.scalars().first()
 
     result = await db.execute(
         select(OAuthToken)

--- a/api/tests/unit/repositories/test_integrations_repository.py
+++ b/api/tests/unit/repositories/test_integrations_repository.py
@@ -153,25 +153,21 @@ class TestIntegrationsRepository:
         assert result is None
         mock_session.execute.assert_called_once()
 
-    async def test_get_provider_org_token_falls_back_to_global_token(
+    async def test_get_provider_org_token_does_not_fall_back_to_global_token(
         self, repository, mock_session
     ):
-        """Org-scoped lookups should fall back to the provider-level token."""
+        """Org-scoped lookups must not return global provider tokens."""
         provider_id = uuid4()
         organization_id = uuid4()
-        global_token = MagicMock()
-        global_token.organization_id = None
 
         org_result = MagicMock()
         org_result.scalars.return_value.first.return_value = None
-        global_result = MagicMock()
-        global_result.scalars.return_value.first.return_value = global_token
-        mock_session.execute.side_effect = [org_result, global_result]
+        mock_session.execute.return_value = org_result
 
         result = await repository.get_provider_org_token(provider_id, organization_id)
 
-        assert result == global_token
-        assert mock_session.execute.call_count == 2
+        assert result is None
+        mock_session.execute.assert_called_once()
 
     async def test_get_provider_org_token_prefers_org_specific_token(
         self, repository, mock_session

--- a/api/tests/unit/routers/test_cli_refresh_token.py
+++ b/api/tests/unit/routers/test_cli_refresh_token.py
@@ -245,8 +245,8 @@ class TestRefreshTokenClientCredentials:
         assert created_token.organization_id == org_id
 
     @pytest.mark.asyncio
-    async def test_scoped_refresh_falls_back_to_global_provider_and_token(self):
-        """Scoped refresh should work when the provider/token are global rows."""
+    async def test_scoped_refresh_uses_org_scoped_token_persistence(self):
+        """Scoped refresh should create/update org-scoped token rows only."""
         from src.routers.cli import sdk_integrations_refresh_token
         from src.models.contracts.cli import SDKIntegrationsRefreshTokenRequest
 
@@ -275,24 +275,18 @@ class TestRefreshTokenClientCredentials:
         mock_provider.organization_id = None
         mock_provider.audience = None
 
-        mock_existing_token = MagicMock()
-        mock_existing_token.organization_id = None
-
         scoped_provider_result = MagicMock()
         scoped_provider_result.scalars.return_value.first.return_value = None
         global_provider_result = MagicMock()
         global_provider_result.scalars.return_value.first.return_value = mock_provider
         scoped_token_result = MagicMock()
         scoped_token_result.scalars.return_value.first.return_value = None
-        global_token_result = MagicMock()
-        global_token_result.scalars.return_value.first.return_value = mock_existing_token
 
         mock_db.execute = AsyncMock(
             side_effect=[
                 scoped_provider_result,
                 global_provider_result,
                 scoped_token_result,
-                global_token_result,
             ]
         )
         mock_db.add = MagicMock()
@@ -323,9 +317,10 @@ class TestRefreshTokenClientCredentials:
             result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
 
         assert result.refreshed is True
-        assert mock_db.execute.call_count == 4
-        mock_db.add.assert_not_called()
-        assert mock_existing_token.expires_at == expires_at
+        assert mock_db.execute.call_count == 3
+        mock_db.add.assert_called_once()
+        created_token = mock_db.add.call_args.args[0]
+        assert created_token.organization_id == org_id
 
     @pytest.mark.asyncio
     async def test_global_refresh_only_selects_global_provider(self):


### PR DESCRIPTION
### Motivation
- Close a tenant/global secret-boundary violation where org-scoped SDK/CLI requests could fall back to global provider/token rows and expose or overwrite platform-level OAuth secrets.

### Description
- Stop org-scoped lookups from falling back to global rows by returning the org-scoped `OAuthToken` result directly in `IntegrationsRepository.get_provider_org_token` (`api/src/repositories/integrations.py`).
- Apply the same strict scoping to the shared helper `get_oauth_token_for_scope` so refresh flows cannot select global token rows for org-scoped callers (`api/src/services/oauth_scope_resolution.py`).
- Update unit tests to assert the secure behavior: repository test now expects no fallback to global tokens and refresh-token tests now assert org-scoped token persistence/creation instead of reusing global rows (`api/tests/unit/repositories/test_integrations_repository.py`, `api/tests/unit/routers/test_cli_refresh_token.py`).

### Testing
- Ran the focused repository unit test `pytest -q api/tests/unit/repositories/test_integrations_repository.py::TestIntegrationsRepository::test_get_provider_org_token_does_not_fall_back_to_global_token` and it passed.
- Ran the focused refresh-token unit test `pytest -q api/tests/unit/routers/test_cli_refresh_token.py::TestRefreshTokenClientCredentials::test_scoped_refresh_uses_org_scoped_token_persistence` and it passed.
- Both targeted tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a3fe030c832884cf6c72c12a04e0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth token scoping behavior. Organization-scoped token lookups no longer fall back to global provider tokens, ensuring tokens remain properly isolated per organization.

* **Documentation**
  * Updated OAuth scope resolution documentation to clarify token lookup boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->