### PR TITLE
Support Azure Blob sync cache fallbacks

### DIFF
--- a/api/src/core/module_cache_sync.py
+++ b/api/src/core/module_cache_sync.py
@@ -7,7 +7,7 @@ for the MetaPathFinder to fetch modules during import.
 This module provides synchronous versions of the cache functions
 specifically for use in virtual_import.py's MetaPathFinder.
 
-When a cache miss occurs, we fall back to S3 to fetch the module
+When a cache miss occurs, we fall back to object storage to fetch the module
 and re-cache it in Redis. This provides self-healing behavior when:
 - Redis cache entries expire (24hr TTL)
 - Redis restarts or evicts keys
@@ -32,9 +32,11 @@ MODULE_CACHE_TTL = 86400
 
 REPO_PREFIX = "_repo/"
 
-# Cached S3 client — reused across calls to avoid repeated setup
+# Cached object storage clients — reused across calls to avoid repeated setup
 _s3_client: Any = None
 _s3_available: bool | None = None
+_blob_container_client: Any = None
+_blob_available: bool | None = None
 
 
 @lru_cache(maxsize=1)
@@ -92,6 +94,81 @@ def _get_s3_client() -> Any:
         return None
 
 
+def _object_storage_provider() -> str:
+    return os.environ.get("BIFROST_OBJECT_STORAGE_PROVIDER", "s3").lower()
+
+
+def _get_blob_container_client() -> Any:
+    """
+    Get or create a sync Azure Blob container client.
+
+    This is used by the synchronous import hook and requirements-cache fallback
+    paths that run outside the async RepoStorage API.
+    """
+    global _blob_available, _blob_container_client
+
+    if _blob_available is False:
+        return None
+
+    if _blob_container_client is not None:
+        return _blob_container_client
+
+    account_url = os.environ.get("BIFROST_AZURE_BLOB_ACCOUNT_URL")
+    container = os.environ.get("BIFROST_AZURE_BLOB_CONTAINER")
+    auth_mode = os.environ.get("BIFROST_AZURE_BLOB_AUTH", "default_credential")
+    account_key = os.environ.get("BIFROST_AZURE_BLOB_ACCOUNT_KEY")
+
+    if not account_url or not container:
+        logger.debug("Azure Blob not configured, skipping Blob fallback")
+        _blob_available = False
+        return None
+
+    try:
+        from azure.storage.blob import BlobServiceClient
+
+        credential: Any
+        if auth_mode == "account_key":
+            if not account_key:
+                logger.debug("Azure Blob account_key auth selected without account key")
+                _blob_available = False
+                return None
+            credential = account_key
+        elif auth_mode == "default_credential":
+            from azure.identity import DefaultAzureCredential
+
+            credential = DefaultAzureCredential()
+        else:
+            logger.debug("Unsupported Azure Blob auth mode: %s", auth_mode)
+            _blob_available = False
+            return None
+
+        service_client = BlobServiceClient(account_url, credential=credential)
+        _blob_container_client = service_client.get_container_client(container)
+        _blob_available = True
+        return _blob_container_client
+    except Exception as e:
+        _blob_available = False
+        logger.debug("Azure Blob fallback disabled: %s", e)
+        return None
+
+
+def _get_blob_module(path: str) -> bytes | None:
+    """Fetch a module from Azure Blob _repo/ prefix (synchronous)."""
+    client = _get_blob_container_client()
+    if client is None:
+        return None
+
+    try:
+        return client.download_blob(f"{REPO_PREFIX}{path}").readall()
+    except Exception as e:
+        error_code = getattr(e, "error_code", "")
+        if error_code == "BlobNotFound":
+            logger.debug(f"Module not found in Azure Blob: {path}")
+            return None
+        logger.warning(f"Azure Blob fallback error for {path}: {e}")
+        return None
+
+
 def _get_s3_module(path: str) -> bytes | None:
     """
     Fetch a module from S3 _repo/ prefix (synchronous).
@@ -124,6 +201,12 @@ def _get_s3_module(path: str) -> bytes | None:
         return None
 
 
+def _get_object_storage_module(path: str) -> bytes | None:
+    if _object_storage_provider() == "azure_blob":
+        return _get_blob_module(path)
+    return _get_s3_module(path)
+
+
 def get_module_sync(path: str) -> CachedModule | None:
     """
     Fetch a single module from cache (synchronous).
@@ -142,16 +225,18 @@ def get_module_sync(path: str) -> CachedModule | None:
         if data:
             return json.loads(data)
 
