### PR TITLE
Reap exited template children to prevent zombie one-shot workers

### DIFF
--- a/api/src/services/execution/template_process.py
+++ b/api/src/services/execution/template_process.py
@@ -90,6 +90,25 @@ CMD_FORK = "fork"
 CMD_SHUTDOWN = "shutdown"
 
 
+def _reap_exited_children() -> None:
+    """Reap exited forked children to avoid zombie accumulation."""
+    while True:
+        try:
+            pid, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            # No child processes exist.
+            break
+        except OSError as e:
+            logger.debug(f"template waitpid ignored: {e}")
+            break
+
+        if pid == 0:
+            # At least one child exists, but none has exited yet.
+            break
+
+        logger.debug(f"Reaped exited child process {pid}")
+
+
 def _load_execution_infrastructure(install_requirements_on_startup: bool) -> None:
     """Load execution helpers and optionally install workspace requirements."""
     from src.services.execution.virtual_import import install_virtual_import_hook
@@ -190,6 +209,7 @@ def _template_main(
     # ----- Fork loop -----
     # Single-threaded, no event loop. Just wait for commands and fork.
     while True:
+        _reap_exited_children()
         try:
             if not pipe.poll(timeout=1.0):
                 continue
@@ -211,6 +231,7 @@ def _template_main(
             result_send: Connection = cmd["result_send"]
             _handle_fork_request(pipe, worker_id, persistent, work_recv, result_send)
 
+    _reap_exited_children()
     logger.info("Template process exiting")
 
 

--- a/api/tests/unit/execution/test_template_process.py
+++ b/api/tests/unit/execution/test_template_process.py
@@ -16,6 +16,7 @@ import pytest
 from src.services.execution.template_process import (
     TemplateProcess,
     _load_execution_infrastructure,
+    _reap_exited_children,
 )
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,18 @@ class TestTemplateProcessLifecycle:
         """Shutting down before starting should not raise."""
         template = TemplateProcess()
         template.shutdown()  # Should not raise
+
+
+class TestTemplateProcessReaping:
+    """Tests for zombie child reaping behavior in template process."""
+
+    def test_reap_exited_children_drains_until_no_more_exits(self):
+        """Should call waitpid repeatedly until no exited children remain."""
+        with patch("src.services.execution.template_process.os.waitpid") as waitpid:
+            waitpid.side_effect = [(101, 0), (102, 0), (0, 0)]
+            _reap_exited_children()
+
+        assert waitpid.call_count == 3
 
 
 class TestTemplateProcessFork:

--- a/api/tests/unit/execution/test_template_process.py
+++ b/api/tests/unit/execution/test_template_process.py
@@ -136,10 +136,12 @@ class TestTemplateProcessFork:
         template = TemplateProcess()
         template.start()
         children = []
+        queue_handles = []
         try:
             for _ in range(3):
                 child_pid, wq, rq = template.fork()
                 children.append(child_pid)
+                queue_handles.append((wq, rq))
 
             # All should be unique PIDs
             assert len(set(children)) == 3
@@ -148,6 +150,9 @@ class TestTemplateProcessFork:
             for pid in children:
                 os.kill(pid, 0)  # Should not raise
         finally:
+            for wq, rq in queue_handles:
+                wq.close()
+                rq.close()
             for pid in children:
                 try:
                     os.kill(pid, signal.SIGTERM)
@@ -267,16 +272,18 @@ class TestForkPerformance:
         template = TemplateProcess()
         template.start()
         children = []
+        queue_handles = []
         try:
             template_rss_kb = _get_rss_kb(template.pid)
             template_rss_mb = template_rss_kb / 1024 if template_rss_kb > 0 else -1
 
             start = time.monotonic()
             for i in range(10):
-                child_pid, _, _ = template.fork(
+                child_pid, wq, rq = template.fork(
                     worker_id=f"mem-{i}", persistent=True,
                 )
                 children.append(child_pid)
+                queue_handles.append((wq, rq))
             fork_all_ms = (time.monotonic() - start) * 1000
 
             time.sleep(0.1)
@@ -290,6 +297,9 @@ class TestForkPerformance:
 
             assert alive >= 8, f"Only {alive}/10 children alive"
         finally:
+            for wq, rq in queue_handles:
+                wq.close()
+                rq.close()
             for pid in children:
                 try:
                     os.kill(pid, signal.SIGTERM)


### PR DESCRIPTION
### Motivation
- Recent changes made every execution fork a one-shot child (`persistent=False`) leaving the template process as the children's parent, which allowed exited children to become zombies and risk exhausting the container PID table.
- The template process had no mechanism to reap exited forked children, so repeated executions could cause an availability DoS.

### Description
- Add a `_reap_exited_children()` helper that calls `os.waitpid(-1, os.WNOHANG)` in a loop to drain any exited children without blocking. 
- Call `_reap_exited_children()` on each iteration of the template fork loop and once during shutdown so the template continuously reaps completed one-shot workers. 
- Add a focused unit test `test_reap_exited_children_drains_until_no_more_exits` that patches `os.waitpid` and verifies the reaper loops until no more exited children are reported.

### Testing
- Ran `python -m compileall api/src/services/execution/template_process.py api/tests/unit/execution/test_template_process.py` and compilation succeeded. 
- Added a pure-unit test that exercises `_reap_exited_children()` via mocking `os.waitpid`; the test is present in the unit suite. 
- Attempted to run the repo test runner (`./test.sh ...`) but the project test stack is not running in this environment (`./test.sh stack up` required), so full unit/e2e test execution was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17223d37108328984f86c2608911e8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template process cleanup to prevent accumulation of exited child processes during runtime and at shutdown.

* **Tests**
  * Added unit tests validating child-process reaping behavior.
  * Updated tests to ensure worker/result queue resources are closed during teardown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches template process lifecycle and waitpid handling for all forked workers; change is small and localized but affects execution availability under load.
> 
> **Overview**
> Fixes **zombie forked workers** accumulating under the template process when one-shot children exit without being reaped.
> 
> Adds **`_reap_exited_children()`**, which drains exited children via non-blocking **`waitpid(-1, WNOHANG)`** in a loop, and invokes it on each pass through the template **fork loop** and once at **shutdown**. Adds a unit test that mocks **`waitpid`** to assert repeated reaping until no more exits; fork tests now **close work/result queue handles** during cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb1db3b863fd4d6a12b787b0c9fae914ae931ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->