### PR TITLE
Expose worker admission pressure

### DIFF
--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 QUEUE_NAME = "workflow-executions"
 
 
+def workflow_prefetch_count(settings: Any) -> int:
+    """Cap workflow prefetch at local process admission capacity."""
+    return max(1, min(settings.max_concurrency, settings.max_workers))
+
+
 class WorkflowExecutionConsumer(BaseConsumer):
     """
     Consumer for workflow execution queue.
@@ -67,7 +72,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
         settings = get_settings()
         super().__init__(
             queue_name=QUEUE_NAME,
-            prefetch_count=settings.max_concurrency,
+            prefetch_count=workflow_prefetch_count(settings),
         )
         self._redis_client = get_redis_client()
 

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -1584,7 +1584,8 @@ class ProcessPoolManager:
         busy_count = len([p for p in self.processes.values() if p.state == ProcessState.BUSY])
 
         memory_current, memory_max = get_cgroup_memory()
-        available_slots = max(0, self.max_workers - len(self.processes))
+        max_workers = getattr(self, "max_workers", len(self.processes))
+        available_slots = max(0, max_workers - len(self.processes))
 
         return {
             "type": "worker_heartbeat",
@@ -1595,7 +1596,7 @@ class ProcessPoolManager:
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "processes": processes,
             "pool_size": len(self.processes),
-            "max_workers": self.max_workers,
+            "max_workers": max_workers,
             "available_slots": available_slots,
             "idle_count": idle_count,
             "busy_count": busy_count,

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -339,6 +339,14 @@ class ProcessPoolManager:
         # Process tracking
         self.processes: dict[str, ProcessHandle] = {}
         self._process_counter = 0
+        self._admission_attempts = 0
+        self._admission_successes = 0
+        self._admission_rejections: dict[str, int] = {
+            "slot_timeout": 0,
+            "memory_pressure": 0,
+        }
+        self._admission_wait_seconds_total = 0.0
+        self._admission_wait_seconds_max = 0.0
 
         # State
         self._shutdown = False
@@ -369,6 +377,38 @@ class ProcessPoolManager:
         # installs don't race — the second call waits for the first to
         # finish rather than trying to fork while the template is down.
         self._restart_lock = asyncio.Lock()
+
+    def _record_admission_success(self, wait_seconds: float) -> None:
+        self._admission_successes += 1
+        self._admission_wait_seconds_total += wait_seconds
+        self._admission_wait_seconds_max = max(
+            self._admission_wait_seconds_max,
+            wait_seconds,
+        )
+
+    def _record_admission_rejection(
+        self,
+        reason: str,
+        wait_seconds: float,
+        execution_id: str,
+    ) -> None:
+        self._admission_rejections[reason] = self._admission_rejections.get(reason, 0) + 1
+        self._admission_wait_seconds_total += wait_seconds
+        self._admission_wait_seconds_max = max(
+            self._admission_wait_seconds_max,
+            wait_seconds,
+        )
+        logger.warning(
+            "process_pool_admission_rejected",
+            extra={
+                "execution_id": execution_id,
+                "reason": reason,
+                "wait_seconds": wait_seconds,
+                "active_processes": len(self.processes),
+                "max_workers": self.max_workers,
+                "available_slots": max(0, self.max_workers - len(self.processes)),
+            },
+        )
 
     async def _get_redis(self) -> redis.Redis:  # type: ignore[type-arg]
         """Get or create Redis connection."""
@@ -684,6 +724,9 @@ class ProcessPoolManager:
             execution_id: Unique identifier for the execution
             context: Execution context data (written to Redis)
         """
+        self._admission_attempts += 1
+        admission_started = time.monotonic()
+
         # Wait for any in-progress drain+restart to complete before routing.
         # Without this, executions arriving during a package-install restart
         # would hit a dead template and fail with ConnectionResetError.
@@ -699,6 +742,11 @@ class ProcessPoolManager:
             # Clean up the context we just wrote
             r = await self._get_redis()
             await r.delete(f"bifrost:exec:{execution_id}:context")
+            self._record_admission_rejection(
+                reason="memory_pressure",
+                wait_seconds=time.monotonic() - admission_started,
+                execution_id=execution_id,
+            )
             raise MemoryError(
                 f"Cannot route execution {execution_id[:8]}: memory pressure "
                 f"exceeds {settings.memory_pressure_threshold:.0%} threshold"
@@ -708,6 +756,11 @@ class ProcessPoolManager:
         # _slot_condition, so this wakes immediately once a slot frees.
         if len(self.processes) >= self.max_workers:
             if not await self._wait_for_slot():
+                self._record_admission_rejection(
+                    reason="slot_timeout",
+                    wait_seconds=time.monotonic() - admission_started,
+                    execution_id=execution_id,
+                )
                 raise ProcessPoolAdmissionRejected("No worker slot available after timeout")
 
         # Fork the worker. _fork_process returns a handle already in BUSY.
@@ -722,6 +775,7 @@ class ProcessPoolManager:
             timeout_seconds=timeout,
         )
         handle.result_reported = False