-        # Redis miss — try S3 fallback
-        s3_content = _get_s3_module(path)
-        if s3_content is not None:
+        # Redis miss — try object storage fallback
+        storage_content = _get_object_storage_module(path)
+        if storage_content is not None:
             try:
-                content_str = s3_content.decode("utf-8")
+                content_str = storage_content.decode("utf-8")
             except UnicodeDecodeError:
-                logger.warning(f"Could not decode S3 module as UTF-8: {path}")
+                logger.warning(
+                    f"Could not decode object storage module as UTF-8: {path}"
+                )
                 return None
 
-            content_hash = hashlib.sha256(s3_content).hexdigest()
+            content_hash = hashlib.sha256(storage_content).hexdigest()
             module: CachedModule = {
                 "content": content_str,
                 "path": path,
@@ -164,11 +249,11 @@ def get_module_sync(path: str) -> CachedModule | None:
                 # Also add to module index
                 client.sadd(MODULE_INDEX_KEY, path)
             except redis.RedisError as e:
-                logger.warning(f"Failed to cache S3 module to Redis: {e}")
+                logger.warning(f"Failed to cache object storage module to Redis: {e}")
 
             return module
 
-        logger.debug(f"Module not in cache or S3: {path}")
+        logger.debug(f"Module not in cache or object storage: {path}")
         return None
 
     except redis.RedisError as e:
@@ -200,11 +285,37 @@ def _list_s3_modules() -> set[str]:
                 key: str = obj["Key"]
                 if key.endswith(".py"):
                     # Strip the _repo/ prefix to get the relative path
-                    paths.add(key[len(REPO_PREFIX):])
+                    paths.add(key[len(REPO_PREFIX) :])
     except Exception as e:
         logger.warning(f"S3 list error when rebuilding module index: {e}")
 
     return paths
+
+
+def _list_blob_modules() -> set[str]:
+    """
+    List all Python module paths in Azure Blob _repo/ (synchronous).
+    """
+    client = _get_blob_container_client()
+    if client is None:
+        return set()
+
+    paths: set[str] = set()
+    try:
+        for blob in client.list_blobs(name_starts_with=REPO_PREFIX):
+            key: str = blob.name
+            if key.endswith(".py"):
+                paths.add(key[len(REPO_PREFIX) :])
+    except Exception as e:
+        logger.warning(f"Azure Blob list error when rebuilding module index: {e}")
+
+    return paths
+
+
+def _list_object_storage_modules() -> set[str]:
+    if _object_storage_provider() == "azure_blob":
+        return _list_blob_modules()
+    return _list_s3_modules()
 
 
 def get_module_index_sync() -> set[str]:
@@ -220,17 +331,19 @@ def get_module_index_sync() -> set[str]:
         if paths:
             return {p if isinstance(p, str) else p.decode() for p in paths}
 
-        # Redis index is empty — could be cold cache. Try S3.
-        logger.debug("Module index empty in Redis, falling back to S3 listing")
-        s3_paths = _list_s3_modules()
-        if s3_paths:
+        # Redis index is empty — could be cold cache. Try object storage.
+        logger.debug(
+            "Module index empty in Redis, falling back to object storage listing"
+        )
+        storage_paths = _list_object_storage_modules()
+        if storage_paths:
             # Repopulate Redis index so subsequent calls are fast
             try:
-                client.sadd(MODULE_INDEX_KEY, *s3_paths)
+                client.sadd(MODULE_INDEX_KEY, *storage_paths)
                 client.expire(MODULE_INDEX_KEY, MODULE_CACHE_TTL)
             except redis.RedisError as e:
                 logger.warning(f"Failed to repopulate module index in Redis: {e}")
-            return s3_paths
+            return storage_paths
 
         return set()
     except redis.RedisError as e:
@@ -248,3 +361,10 @@ def reset_s3_client() -> None:
     global _s3_client, _s3_available
     _s3_client = None
     _s3_available = None
+
+
+def reset_blob_client() -> None:
+    """Reset the cached Azure Blob client. Used for testing."""
+    global _blob_available, _blob_container_client
+    _blob_container_client = None
+    _blob_available = None

--- a/api/src/core/requirements_cache.py
+++ b/api/src/core/requirements_cache.py
@@ -7,13 +7,13 @@ installed packages survive container restarts.
 
 Persistence Flow:
 1. User installs package via /api/packages/install
-2. API handler appends package to requirements, saves to S3 + Redis cache
+2. API handler appends package to requirements, saves to object storage + Redis cache
 3. API broadcasts "recycle_workers" to all workers
 4. Workers recycle processes; ProcessPoolManager calls install_requirements() at pool startup
 5. pip install runs from requirements.txt (shared filesystem, all workers inherit)
 
-Read path: Redis cache → S3 fallback (re-caches on hit)
-Source of truth: S3 (_repo/requirements.txt) via RepoStorage
+Read path: Redis cache → object storage fallback (re-caches on hit)
+Source of truth: object storage (_repo/requirements.txt) via RepoStorage
 
 Related Files:
 - api/src/routers/packages.py - Saves requirements + broadcasts recycle
@@ -51,7 +51,7 @@ async def get_requirements() -> CachedRequirements | None:
 
     Lookup order:
     1. Redis cache (fast path)
-    2. S3 _repo/requirements.txt (fallback, re-caches to Redis)
+    2. Object storage _repo/requirements.txt (fallback, re-caches to Redis)
     3. None (not found)
 
     Returns:
@@ -76,12 +76,12 @@ def get_requirements_sync() -> str | None:
     Fetch requirements.txt content (synchronous).
 
     Used by install_requirements() which runs in a worker thread.
-    Same lookup order as get_requirements(): Redis → S3 → None.
+    Same lookup order as get_requirements(): Redis → object storage → None.
 
     Returns:
         Requirements content string, or None if not found
     """
-    from src.core.module_cache_sync import _get_s3_client, _get_sync_redis
+    from src.core.module_cache_sync import _get_sync_redis
 
     try:
         client = _get_sync_redis()
@@ -93,9 +93,9 @@ def get_requirements_sync() -> str | None:
                 return content
             return None
 
-        # Redis miss — fall back to S3
-        logger.info("[requirements] Redis cache empty, falling back to S3")
-        content = _read_requirements_from_s3(_get_s3_client)
+        # Redis miss — fall back to the configured object storage provider.
+        logger.info("[requirements] Redis cache empty, falling back to object storage")
+        content = _read_requirements_from_object_storage()
         if not content:
             return None
 
@@ -103,8 +103,12 @@ def get_requirements_sync() -> str | None:
         try:
             content_hash = hashlib.sha256(content.encode()).hexdigest()
             cached_data = CachedRequirements(content=content, hash=content_hash)
-            client.setex(REQUIREMENTS_KEY, REQUIREMENTS_CACHE_TTL, json.dumps(cached_data))
-            logger.info("[requirements] Re-cached requirements from S3 to Redis")
+            client.setex(
+                REQUIREMENTS_KEY, REQUIREMENTS_CACHE_TTL, json.dumps(cached_data)
+            )
+            logger.info(
+                "[requirements] Re-cached requirements from object storage to Redis"
+            )
         except Exception as e:
             logger.warning(f"[requirements] Failed to re-cache to Redis: {e}")
 
@@ -112,6 +116,41 @@ def get_requirements_sync() -> str | None:
 
     except Exception as e:
         logger.warning(f"[requirements] Error reading requirements: {e}")
+        return None
+
+
+def _object_storage_provider() -> str:
+    return os.environ.get("BIFROST_OBJECT_STORAGE_PROVIDER", "s3").lower()
+
+
+def _read_requirements_from_object_storage() -> str | None:
+    if _object_storage_provider() == "azure_blob":
+        return _read_requirements_from_blob()
+    from src.core.module_cache_sync import _get_s3_client
+
+    return _read_requirements_from_s3(_get_s3_client)
+
+
+def _read_requirements_from_blob() -> str | None:
+    """Read _repo/requirements.txt from Azure Blob using the sync Blob client."""
+    from src.core.module_cache_sync import _get_blob_container_client
+
+    client = _get_blob_container_client()
+    if client is None:
+        return None
+
+    try:
+        content = client.download_blob("_repo/requirements.txt").readall().decode()
+        if content.strip():
+            logger.info("[requirements] Loaded requirements.txt from Azure Blob")
+            return content
+        return None
+    except Exception as e:
+        error_code = getattr(e, "error_code", "")
+        if error_code == "BlobNotFound":
+            logger.info("[requirements] No requirements.txt in Azure Blob")
+            return None
+        logger.warning(f"[requirements] Azure Blob read error: {e}")
         return None
 
 
@@ -159,7 +198,7 @@ async def set_requirements(content: str, content_hash: str) -> None:
 
 async def warm_requirements_cache() -> bool:
     """
-    Load requirements.txt from S3 into Redis cache.
+    Load requirements.txt from object storage into Redis cache.
 
     Called by init container or API startup to ensure cache is warm.
     Also called before broadcasting recycle when installing from requirements.txt,
@@ -178,20 +217,20 @@ async def warm_requirements_cache() -> bool:
         if content.strip():
             content_hash = hashlib.sha256(content.encode()).hexdigest()
             await set_requirements(content=content, content_hash=content_hash)
-            logger.info("Warmed requirements cache from S3")
+            logger.info("Warmed requirements cache from object storage")
             return True
 
-        logger.info("requirements.txt in S3 is empty")
+        logger.info("requirements.txt in object storage is empty")
         return False
     except Exception as e:
-        # File may not exist yet in S3
-        logger.info(f"No requirements.txt found in S3: {e}")
+        # File may not exist yet in object storage
+        logger.info(f"No requirements.txt found in object storage: {e}")
         return False
 
 
 async def save_requirements(content: str) -> None:
     """
-    Save requirements.txt to S3 and update Redis cache.
+    Save requirements.txt to object storage and update Redis cache.
 
     Args:
         content: Full requirements.txt content
@@ -200,13 +239,13 @@ async def save_requirements(content: str) -> None:
 
     content_hash = hashlib.sha256(content.encode()).hexdigest()
 
-    # Write to S3 (source of truth)
+    # Write to object storage (source of truth)
     repo = RepoStorage()
     await repo.write("requirements.txt", content.encode())
 
     # Update Redis cache (workers read this synchronously at startup)
     await set_requirements(content, content_hash)
-    logger.info("Saved requirements.txt to S3 and cache")
+    logger.info("Saved requirements.txt to object storage and cache")
 
 
 def append_package_to_requirements(

--- a/api/tests/unit/core/test_requirements_cache.py
+++ b/api/tests/unit/core/test_requirements_cache.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -12,6 +12,7 @@ from src.core.requirements_cache import (
     CachedRequirements,
     append_package_to_requirements,
     get_requirements,
+    get_requirements_sync,
     save_requirements,
     set_requirements,
     warm_requirements_cache,
@@ -33,14 +34,17 @@ class TestGetRequirements:
         cached = {"content": "flask==2.3.0\n", "hash": "abc123"}
         mock_redis_client.get.return_value = json.dumps(cached)
 
-        with patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client):
+        with patch(
+            "src.core.requirements_cache.get_redis_client",
+            return_value=mock_redis_client,
+        ):
             result = await get_requirements()
 
             assert result == cached
             mock_redis_client.get.assert_called_once_with(REQUIREMENTS_KEY)
 
-    async def test_falls_back_to_s3_on_cache_miss(self, mock_redis_client):
-        """Test get_requirements falls back to S3 when Redis cache is empty."""
+    async def test_falls_back_to_object_storage_on_cache_miss(self, mock_redis_client):
+        """Test get_requirements falls back to object storage when Redis cache is empty."""
         content = "flask==2.3.0\n"
         cached = {"content": content, "hash": "abc123"}
 
@@ -51,7 +55,10 @@ class TestGetRequirements:
         mock_repo.read.return_value = content.encode()
 
         with (
-            patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client),
+            patch(
+                "src.core.requirements_cache.get_redis_client",
+                return_value=mock_redis_client,
+            ),
             patch("src.services.repo_storage.RepoStorage", return_value=mock_repo),
         ):
             result = await get_requirements()
@@ -59,23 +66,110 @@ class TestGetRequirements:
             assert result == cached
             # Called twice: first miss, then after warm
             assert mock_redis_client.get.call_count == 2
-            # S3 was read for fallback
+            # Object storage was read for fallback
             mock_repo.read.assert_called_once_with("requirements.txt")
 
-    async def test_returns_none_when_not_in_cache_or_s3(self, mock_redis_client):
-        """Test get_requirements returns None when not in Redis or S3."""
+    async def test_returns_none_when_not_in_cache_or_object_storage(
+        self, mock_redis_client
+    ):
+        """Test get_requirements returns None when not in Redis or object storage."""
         mock_redis_client.get.return_value = None
         mock_redis_client.setex = AsyncMock()
         mock_repo = AsyncMock()
         mock_repo.read.side_effect = Exception("NoSuchKey")
 
         with (
-            patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client),
+            patch(
+                "src.core.requirements_cache.get_redis_client",
+                return_value=mock_redis_client,
+            ),
             patch("src.services.repo_storage.RepoStorage", return_value=mock_repo),
         ):
             result = await get_requirements()
 
             assert result is None
+
+
+class TestGetRequirementsSync:
+    """Tests for sync requirements cache lookup used by worker startup."""
+
+    def test_returns_cached_data(self):
+        """Test get_requirements_sync returns Redis cached content."""
+        cached = {"content": "flask==2.3.0\n", "hash": "abc123"}
+        mock_redis_client = Mock()
+        mock_redis_client.get.return_value = json.dumps(cached)
+
+        with patch(
+            "src.core.module_cache_sync._get_sync_redis",
+            return_value=mock_redis_client,
+        ):
+            assert get_requirements_sync() == cached["content"]
+            mock_redis_client.get.assert_called_once_with(REQUIREMENTS_KEY)
+
+    def test_azure_blob_provider_uses_blob_fallback_not_s3(self):
+        """Test Azure Blob deployments do not use the S3 dead-man fallback."""
+        content = "flask==2.3.0\n"
+        mock_redis_client = Mock()
+        mock_redis_client.get.return_value = None
+        mock_blob_client = Mock()
+        mock_blob_client.download_blob.return_value.readall.return_value = (
+            content.encode()
+        )
+        mock_s3_client = Mock()
+
+        with (
+            patch.dict("os.environ", {"BIFROST_OBJECT_STORAGE_PROVIDER": "azure_blob"}),
+            patch(
+                "src.core.module_cache_sync._get_sync_redis",
+                return_value=mock_redis_client,
+            ),
+            patch(
+                "src.core.module_cache_sync._get_blob_container_client",
+                return_value=mock_blob_client,
+            ),
+            patch(
+                "src.core.module_cache_sync._get_s3_client", return_value=mock_s3_client
+            ),
+        ):
+            assert get_requirements_sync() == content
+
+        mock_blob_client.download_blob.assert_called_once_with("_repo/requirements.txt")
+        mock_s3_client.get_object.assert_not_called()
+        mock_redis_client.setex.assert_called_once()
+
+    def test_s3_provider_keeps_s3_fallback(self):
+        """Test S3 deployments still use S3 fallback on Redis miss."""
+        content = "flask==2.3.0\n"
+        mock_redis_client = Mock()
+        mock_redis_client.get.return_value = None
+        mock_s3_client = Mock()
+        mock_s3_client.get_object.return_value = {
+            "Body": Mock(read=Mock(return_value=content.encode()))
+        }
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "BIFROST_OBJECT_STORAGE_PROVIDER": "s3",
+                    "BIFROST_S3_BUCKET": "bucket",
+                },
+            ),
+            patch(
+                "src.core.module_cache_sync._get_sync_redis",
+                return_value=mock_redis_client,
+            ),
+            patch(
+                "src.core.module_cache_sync._get_s3_client", return_value=mock_s3_client
+            ),
+        ):
+            assert get_requirements_sync() == content
+
+        mock_s3_client.get_object.assert_called_once_with(
+            Bucket="bucket",
+            Key="_repo/requirements.txt",
+        )
+        mock_redis_client.setex.assert_called_once()
 
 
 class TestSetRequirements:
@@ -93,7 +187,10 @@ class TestSetRequirements:
         content = "flask==2.3.0\n"
         content_hash = "abc123"
 
-        with patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client):
+        with patch(
+            "src.core.requirements_cache.get_redis_client",
+            return_value=mock_redis_client,
+        ):
             await set_requirements(content, content_hash)
 
             mock_redis_client.setex.assert_called_once()
@@ -117,13 +214,16 @@ class TestWarmRequirementsCache:
         return mock_client
 
     async def test_caches_from_s3(self, mock_redis_client):
-        """Test warm_requirements_cache loads from S3 and caches."""
+        """Test warm_requirements_cache loads from object storage and caches."""
         content = "flask==2.3.0\nrequests==2.31.0\n"
         mock_repo = AsyncMock()
         mock_repo.read.return_value = content.encode()
 
         with (
-            patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client),
+            patch(
+                "src.core.requirements_cache.get_redis_client",
+                return_value=mock_redis_client,
+            ),
             patch("src.services.repo_storage.RepoStorage", return_value=mock_repo),
         ):
             result = await warm_requirements_cache()
@@ -138,12 +238,15 @@ class TestWarmRequirementsCache:
             assert cached["content"] == content
 
     async def test_returns_false_when_not_found(self, mock_redis_client):
-        """Test warm_requirements_cache returns False when requirements.txt not in S3."""
+        """Test warm_requirements_cache returns False when requirements.txt not in object storage."""
         mock_repo = AsyncMock()
         mock_repo.read.side_effect = Exception("NoSuchKey")
 
         with (
-            patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client),
+            patch(
+                "src.core.requirements_cache.get_redis_client",
+                return_value=mock_redis_client,
+            ),
             patch("src.services.repo_storage.RepoStorage", return_value=mock_repo),
         ):
             result = await warm_requirements_cache()
@@ -157,7 +260,10 @@ class TestWarmRequirementsCache:
         mock_repo.read.return_value = b"  \n  "
 
         with (
-            patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client),
+            patch(
+                "src.core.requirements_cache.get_redis_client",
+                return_value=mock_redis_client,
+            ),
             patch("src.services.repo_storage.RepoStorage", return_value=mock_repo),
         ):
             result = await warm_requirements_cache()
@@ -176,19 +282,24 @@ class TestSaveRequirements:
         mock_client.setex = AsyncMock()
         return mock_client
 
-    async def test_writes_to_s3_and_cache(self, mock_redis_client):
-        """Test save_requirements writes to S3 and updates Redis cache."""
+    async def test_writes_to_object_storage_and_cache(self, mock_redis_client):
+        """Test save_requirements writes to object storage and updates Redis cache."""
         content = "flask==2.3.0\nrequests==2.31.0\n"
         mock_repo = AsyncMock()
 
         with (
-            patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client),
+            patch(
+                "src.core.requirements_cache.get_redis_client",
+                return_value=mock_redis_client,
+            ),
             patch("src.services.repo_storage.RepoStorage", return_value=mock_repo),
         ):
             await save_requirements(content)
 
-            # Verify S3 write
-            mock_repo.write.assert_called_once_with("requirements.txt", content.encode())
+            # Verify object storage write
+            mock_repo.write.assert_called_once_with(
+                "requirements.txt", content.encode()
+            )
 
             # Verify cache was updated
             mock_redis_client.setex.assert_called_once()
@@ -200,7 +311,10 @@ class TestSaveRequirements:
         mock_repo = AsyncMock()
 
         with (
-            patch("src.core.requirements_cache.get_redis_client", return_value=mock_redis_client),
+            patch(
+                "src.core.requirements_cache.get_redis_client",
+                return_value=mock_redis_client,
+            ),
             patch("src.services.repo_storage.RepoStorage", return_value=mock_repo),
         ):
             await save_requirements(content)
@@ -217,14 +331,18 @@ class TestAppendPackageToRequirements:
     def test_appends_new_package(self):
         """Test appending a new package returns is_update=False."""
         current = "flask==2.3.0\n"
-        content, is_update = append_package_to_requirements(current, "requests", "2.31.0")
+        content, is_update = append_package_to_requirements(
+            current, "requests", "2.31.0"
+        )
         assert content == "flask==2.3.0\nrequests==2.31.0\n"
         assert is_update is False
 
     def test_updates_existing_package(self):
         """Test updating an existing package returns is_update=True."""
         current = "flask==2.3.0\nrequests==2.28.0\n"
-        content, is_update = append_package_to_requirements(current, "requests", "2.31.0")
+        content, is_update = append_package_to_requirements(
+            current, "requests", "2.31.0"
+        )
         assert content == "flask==2.3.0\nrequests==2.31.0\n"
         assert is_update is True
 

--- a/api/tests/unit/test_virtual_import_s3_fallback.py
+++ b/api/tests/unit/test_virtual_import_s3_fallback.py
@@ -1,4 +1,5 @@
 """Tests for virtual import S3 fallback."""
+
 import json
 import logging
 from unittest.mock import MagicMock, patch
@@ -10,9 +11,10 @@ def test_s3_fallback_on_redis_miss():
     """When Redis returns None, should try S3 and cache result."""
     from src.core.module_cache_sync import get_module_sync
 
-    with patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory, \
-         patch("src.core.module_cache_sync._get_s3_module") as mock_s3:
-
+    with (
+        patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+        patch("src.core.module_cache_sync._get_s3_module") as mock_s3,
+    ):
         # Redis returns None (cache miss)
         mock_redis = MagicMock()
         mock_redis.get.return_value = None
@@ -36,11 +38,14 @@ def test_redis_hit_skips_s3():
     """When Redis has the module, should not touch S3."""
     from src.core.module_cache_sync import get_module_sync
 
-    cached = json.dumps({"content": "cached content", "path": "shared/utils.py", "hash": "abc"})
+    cached = json.dumps(
+        {"content": "cached content", "path": "shared/utils.py", "hash": "abc"}
+    )
 
-    with patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory, \
-         patch("src.core.module_cache_sync._get_s3_module") as mock_s3:
-
+    with (
+        patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+        patch("src.core.module_cache_sync._get_s3_module") as mock_s3,
+    ):
         mock_redis = MagicMock()
         mock_redis.get.return_value = cached
         mock_redis_factory.return_value = mock_redis
@@ -56,9 +61,10 @@ def test_s3_miss_returns_none():
     """When both Redis and S3 miss, should return None."""
     from src.core.module_cache_sync import get_module_sync
 
-    with patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory, \
-         patch("src.core.module_cache_sync._get_s3_module") as mock_s3:
-
+    with (
+        patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+        patch("src.core.module_cache_sync._get_s3_module") as mock_s3,
+    ):
         mock_redis = MagicMock()
         mock_redis.get.return_value = None
         mock_redis_factory.return_value = mock_redis
@@ -67,6 +73,29 @@ def test_s3_miss_returns_none():
         result = get_module_sync("shared/nonexistent.py")
 
         assert result is None
+
+
+def test_azure_blob_provider_uses_blob_module_fallback_not_s3():
+    """Azure Blob deployments should not use S3 for sync module fallback."""
+    from src.core.module_cache_sync import get_module_sync
+
+    with (
+        patch.dict("os.environ", {"BIFROST_OBJECT_STORAGE_PROVIDER": "azure_blob"}),
+        patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+        patch("src.core.module_cache_sync._get_blob_module") as mock_blob,
+        patch("src.core.module_cache_sync._get_s3_module") as mock_s3,
+    ):
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mock_redis_factory.return_value = mock_redis
+        mock_blob.return_value = b"def helper(): return 42"
+
+        result = get_module_sync("shared/utils.py")
+
+        mock_blob.assert_called_once_with("shared/utils.py")
+        mock_s3.assert_not_called()
+        assert result is not None
+        assert result["content"] == "def helper(): return 42"
 
 
 class TestModuleIndexS3Fallback:
@@ -82,9 +111,12 @@ class TestModuleIndexS3Fallback:
             "features/spotify_journal/__init__.py",
         }
 
-        with patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory, \
-             patch("src.core.module_cache_sync._list_s3_modules", return_value=s3_paths) as mock_list:
-
+        with (
+            patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+            patch(
+                "src.core.module_cache_sync._list_s3_modules", return_value=s3_paths
+            ) as mock_list,
+        ):
             mock_redis = MagicMock()
             mock_redis.smembers.return_value = set()  # Redis index empty
             mock_redis_factory.return_value = mock_redis
@@ -101,11 +133,14 @@ class TestModuleIndexS3Fallback:
         """When Redis index has entries, should not touch S3."""
         from src.core.module_cache_sync import get_module_index_sync
 
-        with patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory, \
-             patch("src.core.module_cache_sync._list_s3_modules") as mock_list:
-
+        with (
+            patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+            patch("src.core.module_cache_sync._list_s3_modules") as mock_list,
+        ):
             mock_redis = MagicMock()
-            mock_redis.smembers.return_value = {"features/spotify_journal/services/spotify_api.py"}
+            mock_redis.smembers.return_value = {
+                "features/spotify_journal/services/spotify_api.py"
+            }
             mock_redis_factory.return_value = mock_redis
 
             result = get_module_index_sync()
@@ -117,9 +152,10 @@ class TestModuleIndexS3Fallback:
         """When both Redis and S3 are empty, should return empty set."""
         from src.core.module_cache_sync import get_module_index_sync
 
-        with patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory, \
-             patch("src.core.module_cache_sync._list_s3_modules", return_value=set()):
-
+        with (
+            patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+            patch("src.core.module_cache_sync._list_s3_modules", return_value=set()),
+        ):
             mock_redis = MagicMock()
             mock_redis.smembers.return_value = set()
             mock_redis_factory.return_value = mock_redis
@@ -129,6 +165,37 @@ class TestModuleIndexS3Fallback:
             assert result == set()
             # Should not try to sadd empty set
             mock_redis.sadd.assert_not_called()
+
+    def test_empty_redis_index_falls_back_to_blob_when_configured(self):
+        """When Azure Blob is configured, cold indexes should list Blob, not S3."""
+        from src.core.module_cache import MODULE_INDEX_KEY
+        from src.core.module_cache_sync import get_module_index_sync
+
+        blob_paths = {
+            "features/spotify_journal/services/spotify_api.py",
+            "features/spotify_journal/__init__.py",
+        }
+
+        with (
+            patch.dict("os.environ", {"BIFROST_OBJECT_STORAGE_PROVIDER": "azure_blob"}),
+            patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+            patch(
+                "src.core.module_cache_sync._list_blob_modules",
+                return_value=blob_paths,
+            ) as mock_blob_list,
+            patch("src.core.module_cache_sync._list_s3_modules") as mock_s3_list,
+        ):
+            mock_redis = MagicMock()
+            mock_redis.smembers.return_value = set()
+            mock_redis_factory.return_value = mock_redis
+
+            result = get_module_index_sync()
+
+            mock_blob_list.assert_called_once()
+            mock_s3_list.assert_not_called()
+            assert result == blob_paths
+            mock_redis.sadd.assert_called_once()
+            assert mock_redis.sadd.call_args[0][0] == MODULE_INDEX_KEY
 
     def test_namespace_package_resolves_via_s3_index_fallback(self):
         """Integration: namespace package lookup succeeds when Redis index is cold but S3 has modules."""
@@ -143,9 +210,16 @@ class TestModuleIndexS3Fallback:
                 return {"content": "API = True", "path": path, "hash": "abc"}
             return None
 
-        with patch("src.services.execution.virtual_import.get_module_sync", side_effect=mock_get_module), \
-             patch("src.services.execution.virtual_import.get_module_index_sync", return_value=s3_paths):
-
+        with (
+            patch(
+                "src.services.execution.virtual_import.get_module_sync",
+                side_effect=mock_get_module,
+            ),
+            patch(
+                "src.services.execution.virtual_import.get_module_index_sync",
+                return_value=s3_paths,
+            ),
+        ):
             # "features" should be recognized as a namespace package
             spec = finder.find_spec("features")
 
@@ -161,6 +235,7 @@ class TestS3ClientCaching:
     def reset_cache(self):
         """Reset S3 client cache before each test."""
         from src.core.module_cache_sync import reset_s3_client
+
         reset_s3_client()
         yield
         reset_s3_client()
@@ -211,9 +286,10 @@ class TestS3ClientCaching:
         """S3 fallback should add module to Redis index after caching."""
         from src.core.module_cache_sync import get_module_sync
 
-        with patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory, \
-             patch("src.core.module_cache_sync._get_s3_module") as mock_s3:
-
+        with (
+            patch("src.core.module_cache_sync._get_sync_redis") as mock_redis_factory,
+            patch("src.core.module_cache_sync._get_s3_module") as mock_s3,
+        ):
             mock_redis = MagicMock()
             mock_redis.get.return_value = None
             mock_redis_factory.return_value = mock_redis
@@ -226,6 +302,7 @@ class TestS3ClientCaching:
             mock_redis.sadd.assert_called_once()
             # The key should be the module index key
             from src.core.module_cache import MODULE_INDEX_KEY
+
             call_args = mock_redis.sadd.call_args
             assert call_args[0][0] == MODULE_INDEX_KEY
             assert call_args[0][1] == "modules/helper.py"


### PR DESCRIPTION
## Summary
- route synchronous requirements.txt fallback through the configured object storage provider
- add synchronous Azure Blob module/index fallback for worker import cache misses
- keep S3 behavior covered for S3 deployments

## Verification
- python -m pytest api/tests/unit/core/test_requirements_cache.py api/tests/unit/test_virtual_import_s3_fallback.py api/tests/unit/test_repo_storage.py api/tests/unit/services/test_file_storage_backend_selection.py -q
- python -m ruff check api/src/core/requirements_cache.py api/src/core/module_cache_sync.py api/tests/unit/core/test_requirements_cache.py api/tests/unit/test_virtual_import_s3_fallback.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Blob storage as a configurable object storage backend alongside S3 for module and requirements caching.

* **Tests**
  * Added comprehensive test coverage for Azure Blob storage backend integration.
  * Updated existing tests to support multiple storage provider scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->