### PR TITLE
Fix NinjaOne OAuth refresh token exchange

### DIFF
--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -911,7 +911,12 @@ async def oauth_callback(
         defaults=defaults,
     )
 
-    # Exchange authorization code for tokens
+    # Exchange authorization code for tokens. NinjaOne returns the refresh_token
+    # only when scope is requested on the authorize URL and not replayed here.
+    token_exchange_scopes = " ".join(provider.scopes) if provider.scopes else None
+    if provider.provider_name == "NinjaOne":
+        token_exchange_scopes = None
+
     oauth_client = OAuthProviderClient()
     success, result = await oauth_client.exchange_code_for_token(
         token_url=resolved_token_url,
@@ -919,7 +924,7 @@ async def oauth_callback(
         client_id=provider.client_id,
         client_secret=client_secret,
         redirect_uri=redirect_uri,
-        scopes=" ".join(provider.scopes) if provider.scopes else None,
+        scopes=token_exchange_scopes,
         audience=provider.audience,
     )
 

--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -844,7 +844,10 @@ async def oauth_callback(
 ) -> OAuthCallbackResponse:
     """Handle OAuth callback and exchange authorization code for tokens."""
     from src.core.security import decrypt_secret
-    from src.services.oauth_provider import OAuthProviderClient
+    from src.services.oauth_provider import (
+        OAuthProviderClient,
+        compute_token_exchange_scopes,
+    )
 
     repo = OAuthConnectionRepository(ctx.db)
     # Use org_id from request body for org-specific token storage (None for global)
@@ -911,12 +914,7 @@ async def oauth_callback(
         defaults=defaults,
     )
 
-    # Exchange authorization code for tokens. NinjaOne returns the refresh_token
-    # only when scope is requested on the authorize URL and not replayed here.
-    token_exchange_scopes = " ".join(provider.scopes) if provider.scopes else None
-    if provider.provider_name == "NinjaOne":
-        token_exchange_scopes = None
-
+    # Exchange authorization code for tokens.
     oauth_client = OAuthProviderClient()
     success, result = await oauth_client.exchange_code_for_token(
         token_url=resolved_token_url,
@@ -924,7 +922,7 @@ async def oauth_callback(
         client_id=provider.client_id,
         client_secret=client_secret,
         redirect_uri=redirect_uri,
-        scopes=token_exchange_scopes,
+        scopes=compute_token_exchange_scopes(provider),
         audience=provider.audience,
     )
 

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -23,6 +23,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+PROVIDER_NINJAONE = "NinjaOne"
+
+
+def compute_token_exchange_scopes(provider: "OAuthProvider") -> str | None:
+    """Return scopes to send during authorization-code token exchange."""
+    provider_name = provider.provider_name or ""
+    if provider_name.casefold() == PROVIDER_NINJAONE.casefold():
+        return None
+
+    return " ".join(provider.scopes) if provider.scopes else None
+
 
 def resolve_url_template(
     url: str, entity_id: str | None = None, defaults: dict[str, str] | None = None

--- a/api/tests/unit/routers/test_oauth_refresh.py
+++ b/api/tests/unit/routers/test_oauth_refresh.py
@@ -171,6 +171,7 @@ class TestOAuthRefreshClientCredentials:
         from src.routers.oauth_connections import oauth_callback
 
         provider = MagicMock()
+        provider.provider_name = "Microsoft CSP"
         provider.token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
         provider.client_id = "test-client-id"
         provider.encrypted_client_secret = b"encrypted-secret"
@@ -221,6 +222,59 @@ class TestOAuthRefreshClientCredentials:
         assert mock_exchange.await_args.kwargs["scopes"] == (
             "openid offline_access https://api.partnercenter.microsoft.com/user_impersonation"
         )
+
+    @pytest.mark.asyncio
+    async def test_callback_omits_token_exchange_scope_for_ninjaone(self):
+        """NinjaOne requires offline_access on authorize, but omits refresh_token if scope is replayed."""
+        from src.models.contracts.oauth import OAuthCallbackRequest
+        from src.routers.oauth_connections import oauth_callback
+
+        provider = MagicMock()
+        provider.provider_name = "NinjaOne"
+        provider.token_url = "https://app.ninjarmm.com/oauth/token"
+        provider.client_id = "test-client-id"
+        provider.encrypted_client_secret = b"encrypted-secret"
+        provider.scopes = ["monitoring", "management", "control", "offline_access"]
+        provider.audience = None
+
+        ctx = MagicMock()
+        ctx.db = AsyncMock()
+        ctx.org_id = None
+
+        request = OAuthCallbackRequest(
+            code="authorization_code_123",
+            state="state-123",
+            redirect_uri="https://app.example.com/oauth/callback/NinjaOne",
+            organization_id=None,
+        )
+
+        with (
+            patch("src.routers.oauth_connections.OAuthConnectionRepository.get_connection", new=AsyncMock(return_value=provider)),
+            patch("src.routers.oauth_connections.OAuthConnectionRepository.store_token", new=AsyncMock()),
+            patch("src.routers.oauth_connections.get_url_resolution_defaults", new=AsyncMock(return_value={})),
+            patch("src.routers.oauth_connections.resolve_url_template", return_value=provider.token_url),
+            patch("src.services.oauth_provider.OAuthProviderClient.exchange_code_for_token", new=AsyncMock(return_value=(
+                True,
+                {
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+                    "scope": "monitoring management control offline_access",
+                },
+            ))) as mock_exchange,
+            patch("src.core.security.decrypt_secret", return_value="decrypted-secret"),
+            patch("src.routers.oauth_connections.CACHE_INVALIDATION_AVAILABLE", False),
+        ):
+            result = await oauth_callback(
+                connection_name="NinjaOne",
+                request=request,
+                ctx=ctx,
+                user=MagicMock(),
+            )
+
+        assert result.success is True
+        mock_exchange.assert_awaited_once()
+        assert mock_exchange.await_args.kwargs["scopes"] is None
 
     def test_oauth_flow_type_determines_refresh_behavior(self):
         """Flow type should determine which refresh method is used."""

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -10,7 +10,26 @@ import logging
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from src.services.oauth_provider import OAuthProviderClient
+from src.services.oauth_provider import OAuthProviderClient, compute_token_exchange_scopes
+
+
+def test_compute_token_exchange_scopes_joins_generic_provider_scopes():
+    provider = MagicMock()
+    provider.provider_name = "Microsoft CSP"
+    provider.scopes = ["openid", "offline_access", "https://example.com/read"]
+
+    assert compute_token_exchange_scopes(provider) == (
+        "openid offline_access https://example.com/read"
+    )
+
+
+@pytest.mark.parametrize("provider_name", ["NinjaOne", "ninjaone", "NINJAONE"])
+def test_compute_token_exchange_scopes_omits_ninjaone_scopes(provider_name):
+    provider = MagicMock()
+    provider.provider_name = provider_name
+    provider.scopes = ["monitoring", "management", "control", "offline_access"]
+
+    assert compute_token_exchange_scopes(provider) is None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- omit token-exchange scope replay for NinjaOne authorization-code callbacks
- keep normal scope behavior for other OAuth providers
- add regression coverage for the NinjaOne refresh-token exchange path

## Verification
- pve-t340 VM bifrost-e2e-debian13-01: python -m pytest tests/unit/routers/test_oauth_refresh.py -q -> 9 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth token exchange behavior to support provider-specific authentication requirements with improved scope handling, ensuring more reliable authorization flows and better platform compatibility.

* **Tests**
  * Added test coverage for OAuth token exchange logic to verify correct behavior across different provider configurations, including specific optimization for certain integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->