### PR TITLE
Avoid client OAuth state storage

### DIFF
--- a/client/src/pages/AuthCallback.test.tsx
+++ b/client/src/pages/AuthCallback.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { render, waitFor } from "@testing-library/react";
+
+import { AuthCallback } from "./AuthCallback";
+
+const loginWithOAuth = vi.fn();
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+	const actual =
+		await vi.importActual<typeof import("react-router-dom")>(
+			"react-router-dom",
+		);
+	return {
+		...actual,
+		useNavigate: () => navigate,
+	};
+});
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({
+		loginWithOAuth,
+	}),
+}));
+
+describe("AuthCallback", () => {
+	beforeEach(() => {
+		loginWithOAuth.mockResolvedValue(undefined);
+		navigate.mockReset();
+		sessionStorage.clear();
+		sessionStorage.setItem("oauth_state", "stale-client-state");
+	});
+
+	it("lets the server validate OAuth state instead of reading browser storage", async () => {
+		const getItem = vi.spyOn(Storage.prototype, "getItem");
+		const removeItem = vi.spyOn(Storage.prototype, "removeItem");
+
+		render(
+			<MemoryRouter
+				initialEntries={[
+					"/auth/callback/microsoft?code=auth-code&state=server-state",
+				]}
+			>
+				<Routes>
+					<Route
+						path="/auth/callback/:provider"
+						element={<AuthCallback />}
+					/>
+				</Routes>
+			</MemoryRouter>,
+		);
+
+		await waitFor(() => {
+			expect(loginWithOAuth).toHaveBeenCalledWith(
+				"microsoft",
+				"auth-code",
+				"server-state",
+			);
+		});
+		expect(navigate).toHaveBeenCalledWith("/", { replace: true });
+		expect(getItem).not.toHaveBeenCalledWith("oauth_state");
+		expect(removeItem).not.toHaveBeenCalledWith("oauth_state");
+		expect(removeItem).not.toHaveBeenCalledWith("oauth_provider");
+	});
+});

--- a/client/src/pages/AuthCallback.tsx
+++ b/client/src/pages/AuthCallback.tsx
@@ -45,20 +45,6 @@ export function AuthCallback() {
 				return;
 			}
 
-			// Get stored state
-			// Note: code_verifier is now handled server-side (stored in Redis when init is called)
-			const storedState = sessionStorage.getItem("oauth_state");
-
-			// Clear stored OAuth data
-			sessionStorage.removeItem("oauth_state");
-			sessionStorage.removeItem("oauth_provider");
-
-			// Verify state matches
-			if (state !== storedState) {
-				setError("Invalid OAuth state - possible CSRF attack");
-				return;
-			}
-
 			try {
 				// Exchange code for tokens (server handles PKCE verification)
 				await loginWithOAuth(provider, code, state);

--- a/client/src/pages/Login.test.tsx
+++ b/client/src/pages/Login.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { initOAuth } = vi.hoisted(() => ({
+	initOAuth: vi.fn(),
+}));
+
+import { Login } from "./Login";
+
+vi.mock("@/services/auth", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/services/auth")>(
+			"@/services/auth",
+		);
+	return {
+		...actual,
+		getOAuthProviders: vi.fn(async () => [
+			{ name: "microsoft", display_name: "Microsoft", icon: "microsoft" },
+		]),
+		initOAuth,
+	};
+});
+
+vi.mock("@/services/passkeys", () => ({
+	supportsPasskeys: () => false,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({
+		login: vi.fn(),
+		loginWithMfa: vi.fn(),
+		loginWithPasskey: vi.fn(),
+		isAuthenticated: false,
+		isLoading: false,
+	}),
+}));
+
+vi.mock("@/components/branding/Logo", () => ({
+	Logo: () => <div aria-label="Bifrost" />,
+}));
+
+describe("Login OAuth flow", () => {
+	const originalAssign = window.location.assign;
+
+	beforeEach(() => {
+		initOAuth.mockResolvedValue({
+			authorization_url: "https://login.example.test/authorize",
+			state: "server-state",
+		});
+		vi.spyOn(window.location, "assign").mockImplementation(() => {});
+		sessionStorage.clear();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		window.location.assign = originalAssign;
+	});
+
+	it("redirects to the provider without storing OAuth state in session storage", async () => {
+		const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+		render(
+			<MemoryRouter>
+				<Login />
+			</MemoryRouter>,
+		);
+
+		await userEvent.click(
+			await screen.findByRole("button", { name: /microsoft/i }),
+		);
+
+		await waitFor(() => {
+			expect(initOAuth).toHaveBeenCalledWith(
+				"microsoft",
+				"http://localhost:3000/auth/callback/microsoft",
+			);
+		});
+		expect(window.location.assign).toHaveBeenCalledWith(
+			"https://login.example.test/authorize",
+		);
+		expect(setItem).not.toHaveBeenCalledWith(
+			"oauth_provider",
+			expect.any(String),
+		);
+		expect(setItem).not.toHaveBeenCalledWith(
+			"oauth_state",
+			expect.any(String),
+		);
+	});
+});

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -252,20 +252,11 @@ export function Login() {
 				throw new Error("OAuth provider is not available");
 			}
 
-			// Note: PKCE (code_verifier) is now handled server-side
-			sessionStorage.setItem("oauth_provider", provider);
-
 			// Build callback URL
 			const callbackUrl = `${window.location.origin}/auth/callback/${provider}`;
 
 			// Get authorization URL (server generates and stores PKCE verifier)
-			const { authorization_url, state } = await initOAuth(
-				provider,
-				callbackUrl,
-			);
-
-			// Store state for verification
-			sessionStorage.setItem("oauth_state", state);
+			const { authorization_url } = await initOAuth(provider, callbackUrl);
 
 			// Redirect to OAuth provider
 			window.location.assign(authorization_url);


### PR DESCRIPTION
## Summary
- stop persisting OAuth provider and state in browser session storage during login
- let the server-side OAuth callback validation remain the source of truth for state/PKCE
- add focused tests for login redirect and callback handling

## Verification
- npm test -- Login.test.tsx AuthCallback.test.tsx
- npm run tsc
- npm run lint
- rg OAuth sessionStorage search: no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for OAuth login flow, verifying provider authorization initiation.
  * Added test coverage for OAuth callback handling, ensuring proper code and state parameter processing.

* **Refactor**
  * Simplified OAuth authentication flow by streamlining state and parameter management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->