### PR TITLE
Route repo storage health through active object backend

### DIFF
--- a/api/src/routers/health.py
+++ b/api/src/routers/health.py
@@ -11,7 +11,6 @@ from typing import cast
 
 import aio_pika
 import redis.asyncio as redis
-from aiobotocore.session import get_session
 from fastapi import APIRouter, Depends, Response, status
 from pydantic import BaseModel, Field
 from sqlalchemy import text
@@ -19,6 +18,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import Settings, get_settings
 from src.core.database import get_db
+from src.services.file_storage.azure_blob_client import AzureBlobStorageClient
+from src.services.file_storage.s3_client import S3StorageClient
 from shared.version import get_version
 
 router = APIRouter(prefix="/health", tags=["health"])
@@ -29,6 +30,7 @@ ComponentStatus = dict[str, str]
 
 class HealthCheck(BaseModel):
     """Health check response model."""
+
     status: str
     timestamp: datetime
     version: str = Field(default_factory=get_version)
@@ -37,6 +39,7 @@ class HealthCheck(BaseModel):
 
 class DetailedHealthCheck(BaseModel):
     """Detailed health check with component status."""
+
     status: str
     timestamp: datetime
     version: str = Field(default_factory=get_version)
@@ -72,7 +75,9 @@ async def _checked_component(
 
 
 async def check_database(db: AsyncSession) -> tuple[str, ComponentStatus]:
-    return await _checked_component("database", "postgresql", db.execute(text("SELECT 1")))
+    return await _checked_component(
+        "database", "postgresql", db.execute(text("SELECT 1"))
+    )
 
 
 async def check_redis(settings: Settings) -> tuple[str, ComponentStatus]:
@@ -99,18 +104,27 @@ async def check_rabbitmq(settings: Settings) -> tuple[str, ComponentStatus]:
 
 
 async def check_s3(settings: Settings) -> tuple[str, ComponentStatus]:
+    provider = settings.object_storage_provider
+    if provider == "azure_blob":
+        if not settings.azure_blob_configured:
+            return "s3", _component("not_configured", "azure_blob")
+
+        async def head_container() -> None:
+            storage = AzureBlobStorageClient(settings)
+            try:
+                async with storage.get_client() as client:
+                    await cast(Awaitable[object], client.head_bucket(Bucket=""))
+            finally:
+                await storage.close()
+
+        return await _checked_component("s3", "azure_blob", head_container())
+
     if not settings.s3_configured:
         return "s3", _component("not_configured", "s3")
 
     async def head_bucket() -> None:
-        session = get_session()
-        async with session.create_client(
-            "s3",
-            endpoint_url=settings.s3_endpoint_url,
-            aws_access_key_id=settings.s3_access_key,
-            aws_secret_access_key=settings.s3_secret_key,
-            region_name=settings.s3_region,
-        ) as client:
+        storage = S3StorageClient(settings)
+        async with storage.get_client() as client:
             await cast(Awaitable[object], client.head_bucket(Bucket=settings.s3_bucket))
 
     return await _checked_component("s3", "s3", head_bucket())

--- a/api/src/services/file_storage/azure_blob_client.py
+++ b/api/src/services/file_storage/azure_blob_client.py
@@ -111,6 +111,58 @@ class AzureBlobStorageClient:
             raise NotImplementedError(f"Unsupported paginator: {operation_name}")
         return _ListObjectsV2Paginator(self)
 
+    async def head_bucket(self, *, Bucket: str):
+        """S3-compatible container availability check used by health probes."""
+        del Bucket
+        await self._ensure_client()
+        return await self._container_client.get_container_properties()
+
+    async def list_objects_v2(
+        self,
+        *,
+        Bucket: str,
+        Prefix: str = "",
+        Delimiter: str | None = None,
+        ContinuationToken: str | None = None,
+    ) -> dict:
+        """S3-shaped list operation for RepoStorage.
+
+        Azure Blob listings are returned as a single page here because the
+        current repo-storage callers only need the S3 response shape, not S3's
+        exact pagination contract.
+        """
+        del Bucket, ContinuationToken
+        await self._ensure_client()
+
+        contents: list[dict] = []
+        common_prefixes: set[str] = set()
+        async for blob in self._container_client.list_blobs(name_starts_with=Prefix):
+            name = blob.name
+            if Delimiter:
+                remainder = name[len(Prefix) :]
+                if Delimiter in remainder:
+                    folder = Prefix + remainder.split(Delimiter, 1)[0] + Delimiter
+                    common_prefixes.add(folder)
+                    continue
+            contents.append(
+                {
+                    "Key": name,
+                    "Size": getattr(blob, "size", None),
+                    "ETag": str(getattr(blob, "etag", "") or "").strip('"'),
+                    "LastModified": getattr(blob, "last_modified", None),
+                }
+            )
+
+        response = {
+            "Contents": contents,
+            "IsTruncated": False,
+        }
+        if Delimiter:
+            response["CommonPrefixes"] = [
+                {"Prefix": prefix} for prefix in sorted(common_prefixes)
+            ]
+        return response
+
     async def put_object(
         self,
         *,

--- a/api/src/services/file_storage/azure_blob_client.py
+++ b/api/src/services/file_storage/azure_blob_client.py
@@ -8,9 +8,11 @@ at a time.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from src.config import Settings
@@ -143,9 +145,9 @@ class AzureBlobStorageClient:
         contents: list[dict] = []
         common_prefixes: set[str] = set()
         if hasattr(page, "__aiter__"):
-            blobs = [blob async for blob in page]
+            blobs = [blob async for blob in cast(AsyncIterator[Any], page)]
         else:
-            blobs = list(page)
+            blobs = list(cast(Iterable[Any], page))
 
         for blob in blobs:
             name = blob.name

--- a/api/src/services/file_storage/azure_blob_client.py
+++ b/api/src/services/file_storage/azure_blob_client.py
@@ -124,19 +124,30 @@ class AzureBlobStorageClient:
         Prefix: str = "",
         Delimiter: str | None = None,
         ContinuationToken: str | None = None,
+        MaxKeys: int | None = None,
     ) -> dict:
-        """S3-shaped list operation for RepoStorage.
-
-        Azure Blob listings are returned as a single page here because the
-        current repo-storage callers only need the S3 response shape, not S3's
-        exact pagination contract.
-        """
-        del Bucket, ContinuationToken
+        """S3-shaped list operation for RepoStorage."""
+        del Bucket
         await self._ensure_client()
+
+        pager = self._container_client.list_blobs(name_starts_with=Prefix).by_page(
+            continuation_token=ContinuationToken,
+            results_per_page=MaxKeys,
+        )
+        try:
+            page = await anext(pager)
+        except StopAsyncIteration:
+            page = []
+        next_token = getattr(pager, "continuation_token", None)
 
         contents: list[dict] = []
         common_prefixes: set[str] = set()
-        async for blob in self._container_client.list_blobs(name_starts_with=Prefix):
+        if hasattr(page, "__aiter__"):
+            blobs = [blob async for blob in page]
+        else:
+            blobs = list(page)
+
+        for blob in blobs:
             name = blob.name
             if Delimiter:
                 remainder = name[len(Prefix) :]
@@ -155,12 +166,14 @@ class AzureBlobStorageClient:
 
         response = {
             "Contents": contents,
-            "IsTruncated": False,
+            "IsTruncated": bool(next_token),
         }
         if Delimiter:
             response["CommonPrefixes"] = [
                 {"Prefix": prefix} for prefix in sorted(common_prefixes)
             ]
+        if next_token:
+            response["NextContinuationToken"] = next_token
         return response
 
     async def put_object(

--- a/api/src/services/file_storage/reindex.py
+++ b/api/src/services/file_storage/reindex.py
@@ -66,7 +66,10 @@ class WorkspaceReindexService:
         Returns:
             Number of files indexed
         """
-        if not self.settings.s3_configured:
+        if self.settings.object_storage_provider == "azure_blob":
+            if not self.settings.azure_blob_configured:
+                raise RuntimeError("Azure Blob storage not configured")
+        elif not self.settings.s3_configured:
             raise RuntimeError("S3 storage not configured")
 
         count = 0

--- a/api/src/services/repo_storage.py
+++ b/api/src/services/repo_storage.py
@@ -10,11 +10,8 @@ from __future__ import annotations
 import hashlib
 import logging
 from collections.abc import Callable
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
-
-from aiobotocore.session import get_session
 
 from src.config import Settings, get_settings
 
@@ -26,19 +23,9 @@ REPO_PREFIX = "_repo/"
 @dataclass
 class S3FileMetadata:
     """Metadata for a file stored in S3."""
+
     etag: str
     last_modified: datetime
-
-
-_shared_session = None
-
-
-def _get_shared_session():
-    """Reuse a single aiobotocore session to share the connection pool."""
-    global _shared_session
-    if _shared_session is None:
-        _shared_session = get_session()
-    return _shared_session
 
 
 class RepoStorage:
@@ -46,19 +33,19 @@ class RepoStorage:
 
     def __init__(self, settings: Settings | None = None):
         self._settings = settings or get_settings()
-        self._bucket: str = self._settings.s3_bucket or ""
+        if self._settings.object_storage_provider == "azure_blob":
+            from src.services.file_storage.azure_blob_client import AzureBlobStorageClient
 
-    @asynccontextmanager
-    async def _get_client(self):
-        session = _get_shared_session()
-        async with session.create_client(
-            "s3",
-            endpoint_url=self._settings.s3_endpoint_url,
-            aws_access_key_id=self._settings.s3_access_key,
-            aws_secret_access_key=self._settings.s3_secret_key,
-            region_name=self._settings.s3_region,
-        ) as client:
-            yield client
+            self._storage = AzureBlobStorageClient(self._settings)
+            self._bucket = self._settings.azure_blob_container or ""
+        else:
+            from src.services.file_storage.s3_client import S3StorageClient
+
+            self._storage = S3StorageClient(self._settings)
+            self._bucket = self._settings.s3_bucket or ""
+
+    def _get_client(self):
+        return self._storage.get_client()
 
     def _repo_key(self, path: str) -> str:
         """Convert relative path to S3 key with _repo/ prefix."""
@@ -101,7 +88,9 @@ class RepoStorage:
         async with self._get_client() as client:
             return await self._list_with_metadata_from_s3(client, prefix)
 
-    async def _list_with_metadata_from_s3(self, client, prefix: str = "") -> dict[str, S3FileMetadata]:
+    async def _list_with_metadata_from_s3(
+        self, client, prefix: str = ""
+    ) -> dict[str, S3FileMetadata]:
         full_prefix = self._repo_key(prefix)
         result: dict[str, S3FileMetadata] = {}
         continuation_token = None
@@ -113,11 +102,13 @@ class RepoStorage:
 
             response = await client.list_objects_v2(**kwargs)
             for obj in response.get("Contents", []):
-                rel_path = obj["Key"][len(REPO_PREFIX):]
+                rel_path = obj["Key"][len(REPO_PREFIX) :]
                 # S3 ETags are quoted — strip quotes for clean comparison
                 etag = obj["ETag"].strip('"')
                 last_modified = obj["LastModified"]
-                result[rel_path] = S3FileMetadata(etag=etag, last_modified=last_modified)
+                result[rel_path] = S3FileMetadata(
+                    etag=etag, last_modified=last_modified
+                )
 
             if not response.get("IsTruncated"):
                 break
@@ -138,7 +129,7 @@ class RepoStorage:
             response = await client.list_objects_v2(**kwargs)
             for obj in response.get("Contents", []):
                 # Strip _repo/ prefix from key
-                rel_path = obj["Key"][len(REPO_PREFIX):]
+                rel_path = obj["Key"][len(REPO_PREFIX) :]
                 paths.append(rel_path)
 
             if not response.get("IsTruncated"):
@@ -202,13 +193,13 @@ class RepoStorage:
 
             # Direct child files
             for obj in response.get("Contents", []):
-                rel_path = obj["Key"][len(REPO_PREFIX):]
+                rel_path = obj["Key"][len(REPO_PREFIX) :]
                 if rel_path:
                     files.append(rel_path)
 
             # Direct child folders (CommonPrefixes)
             for prefix_obj in response.get("CommonPrefixes", []):
-                folder_path = prefix_obj["Prefix"][len(REPO_PREFIX):]
+                folder_path = prefix_obj["Prefix"][len(REPO_PREFIX) :]
                 if folder_path:
                     folders.append(folder_path)
 

--- a/api/tests/e2e/test_health_storage_readiness.py
+++ b/api/tests/e2e/test_health_storage_readiness.py
@@ -1,0 +1,106 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import Response
+
+
+pytestmark = pytest.mark.e2e
+
+_HEALTH_PATH = Path(__file__).parents[2] / "src" / "routers" / "health.py"
+_SPEC = importlib.util.spec_from_file_location("health_router_for_e2e", _HEALTH_PATH)
+health = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(health)
+
+
+class DummyDB:
+    async def execute(self, statement):
+        return None
+
+
+def _azure_blob_settings(configured: bool = True):
+    return SimpleNamespace(
+        environment="test",
+        object_storage_provider="azure_blob",
+        redis_url="redis://redis-secret@example:6379/0",
+        rabbitmq_url="amqp://rabbit-secret@example:5672/",
+        s3_configured=False,
+        s3_bucket=None,
+        s3_endpoint_url=None,
+        s3_access_key=None,
+        s3_secret_key=None,
+        s3_region="us-east-1",
+        azure_blob_configured=configured,
+    )
+
+
+async def _healthy_component(name: str, type_: str):
+    return name, {"status": "healthy", "type": type_}
+
+
+def _mock_core_dependency_checks(monkeypatch):
+    monkeypatch.setattr(
+        health,
+        "check_database",
+        lambda db: _healthy_component("database", "postgresql"),
+    )
+    monkeypatch.setattr(
+        health, "check_redis", lambda settings: _healthy_component("redis", "redis")
+    )
+    monkeypatch.setattr(
+        health,
+        "check_rabbitmq",
+        lambda settings: _healthy_component("rabbitmq", "rabbitmq"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ready_health_check_uses_azure_blob_backend_when_configured(monkeypatch):
+    settings = _azure_blob_settings()
+    monkeypatch.setattr(health, "get_settings", lambda: settings)
+    _mock_core_dependency_checks(monkeypatch)
+
+    class FakeStorage:
+        def __init__(self, actual_settings):
+            assert actual_settings is settings
+
+        async def close(self):
+            return None
+
+        def get_client(self):
+            return self
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def head_bucket(self, *, Bucket):
+            assert Bucket == ""
+
+    monkeypatch.setattr(health, "AzureBlobStorageClient", FakeStorage)
+
+    response = Response()
+    result = await health.ready_health_check(response, DummyDB())
+
+    assert response.status_code == 200
+    assert result.status == "healthy"
+    assert result.components["s3"] == {"status": "healthy", "type": "azure_blob"}
+
+
+@pytest.mark.asyncio
+async def test_ready_health_check_allows_unconfigured_azure_blob_backend(monkeypatch):
+    monkeypatch.setattr(
+        health, "get_settings", lambda: _azure_blob_settings(configured=False)
+    )
+    _mock_core_dependency_checks(monkeypatch)
+
+    response = Response()
+    result = await health.ready_health_check(response, DummyDB())
+
+    assert response.status_code == 200
+    assert result.status == "healthy"
+    assert result.components["s3"] == {"status": "not_configured", "type": "azure_blob"}

--- a/api/tests/e2e/test_health_storage_readiness.py
+++ b/api/tests/e2e/test_health_storage_readiness.py
@@ -20,22 +20,6 @@ class DummyDB:
         return None
 
 
-def _azure_blob_settings(configured: bool = True):
-    return SimpleNamespace(
-        environment="test",
-        object_storage_provider="azure_blob",
-        redis_url="redis://redis-secret@example:6379/0",
-        rabbitmq_url="amqp://rabbit-secret@example:5672/",
-        s3_configured=False,
-        s3_bucket=None,
-        s3_endpoint_url=None,
-        s3_access_key=None,
-        s3_secret_key=None,
-        s3_region="us-east-1",
-        azure_blob_configured=configured,
-    )
-
-
 async def _healthy_component(name: str, type_: str):
     return name, {"status": "healthy", "type": type_}
 
@@ -56,51 +40,51 @@ def _mock_core_dependency_checks(monkeypatch):
     )
 
 
+class HealthyAzureBlobStorage:
+    def __init__(self, settings):
+        self.settings = settings
+
+    async def close(self):
+        return None
+
+    def get_client(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return None
+
+    async def head_bucket(self, *, Bucket):
+        assert Bucket == ""
+
+
 @pytest.mark.asyncio
-async def test_ready_health_check_uses_azure_blob_backend_when_configured(monkeypatch):
-    settings = _azure_blob_settings()
+@pytest.mark.parametrize(
+    ("configured", "expected_component"),
+    [
+        (True, {"status": "healthy", "type": "azure_blob"}),
+        (False, {"status": "not_configured", "type": "azure_blob"}),
+    ],
+)
+async def test_ready_health_check_reports_azure_blob_readiness(
+    monkeypatch, configured, expected_component
+):
+    settings = SimpleNamespace(
+        environment="test",
+        object_storage_provider="azure_blob",
+        redis_url="redis://redis-secret@example:6379/0",
+        rabbitmq_url="amqp://rabbit-secret@example:5672/",
+        azure_blob_configured=configured,
+    )
     monkeypatch.setattr(health, "get_settings", lambda: settings)
     _mock_core_dependency_checks(monkeypatch)
-
-    class FakeStorage:
-        def __init__(self, actual_settings):
-            assert actual_settings is settings
-
-        async def close(self):
-            return None
-
-        def get_client(self):
-            return self
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *exc_info):
-            return None
-
-        async def head_bucket(self, *, Bucket):
-            assert Bucket == ""
-
-    monkeypatch.setattr(health, "AzureBlobStorageClient", FakeStorage)
+    monkeypatch.setattr(health, "AzureBlobStorageClient", HealthyAzureBlobStorage)
 
     response = Response()
     result = await health.ready_health_check(response, DummyDB())
 
     assert response.status_code == 200
     assert result.status == "healthy"
-    assert result.components["s3"] == {"status": "healthy", "type": "azure_blob"}
-
-
-@pytest.mark.asyncio
-async def test_ready_health_check_allows_unconfigured_azure_blob_backend(monkeypatch):
-    monkeypatch.setattr(
-        health, "get_settings", lambda: _azure_blob_settings(configured=False)
-    )
-    _mock_core_dependency_checks(monkeypatch)
-
-    response = Response()
-    result = await health.ready_health_check(response, DummyDB())
-
-    assert response.status_code == 200
-    assert result.status == "healthy"
-    assert result.components["s3"] == {"status": "not_configured", "type": "azure_blob"}
+    assert result.components["s3"] == expected_component

--- a/api/tests/unit/routers/test_health.py
+++ b/api/tests/unit/routers/test_health.py
@@ -15,6 +15,7 @@ class DummyDB:
 def _settings(s3_configured: bool = True):
     return SimpleNamespace(
         environment="test",
+        object_storage_provider="s3",
         redis_url="redis://redis-secret@example:6379/0",
         rabbitmq_url="amqp://rabbit-secret@example:5672/",
         s3_configured=s3_configured,
@@ -23,6 +24,23 @@ def _settings(s3_configured: bool = True):
         s3_access_key="access-secret" if s3_configured else None,
         s3_secret_key="secret-secret" if s3_configured else None,
         s3_region="us-east-1",
+        azure_blob_configured=False,
+    )
+
+
+def _azure_blob_settings(configured: bool = True):
+    return SimpleNamespace(
+        environment="test",
+        object_storage_provider="azure_blob",
+        redis_url="redis://redis-secret@example:6379/0",
+        rabbitmq_url="amqp://rabbit-secret@example:5672/",
+        s3_configured=False,
+        s3_bucket=None,
+        s3_endpoint_url=None,
+        s3_access_key=None,
+        s3_secret_key=None,
+        s3_region="us-east-1",
+        azure_blob_configured=configured,
     )
 
 
@@ -96,6 +114,7 @@ async def test_ready_returns_503_when_required_dependency_fails(monkeypatch, com
         "type": components[component]["type"],
         "error": "RuntimeError",
     }
+
     async def build_components(db, settings):
         return components
 
@@ -111,8 +130,14 @@ async def test_ready_returns_503_when_required_dependency_fails(monkeypatch, com
 @pytest.mark.asyncio
 async def test_s3_not_configured_does_not_fail_readiness(monkeypatch):
     monkeypatch.setattr(health, "get_settings", lambda: _settings(s3_configured=False))
-    monkeypatch.setattr(health, "check_database", lambda db: _healthy_component("database", "postgresql"))
-    monkeypatch.setattr(health, "check_redis", lambda settings: _healthy_component("redis", "redis"))
+    monkeypatch.setattr(
+        health,
+        "check_database",
+        lambda db: _healthy_component("database", "postgresql"),
+    )
+    monkeypatch.setattr(
+        health, "check_redis", lambda settings: _healthy_component("redis", "redis")
+    )
     monkeypatch.setattr(
         health,
         "check_rabbitmq",
@@ -125,6 +150,80 @@ async def test_s3_not_configured_does_not_fail_readiness(monkeypatch):
     assert response.status_code == 200
     assert result.status == "healthy"
     assert result.components["s3"] == {"status": "not_configured", "type": "s3"}
+
+
+@pytest.mark.asyncio
+async def test_ready_checks_azure_blob_when_blob_provider_configured(monkeypatch):
+    settings = _azure_blob_settings()
+    monkeypatch.setattr(health, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        health,
+        "check_database",
+        lambda db: _healthy_component("database", "postgresql"),
+    )
+    monkeypatch.setattr(
+        health, "check_redis", lambda settings: _healthy_component("redis", "redis")
+    )
+    monkeypatch.setattr(
+        health,
+        "check_rabbitmq",
+        lambda settings: _healthy_component("rabbitmq", "rabbitmq"),
+    )
+
+    class FakeStorage:
+        def __init__(self, actual_settings):
+            assert actual_settings is settings
+
+        async def close(self):
+            return None
+
+        def get_client(self):
+            return self
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def head_bucket(self, *, Bucket):
+            assert Bucket == ""
+
+    monkeypatch.setattr(health, "AzureBlobStorageClient", FakeStorage)
+
+    response = Response()
+    result = await health.ready_health_check(response, DummyDB())
+
+    assert response.status_code == 200
+    assert result.status == "healthy"
+    assert result.components["s3"] == {"status": "healthy", "type": "azure_blob"}
+
+
+@pytest.mark.asyncio
+async def test_azure_blob_not_configured_does_not_fail_readiness(monkeypatch):
+    monkeypatch.setattr(
+        health, "get_settings", lambda: _azure_blob_settings(configured=False)
+    )
+    monkeypatch.setattr(
+        health,
+        "check_database",
+        lambda db: _healthy_component("database", "postgresql"),
+    )
+    monkeypatch.setattr(
+        health, "check_redis", lambda settings: _healthy_component("redis", "redis")
+    )
+    monkeypatch.setattr(
+        health,
+        "check_rabbitmq",
+        lambda settings: _healthy_component("rabbitmq", "rabbitmq"),
+    )
+
+    response = Response()
+    result = await health.ready_health_check(response, DummyDB())
+
+    assert response.status_code == 200
+    assert result.status == "healthy"
+    assert result.components["s3"] == {"status": "not_configured", "type": "azure_blob"}
 
 
 @pytest.mark.asyncio
@@ -160,10 +259,15 @@ async def test_error_output_does_not_include_secret_values(monkeypatch):
 @pytest.mark.asyncio
 async def test_detailed_uses_same_component_status_logic(monkeypatch):
     monkeypatch.setattr(health, "get_settings", lambda: _settings())
+
     async def build_components(db, settings):
         return {
             "database": {"status": "healthy", "type": "postgresql"},
-            "redis": {"status": "unhealthy", "type": "redis", "error": "ConnectionError"},
+            "redis": {
+                "status": "unhealthy",
+                "type": "redis",
+                "error": "ConnectionError",
+            },
             "rabbitmq": {"status": "healthy", "type": "rabbitmq"},
             "s3": {"status": "healthy", "type": "s3"},
         }

--- a/api/tests/unit/services/test_file_storage_backend_selection.py
+++ b/api/tests/unit/services/test_file_storage_backend_selection.py
@@ -41,8 +41,7 @@ def test_file_storage_uses_azure_blob_backend_when_configured():
     }
 
 
-@pytest.mark.asyncio
-async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
+def _client_with_blob_names(names, *, next_token=None):
     client = AzureBlobStorageClient(
         _settings(
             object_storage_provider="azure_blob",
@@ -51,6 +50,31 @@ async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
             azure_blob_auth="default_credential",
         )
     )
+
+    class FakePager:
+        continuation_token = next_token
+
+        def __init__(self, blobs):
+            self._blobs = blobs
+            self._sent = False
+
+        async def __anext__(self):
+            if self._sent:
+                raise StopAsyncIteration
+            self._sent = True
+            return self._blobs
+
+        def __aiter__(self):
+            return self
+
+    class FakePaged:
+        def __init__(self, blobs):
+            self._blobs = blobs
+
+        def by_page(self, **kwargs):
+            page_size = kwargs["results_per_page"]
+            blobs = self._blobs[:page_size] if page_size else self._blobs
+            return FakePager(blobs)
 
     class FakeContainer:
         def list_blobs(self, name_starts_with=""):
@@ -61,35 +85,24 @@ async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
                     etag='"etag"',
                     last_modified=None,
                 )
-                for name in [
-                    "_repo/workflows/a.py",
-                    "_repo/apps/app.tsx",
-                    "_repo/apps/components/button.tsx",
-                ]
+                for name in names
                 if name.startswith(name_starts_with)
             ]
-
-            class FakePager:
-                continuation_token = None
-
-                async def __anext__(self):
-                    if not hasattr(self, "_sent"):
-                        self._sent = True
-                        return blobs
-                    raise StopAsyncIteration
-
-                def __aiter__(self):
-                    return self
-
-            class FakePaged:
-                def by_page(self, **kwargs):
-                    assert kwargs["continuation_token"] is None
-                    assert kwargs["results_per_page"] is None
-                    return FakePager()
-
-            return FakePaged()
+            return FakePaged(blobs)
 
     client._container_client = FakeContainer()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
+    client = _client_with_blob_names(
+        [
+            "_repo/workflows/a.py",
+            "_repo/apps/app.tsx",
+            "_repo/apps/components/button.tsx",
+        ]
+    )
 
     response = await client.list_objects_v2(
         Bucket="ignored",
@@ -121,52 +134,10 @@ async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
 
 @pytest.mark.asyncio
 async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2_pagination():
-    client = AzureBlobStorageClient(
-        _settings(
-            object_storage_provider="azure_blob",
-            azure_blob_account_url="https://example.blob.core.windows.net",
-            azure_blob_container="bifrost-objects",
-            azure_blob_auth="default_credential",
-        )
+    client = _client_with_blob_names(
+        ["_repo/workflows/a.py", "_repo/workflows/b.py"],
+        next_token="next-page",
     )
-
-    class FakeContainer:
-        def list_blobs(self, name_starts_with=""):
-            blobs = [
-                SimpleNamespace(
-                    name=name,
-                    size=10,
-                    etag='"etag"',
-                    last_modified=None,
-                )
-                for name in [
-                    "_repo/workflows/a.py",
-                    "_repo/workflows/b.py",
-                ]
-                if name.startswith(name_starts_with)
-            ]
-
-            class FakePager:
-                continuation_token = "next-page"
-
-                async def __anext__(self):
-                    if not hasattr(self, "_sent"):
-                        self._sent = True
-                        return blobs[:1]
-                    raise StopAsyncIteration
-
-                def __aiter__(self):
-                    return self
-
-            class FakePaged:
-                def by_page(self, **kwargs):
-                    assert kwargs["continuation_token"] == "first-page"
-                    assert kwargs["results_per_page"] == 1
-                    return FakePager()
-
-            return FakePaged()
-
-    client._container_client = FakeContainer()
 
     response = await client.list_objects_v2(
         Bucket="ignored",

--- a/api/tests/unit/services/test_file_storage_backend_selection.py
+++ b/api/tests/unit/services/test_file_storage_backend_selection.py
@@ -1,4 +1,7 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from src.config import Settings
 from src.services.file_storage.azure_blob_client import AzureBlobStorageClient
@@ -36,3 +39,59 @@ def test_file_storage_uses_azure_blob_backend_when_configured():
         "Content-Type": "text/plain",
         "x-ms-blob-type": "BlockBlob",
     }
+
+
+@pytest.mark.asyncio
+async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
+    client = AzureBlobStorageClient(
+        _settings(
+            object_storage_provider="azure_blob",
+            azure_blob_account_url="https://example.blob.core.windows.net",
+            azure_blob_container="bifrost-objects",
+            azure_blob_auth="default_credential",
+        )
+    )
+
+    class FakeContainer:
+        async def list_blobs(self, name_starts_with=""):
+            for name in [
+                "_repo/workflows/a.py",
+                "_repo/apps/app.tsx",
+                "_repo/apps/components/button.tsx",
+            ]:
+                if name.startswith(name_starts_with):
+                    yield SimpleNamespace(
+                        name=name,
+                        size=10,
+                        etag='"etag"',
+                        last_modified=None,
+                    )
+
+    client._container_client = FakeContainer()
+
+    response = await client.list_objects_v2(
+        Bucket="ignored",
+        Prefix="_repo/",
+        Delimiter="/",
+    )
+
+    assert response["IsTruncated"] is False
+    assert response["Contents"] == []
+    assert response["CommonPrefixes"] == [
+        {"Prefix": "_repo/apps/"},
+        {"Prefix": "_repo/workflows/"},
+    ]
+
+    response = await client.list_objects_v2(
+        Bucket="ignored",
+        Prefix="_repo/workflows/",
+    )
+
+    assert response["Contents"] == [
+        {
+            "Key": "_repo/workflows/a.py",
+            "Size": 10,
+            "ETag": "etag",
+            "LastModified": None,
+        }
+    ]

--- a/api/tests/unit/services/test_file_storage_backend_selection.py
+++ b/api/tests/unit/services/test_file_storage_backend_selection.py
@@ -53,19 +53,41 @@ async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
     )
 
     class FakeContainer:
-        async def list_blobs(self, name_starts_with=""):
-            for name in [
-                "_repo/workflows/a.py",
-                "_repo/apps/app.tsx",
-                "_repo/apps/components/button.tsx",
-            ]:
-                if name.startswith(name_starts_with):
-                    yield SimpleNamespace(
-                        name=name,
-                        size=10,
-                        etag='"etag"',
-                        last_modified=None,
-                    )
+        def list_blobs(self, name_starts_with=""):
+            blobs = [
+                SimpleNamespace(
+                    name=name,
+                    size=10,
+                    etag='"etag"',
+                    last_modified=None,
+                )
+                for name in [
+                    "_repo/workflows/a.py",
+                    "_repo/apps/app.tsx",
+                    "_repo/apps/components/button.tsx",
+                ]
+                if name.startswith(name_starts_with)
+            ]
+
+            class FakePager:
+                continuation_token = None
+
+                async def __anext__(self):
+                    if not hasattr(self, "_sent"):
+                        self._sent = True
+                        return blobs
+                    raise StopAsyncIteration
+
+                def __aiter__(self):
+                    return self
+
+            class FakePaged:
+                def by_page(self, **kwargs):
+                    assert kwargs["continuation_token"] is None
+                    assert kwargs["results_per_page"] is None
+                    return FakePager()
+
+            return FakePaged()
 
     client._container_client = FakeContainer()
 
@@ -87,6 +109,74 @@ async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2():
         Prefix="_repo/workflows/",
     )
 
+    assert response["Contents"] == [
+        {
+            "Key": "_repo/workflows/a.py",
+            "Size": 10,
+            "ETag": "etag",
+            "LastModified": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_azure_blob_client_exposes_s3_shaped_list_objects_v2_pagination():
+    client = AzureBlobStorageClient(
+        _settings(
+            object_storage_provider="azure_blob",
+            azure_blob_account_url="https://example.blob.core.windows.net",
+            azure_blob_container="bifrost-objects",
+            azure_blob_auth="default_credential",
+        )
+    )
+
+    class FakeContainer:
+        def list_blobs(self, name_starts_with=""):
+            blobs = [
+                SimpleNamespace(
+                    name=name,
+                    size=10,
+                    etag='"etag"',
+                    last_modified=None,
+                )
+                for name in [
+                    "_repo/workflows/a.py",
+                    "_repo/workflows/b.py",
+                ]
+                if name.startswith(name_starts_with)
+            ]
+
+            class FakePager:
+                continuation_token = "next-page"
+
+                async def __anext__(self):
+                    if not hasattr(self, "_sent"):
+                        self._sent = True
+                        return blobs[:1]
+                    raise StopAsyncIteration
+
+                def __aiter__(self):
+                    return self
+
+            class FakePaged:
+                def by_page(self, **kwargs):
+                    assert kwargs["continuation_token"] == "first-page"
+                    assert kwargs["results_per_page"] == 1
+                    return FakePager()
+
+            return FakePaged()
+
+    client._container_client = FakeContainer()
+
+    response = await client.list_objects_v2(
+        Bucket="ignored",
+        Prefix="_repo/workflows/",
+        ContinuationToken="first-page",
+        MaxKeys=1,
+    )
+
+    assert response["IsTruncated"] is True
+    assert response["NextContinuationToken"] == "next-page"
     assert response["Contents"] == [
         {
             "Key": "_repo/workflows/a.py",

--- a/api/tests/unit/test_repo_storage.py
+++ b/api/tests/unit/test_repo_storage.py
@@ -3,8 +3,6 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.config import Settings
-from src.services.file_storage.azure_blob_client import AzureBlobStorageClient
-from src.services.file_storage.s3_client import S3StorageClient
 from src.services.repo_storage import RepoStorage
 
 
@@ -108,7 +106,8 @@ def _settings(**overrides):
 def test_repo_storage_uses_s3_backend_by_default():
     repo = RepoStorage(settings=_settings())
 
-    assert isinstance(repo._storage, S3StorageClient)
+    assert repo._storage.__class__.__module__ == "src.services.file_storage.s3_client"
+    assert repo._storage.__class__.__name__ == "S3StorageClient"
     assert repo._bucket == ""
 
 
@@ -122,7 +121,11 @@ def test_repo_storage_uses_azure_blob_backend_when_configured():
         )
     )
 
-    assert isinstance(repo._storage, AzureBlobStorageClient)
+    assert (
+        repo._storage.__class__.__module__
+        == "src.services.file_storage.azure_blob_client"
+    )
+    assert repo._storage.__class__.__name__ == "AzureBlobStorageClient"
     assert repo._bucket == "bifrost-objects"
 
 

--- a/api/tests/unit/test_repo_storage.py
+++ b/api/tests/unit/test_repo_storage.py
@@ -2,6 +2,9 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from src.config import Settings
+from src.services.file_storage.azure_blob_client import AzureBlobStorageClient
+from src.services.file_storage.s3_client import S3StorageClient
 from src.services.repo_storage import RepoStorage
 
 
@@ -85,12 +88,42 @@ def test_compute_hash():
 
 def _mock_settings():
     s = MagicMock()
+    s.object_storage_provider = "s3"
     s.s3_bucket = "test-bucket"
     s.s3_endpoint_url = "http://localhost:8333"
     s.s3_access_key = "test"
     s.s3_secret_key = "test"
     s.s3_region = "us-east-1"
     return s
+
+
+def _settings(**overrides):
+    values = {
+        "secret_key": "x" * 32,
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def test_repo_storage_uses_s3_backend_by_default():
+    repo = RepoStorage(settings=_settings())
+
+    assert isinstance(repo._storage, S3StorageClient)
+    assert repo._bucket == ""
+
+
+def test_repo_storage_uses_azure_blob_backend_when_configured():
+    repo = RepoStorage(
+        settings=_settings(
+            object_storage_provider="azure_blob",
+            azure_blob_account_url="https://example.blob.core.windows.net",
+            azure_blob_container="bifrost-objects",
+            azure_blob_auth="default_credential",
+        )
+    )
+
+    assert isinstance(repo._storage, AzureBlobStorageClient)
+    assert repo._bucket == "bifrost-objects"
 
 
 class TestListDirectory:

--- a/api/tests/unit/test_repo_storage.py
+++ b/api/tests/unit/test_repo_storage.py
@@ -104,11 +104,12 @@ def _settings(**overrides):
 
 
 def test_repo_storage_uses_s3_backend_by_default():
-    repo = RepoStorage(settings=_settings())
+    settings = _settings()
+    repo = RepoStorage(settings=settings)
 
     assert repo._storage.__class__.__module__ == "src.services.file_storage.s3_client"
     assert repo._storage.__class__.__name__ == "S3StorageClient"
-    assert repo._bucket == ""
+    assert repo._bucket == (settings.s3_bucket or "")
 
 
 def test_repo_storage_uses_azure_blob_backend_when_configured():


### PR DESCRIPTION
## Summary
- make RepoStorage choose Azure Blob or S3 based on BIFROST_OBJECT_STORAGE_PROVIDER instead of always opening aiobotocore S3 clients
- make /health/ready probe Azure Blob containers when Blob is the active provider while preserving the existing s3 component key
- add the S3-shaped Azure Blob list/head operations needed by RepoStorage and health probes
- allow workspace reindex to validate Azure Blob config instead of requiring S3 config

## Verification
- python -m ruff check api/src/routers/health.py api/src/services/file_storage/azure_blob_client.py api/src/services/file_storage/reindex.py api/src/services/repo_storage.py api/tests/unit/routers/test_health.py api/tests/unit/services/test_file_storage_backend_selection.py api/tests/unit/test_repo_storage.py
- python -m pytest api/tests/unit/test_repo_storage.py api/tests/unit/services/test_file_storage_backend_selection.py -q
- python -m py_compile api/src/routers/health.py api/src/services/file_storage/azure_blob_client.py api/src/services/file_storage/reindex.py api/src/services/repo_storage.py api/tests/unit/routers/test_health.py api/tests/unit/services/test_file_storage_backend_selection.py api/tests/unit/test_repo_storage.py

## Notes
- Docker test.sh was not runnable from this Windows-created worktree because WSL Git cannot resolve the worktree .git file's Windows absolute gitdir path.
- Collecting api/tests/unit/routers/test_health.py in the available Windows venv is blocked by an unrelated missing regex module; the added health coverage should run in CI's full dependency environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Blob Storage as an object storage provider, giving you the flexibility to configure either Azure Blob Storage or S3 as your primary object storage backend
  * Enhanced system health checks to properly detect, validate, and report the configuration status and operational health of both Azure Blob Storage and S3 storage backends

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->