### PR TITLE
Harden local file backend path resolution

### DIFF
--- a/api/src/services/file_backend.py
+++ b/api/src/services/file_backend.py
@@ -9,12 +9,13 @@ S3 key resolution is delegated to `shared.file_paths.resolve_s3_key`.
 """
 
 import asyncio
+import os
 from abc import ABC, abstractmethod
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from shared.file_paths import resolve_s3_key
+from shared.file_paths import resolve_s3_key, validate_location_name
 from src.core.paths import TEMP_PATH, UPLOADS_PATH
 from src.services.file_storage import FileStorageService
 
@@ -28,6 +29,23 @@ def _validate_workspace_path(path: str) -> str:
     """Validate a workspace-relative path and return its normalized form."""
     s3_key = resolve_s3_key("workspace", None, path)
     return s3_key.removeprefix(_REPO_PREFIX)
+
+
+def _validate_local_relative_path(path: str) -> Path:
+    """Validate an API path before resolving it against a local sandbox root."""
+    if "\x00" in path:
+        raise ValueError(f"Invalid path: contains NUL byte: {path!r}")
+
+    normalized = path.replace("\\", "/")
+    path_obj = Path(path)
+    if path_obj.is_absolute() or PureWindowsPath(path).drive or normalized.startswith("/"):
+        raise ValueError(f"Invalid path: must be relative: {path}")
+
+    parts = [part for part in normalized.split("/") if part not in ("", ".")]
+    if ".." in parts:
+        raise ValueError(f"Invalid path: path traversal not allowed: {path}")
+
+    return Path(*parts) if parts else Path()
 
 
 class FileBackend(ABC):
@@ -77,6 +95,8 @@ class LocalBackend(FileBackend):
 
         Local mode is unscoped — used for CLI development without multi-tenancy.
         """
+        validate_location_name(location)
+
         if location == "temp":
             base_dir = self.temp_root
         elif location == "uploads":
@@ -87,22 +107,24 @@ class LocalBackend(FileBackend):
             # Freeform local locations are siblings of workspace_root.
             base_dir = self.workspace_root.parent / location
 
-        # Resolve the path
-        p = Path(path)
-        if not p.is_absolute():
-            p = base_dir / p
+        relative_path = _validate_local_relative_path(path)
 
         try:
-            p = p.resolve()
+            base_path = os.path.realpath(str(base_dir.resolve()))
+            p = Path(os.path.realpath(os.path.join(base_path, str(relative_path))))
         except Exception as e:
             raise ValueError(f"Invalid path: {path}") from e
 
         # Sandbox check - ensure path is within the base directory.
-        # Use relative_to() rather than str.startswith() to avoid sibling-prefix
-        # confusion (e.g., base "/tmp/foo" would otherwise accept "/tmp/foo_evil/x").
-        base_resolved = base_dir.resolve()
+        # Include the path separator when checking the normalized string form to
+        # avoid sibling-prefix confusion (base "/tmp/foo" vs "/tmp/foo_evil/x").
+        base_prefix = base_path if base_path.endswith(os.sep) else f"{base_path}{os.sep}"
+        if str(p) != base_path and not str(p).startswith(base_prefix):
+            raise ValueError(f"Path must be within {location} directory: {path}")
+
+        # Keep a Path-native containment check as defense in depth.
         try:
-            p.relative_to(base_resolved)
+            p.relative_to(Path(base_path))
         except ValueError as e:
             raise ValueError(f"Path must be within {location} directory: {path}") from e
 

--- a/api/tests/unit/services/test_file_backend.py
+++ b/api/tests/unit/services/test_file_backend.py
@@ -148,19 +148,30 @@ class TestLocalBackendSandbox:
     def test_parent_traversal_is_rejected(self, tmp_path: Path):
         backend = self._make_backend(tmp_path)
 
-        with pytest.raises(ValueError, match="must be within workspace"):
+        with pytest.raises(ValueError, match="path traversal"):
             backend._resolve_path("../escape.txt", "workspace")
 
-    def test_sibling_prefix_confusion_is_rejected(self, tmp_path: Path):
-        """A path that resolves to a sibling directory sharing a string prefix
-        with the sandbox base must be rejected — the old startswith() check
-        accepted these (e.g., base /tmp/foo vs /tmp/foo_evil/x)."""
+    def test_backslash_parent_traversal_is_rejected(self, tmp_path: Path):
         backend = self._make_backend(tmp_path)
-        # Create a real sibling whose name starts with the temp root's name.
-        sibling = backend.temp_root.parent / (backend.temp_root.name + "_evil")
-        sibling.mkdir()
-        attack = sibling / "x"
-        attack.write_text("nope")
 
-        with pytest.raises(ValueError, match="must be within temp"):
-            backend._resolve_path(str(attack), "temp")
+        with pytest.raises(ValueError, match="path traversal"):
+            backend._resolve_path(r"..\escape.txt", "workspace")
+
+    def test_absolute_path_is_rejected_before_filesystem_access(self, tmp_path: Path):
+        backend = self._make_backend(tmp_path)
+
+        with pytest.raises(ValueError, match="must be relative"):
+            backend._resolve_path(str(tmp_path / "temp_evil" / "x"), "temp")
+
+    def test_location_parent_traversal_is_rejected(self, tmp_path: Path):
+        backend = self._make_backend(tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid location name"):
+            backend._resolve_path("safe.txt", "../outside")
+
+    def test_safe_freeform_location_resolves_as_workspace_sibling(self, tmp_path: Path):
+        backend = self._make_backend(tmp_path)
+
+        resolved = backend._resolve_path("q1.txt", "reports")
+
+        assert resolved == (backend.workspace_root.parent / "reports/q1.txt").resolve()


### PR DESCRIPTION
## Summary
- validate local backend locations with the shared file location policy
- reject absolute, drive-relative, NUL, and parent-traversal paths before filesystem access
- keep normalized safe-root containment checks around local filesystem sinks

## Security
Addresses the CodeQL py/path-injection cluster in api/src/services/file_backend.py (#11-#15).

## Tests
- python -m pytest api/tests/unit/services/test_file_backend.py -q
- python -m ruff check api/src/services/file_backend.py api/tests/unit/services/test_file_backend.py
- git diff --check