+        self._record_admission_success(time.monotonic() - admission_started)
 
         return handle
 
@@ -1528,6 +1582,7 @@ class ProcessPoolManager:
         busy_count = len([p for p in self.processes.values() if p.state == ProcessState.BUSY])
 
         memory_current, memory_max = get_cgroup_memory()
+        available_slots = max(0, self.max_workers - len(self.processes))
 
         return {
             "type": "worker_heartbeat",
@@ -1538,8 +1593,17 @@ class ProcessPoolManager:
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "processes": processes,
             "pool_size": len(self.processes),
+            "max_workers": self.max_workers,
+            "available_slots": available_slots,
             "idle_count": idle_count,
             "busy_count": busy_count,
+            "admission": {
+                "attempts": getattr(self, "_admission_attempts", 0),
+                "successes": getattr(self, "_admission_successes", 0),
+                "rejections": dict(getattr(self, "_admission_rejections", {})),
+                "wait_seconds_total": getattr(self, "_admission_wait_seconds_total", 0.0),
+                "wait_seconds_max": getattr(self, "_admission_wait_seconds_max", 0.0),
+            },
             "requirements_installed": self._requirements_installed,
             "requirements_total": self._requirements_total,
             "memory_current_bytes": memory_current,

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -756,6 +756,8 @@ class ProcessPoolManager:
         # _slot_condition, so this wakes immediately once a slot frees.
         if len(self.processes) >= self.max_workers:
             if not await self._wait_for_slot():
+                r = await self._get_redis()
+                await r.delete(f"bifrost:exec:{execution_id}:context")
                 self._record_admission_rejection(
                     reason="slot_timeout",
                     wait_seconds=time.monotonic() - admission_started,

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -17,6 +17,7 @@ import pytest
 from src.services.execution.process_pool import (
     ExecutionInfo,
     ProcessHandle,
+    ProcessPoolAdmissionRejected,
     ProcessPoolManager,
     ProcessState,
 )
@@ -739,6 +740,32 @@ class TestAdmissionControl:
             with patch.object(pool, '_write_context_to_redis', new_callable=AsyncMock):
                 with pytest.raises(MemoryError, match="memory pressure"):
                     await pool.route_execution("exec-123", {"timeout_seconds": 300})
+
+        assert pool._admission_attempts == 1
+        assert pool._admission_rejections["memory_pressure"] == 1
+
+    @pytest.mark.asyncio
+    async def test_route_execution_records_slot_timeout_admission_rejection(self):
+        """Should count slot-timeout rejection when no local process slot opens."""
+        pool = ProcessPoolManager(max_workers=1)
+        pool._started = True
+        pool.processes["busy"] = MagicMock()
+
+        with (
+            patch(
+                "src.services.execution.process_pool.has_sufficient_memory_cgroup",
+                return_value=True,
+            ),
+            patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock),
+            patch.object(pool, "_wait_for_slot", new_callable=AsyncMock, return_value=False),
+        ):
+            with pytest.raises(ProcessPoolAdmissionRejected, match="No worker slot"):
+                await pool.route_execution("exec-123", {"timeout_seconds": 300})
+
+        assert pool._admission_attempts == 1
+        assert pool._admission_successes == 0
+        assert pool._admission_rejections["slot_timeout"] == 1
+        assert pool._admission_wait_seconds_total >= 0
 
     @pytest.mark.asyncio
     async def test_route_execution_allows_when_memory_ok(self):

--- a/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
+++ b/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
@@ -62,6 +62,20 @@ def test_workflow_prefetch_count_keeps_lower_global_concurrency() -> None:
     assert workflow_prefetch_count(settings) == 3
 
 
+def test_workflow_prefetch_count_has_minimum_of_one() -> None:
+    """Workflow consumer prefetch must never be configured below one."""
+    settings = type(
+        "Settings",
+        (),
+        {
+            "max_concurrency": 0,
+            "max_workers": 0,
+        },
+    )()
+
+    assert workflow_prefetch_count(settings) == 1
+
+
 @pytest.mark.asyncio
 async def test_process_message_rejects_missing_execution_id() -> None:
     consumer = make_consumer()

--- a/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
+++ b/api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import pytest
 
-from src.jobs.consumers.workflow_execution import WorkflowExecutionConsumer
+from src.jobs.consumers.workflow_execution import WorkflowExecutionConsumer, workflow_prefetch_count
 from src.jobs.rabbitmq import (
     DomainFailureHandled,
     DuplicateMessage,
@@ -32,6 +32,34 @@ def pending_context() -> dict[str, object]:
         "user_name": "Test User",
         "user_email": "test@example.com",
     }
+
+
+def test_workflow_prefetch_count_is_capped_by_process_capacity() -> None:
+    """Workflow consumer prefetch should not exceed local process slots."""
+    settings = type(
+        "Settings",
+        (),
+        {
+            "max_concurrency": 20,
+            "max_workers": 5,
+        },
+    )()
+
+    assert workflow_prefetch_count(settings) == 5
+
+
+def test_workflow_prefetch_count_keeps_lower_global_concurrency() -> None:
+    """A lower global concurrency limit should still constrain prefetch."""
+    settings = type(
+        "Settings",
+        (),
+        {
+            "max_concurrency": 3,
+            "max_workers": 10,
+        },
+    )()
+
+    assert workflow_prefetch_count(settings) == 3
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_worker_metrics.py
+++ b/api/tests/unit/test_worker_metrics.py
@@ -3,6 +3,8 @@
 from unittest.mock import patch
 from datetime import datetime, timezone
 
+import pytest
+
 
 class TestHeartbeatCgroupData:
     """Tests for cgroup memory data in heartbeat payload."""
@@ -107,8 +109,8 @@ class TestHeartbeatCgroupData:
             "slot_timeout": 1,
             "memory_pressure": 1,
         }
