### PR TITLE
Harden dotenv loading against API URL override

### DIFF
--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -128,7 +128,7 @@ _thread_local = threading.local()
 # Walk upward from cwd, not from this file. With pipx-installed CLIs, __file__
 # lives in the pipx venv and the default upward walk never reaches the user's
 # workspace, so a .env in the project root is silently ignored.
-load_allowed_dotenv()
+load_allowed_dotenv(override=False)
 
 
 async def refresh_tokens() -> bool:

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -67,7 +67,7 @@ def get_credentials_path() -> Path:
 
 
 def load_allowed_dotenv(
-    dotenv_path: str | os.PathLike[str] | None = None, *, override: bool = True
+    dotenv_path: str | os.PathLike[str] | None = None, *, override: bool = False
 ) -> None:
     """Load the CWD ``.env`` allowlist used by the CLI.
 

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -99,6 +99,24 @@ class TestDotenvAllowlist:
         assert "HTTPS_PROXY" not in os.environ
         assert "SSL_CERT_FILE" not in os.environ
 
+    def test_load_allowed_dotenv_does_not_override_existing_api_url_by_default(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text("BIFROST_API_URL=https://from-dotenv.example\n", encoding="utf-8")
+        monkeypatch.setenv("BIFROST_API_URL", "https://from-env.example")
+
+        creds_mod.load_allowed_dotenv(env_file)
+
+        assert os.environ["BIFROST_API_URL"] == "https://from-env.example"
+
+    def test_load_allowed_dotenv_can_override_when_explicitly_enabled(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text("BIFROST_API_URL=https://from-dotenv.example\n", encoding="utf-8")
+        monkeypatch.setenv("BIFROST_API_URL", "https://from-env.example")
+
+        creds_mod.load_allowed_dotenv(env_file, override=True)
+
+        assert os.environ["BIFROST_API_URL"] == "https://from-dotenv.example"
+
 
 # ---------- JsonBackend (multi-record) ----------
 


### PR DESCRIPTION
### Motivation
- A project-local `.env` could override `BIFROST_API_URL` during SDK/CLI import and cause inherited `BIFROST_ACCESS_TOKEN`/`BIFROST_REFRESH_TOKEN` to be sent to an attacker-controlled endpoint.  
- The change prevents an attacker-controlled working directory from silently redirecting SDK traffic while preserving legitimate override capability when explicitly requested.

### Description
- Change `load_allowed_dotenv()` default to `override=False` so allowlisted `.env` keys do not replace existing environment values by default.  
- Make the SDK import-time call explicit with `load_allowed_dotenv(override=False)` in `api/bifrost/client.py`.  
- Add unit tests to `api/tests/unit/test_credentials.py` that assert default non-override behavior and that `override=True` still allows an explicit override.  
- Files changed: `api/bifrost/credentials.py`, `api/bifrost/client.py`, `api/tests/unit/test_credentials.py`.

### Testing
- Added unit tests verifying `load_allowed_dotenv()` default behavior and explicit `override=True`; these tests are included in `api/tests/unit/test_credentials.py`.  
- Attempted to run the repository test runner (`./test.sh ...`) but automated execution was blocked in this environment because required Docker tooling is unavailable (`docker: command not found`), so unit tests were not executed here.  
- The changes are minimal and focused; CI should run the new unit tests and confirm behavior in a proper test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120f5a02288328a04e5bccad5a8026)