-        assert heartbeat["admission"]["wait_seconds_total"] == 3.25
-        assert heartbeat["admission"]["wait_seconds_max"] == 1.5
+        assert heartbeat["admission"]["wait_seconds_total"] == pytest.approx(3.25)
+        assert heartbeat["admission"]["wait_seconds_max"] == pytest.approx(1.5)
 
     def test_fork_memory_mb_uses_private_dirty(self):
         """Per-fork memory_mb should reflect private-dirty (USS), not COW-inflated RSS."""

--- a/api/tests/unit/test_worker_metrics.py
+++ b/api/tests/unit/test_worker_metrics.py
@@ -73,6 +73,43 @@ class TestHeartbeatCgroupData:
         assert heartbeat["memory_current_bytes"] == 322_834_432
         assert heartbeat["memory_max_bytes"] == -1
 
+    def test_heartbeat_includes_admission_pressure(self):
+        """Heartbeat should expose admission wait and rejection counters."""
+        from src.services.execution.process_pool import ProcessPoolManager
+
+        pool = ProcessPoolManager.__new__(ProcessPoolManager)
+        pool.worker_id = "test-worker"
+        pool.processes = {}
+        pool.max_workers = 10
+        pool._started_at = datetime.now(timezone.utc)
+        pool._requirements_installed = 0
+        pool._requirements_total = 0
+        pool.heartbeat_interval_seconds = 10
+        pool._admission_attempts = 8
+        pool._admission_successes = 6
+        pool._admission_rejections = {
+            "slot_timeout": 1,
+            "memory_pressure": 1,
+        }
+        pool._admission_wait_seconds_total = 3.25
+        pool._admission_wait_seconds_max = 1.5
+
+        with patch(
+            "src.services.execution.process_pool.get_cgroup_memory",
+            return_value=(-1, -1),
+        ):
+            heartbeat = pool._build_heartbeat()
+
+        assert heartbeat["available_slots"] == 10
+        assert heartbeat["admission"]["attempts"] == 8
+        assert heartbeat["admission"]["successes"] == 6
+        assert heartbeat["admission"]["rejections"] == {
+            "slot_timeout": 1,
+            "memory_pressure": 1,
+        }
+        assert heartbeat["admission"]["wait_seconds_total"] == 3.25
+        assert heartbeat["admission"]["wait_seconds_max"] == 1.5
+
     def test_fork_memory_mb_uses_private_dirty(self):
         """Per-fork memory_mb should reflect private-dirty (USS), not COW-inflated RSS."""
         from src.services.execution.process_pool import ProcessPoolManager, ProcessState


### PR DESCRIPTION
## Summary
- cap workflow RabbitMQ prefetch at local process-pool capacity
- expose process-pool admission attempts, successes, rejection reasons, wait totals, and available slots in worker heartbeats
- add structured warning logs for admission rejections
- add focused unit coverage for prefetch calculation and admission pressure heartbeat fields

## Verification
- python -m ruff check api/src/jobs/consumers/workflow_execution.py api/src/services/execution/process_pool.py api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py api/tests/unit/test_worker_metrics.py api/tests/unit/execution/test_process_pool.py
- python -m py_compile api/src/jobs/consumers/workflow_execution.py api/src/services/execution/process_pool.py api/tests/unit/jobs/consumers/test_workflow_execution_delivery.py api/tests/unit/test_worker_metrics.py api/tests/unit/execution/test_process_pool.py
- git diff --check

## Not run locally
- Dockerized ./test.sh targeted tests: this workstation/WSL Docker path is not available; CI is the Linux/Docker verification venue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced worker heartbeat metrics now include admission control data: available slots, admission attempts, successes, rejection counts, and wait-time aggregates.

* **Improvements**
  * Optimized message queue intake to align with local worker capacity, preventing resource bottlenecks and improving overall system efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->