### PR TITLE
Fix worker pressure and restart-orphan cleanup

### DIFF
--- a/api/src/core/module_cache_sync.py
+++ b/api/src/core/module_cache_sync.py
@@ -58,6 +58,10 @@ def _get_s3_client() -> Any:
     """
     global _s3_client, _s3_available
 
+    if _object_storage_provider() != "s3":
+        _s3_available = False
+        return None
+
     if _s3_available is False:
         return None
 
@@ -95,7 +99,12 @@ def _get_s3_client() -> Any:
 
 
 def _object_storage_provider() -> str:
-    return os.environ.get("BIFROST_OBJECT_STORAGE_PROVIDER", "s3").lower()
+    provider = os.environ.get("BIFROST_OBJECT_STORAGE_PROVIDER")
+    if provider:
+        return provider.lower()
+    if os.environ.get("BIFROST_AZURE_BLOB_ACCOUNT_URL") and os.environ.get("BIFROST_AZURE_BLOB_CONTAINER"):
+        return "azure_blob"
+    return "s3"
 
 
 def _get_blob_container_client() -> Any:

--- a/api/src/core/module_cache_sync.py
+++ b/api/src/core/module_cache_sync.py
@@ -59,7 +59,6 @@ def _get_s3_client() -> Any:
     global _s3_client, _s3_available
 
     if _object_storage_provider() != "s3":
-        _s3_available = False
         return None
 
     if _s3_available is False:

--- a/api/src/jobs/schedulers/execution_cleanup.py
+++ b/api/src/jobs/schedulers/execution_cleanup.py
@@ -8,6 +8,7 @@ Runs every 5 minutes to find and timeout stuck executions.
 """
 
 import logging
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -15,6 +16,7 @@ from sqlalchemy import select, and_
 
 from src.core.database import get_session_factory
 from src.core.pubsub import publish_execution_update, publish_history_update
+from src.core.redis_client import get_redis_client
 from src.models import Execution as ExecutionModel, ExecutionLog
 from src.models.orm.workflows import Workflow
 
@@ -24,6 +26,83 @@ logger = logging.getLogger(__name__)
 PENDING_TIMEOUT_MINUTES = 10  # If PENDING for 10+ minutes, it's stuck in queue
 RUNNING_TIMEOUT_MINUTES = 30  # If RUNNING for 30+ minutes, worker likely crashed
 CANCELLING_TIMEOUT_MINUTES = 3  # If CANCELLING for 3+ minutes, worker failed to cancel
+RESTART_ORPHAN_GRACE_SECONDS = 120
+
+
+async def _load_worker_heartbeat_state(now: datetime) -> dict[str, Any]:
+    """Read Redis worker heartbeats for restart-orphan detection."""
+    state: dict[str, Any] = {
+        "active_execution_ids": set(),
+        "oldest_worker_started_at": None,
+        "heartbeat_count": 0,
+    }
+    redis_client = get_redis_client()
+    if not redis_client:
+        return state
+
+    cursor = 0
+    while True:
+        cursor, keys = await redis_client.scan(cursor, match="bifrost:pool:*:heartbeat", count=100)
+        for key in keys:
+            raw = await redis_client.get(key)
+            if not raw:
+                continue
+            try:
+                heartbeat = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            state["heartbeat_count"] += 1
+            started_at = _parse_heartbeat_time(heartbeat.get("started_at"))
+            if started_at is not None:
+                oldest = state["oldest_worker_started_at"]
+                state["oldest_worker_started_at"] = started_at if oldest is None else min(oldest, started_at)
+            for process in heartbeat.get("processes") or []:
+                execution = process.get("execution") if isinstance(process, dict) else None
+                execution_id = execution.get("execution_id") if isinstance(execution, dict) else None
+                if execution_id:
+                    state["active_execution_ids"].add(str(execution_id))
+        if cursor == 0:
+            break
+
+    return state
+
+
+def _parse_heartbeat_time(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_restart_orphan(
+    execution: ExecutionModel,
+    *,
+    now: datetime,
+    heartbeat_state: dict[str, Any],
+) -> bool:
+    if not execution.started_at:
+        return False
+    if heartbeat_state.get("heartbeat_count", 0) <= 0:
+        return False
+    if str(execution.id) in heartbeat_state.get("active_execution_ids", set()):
+        return False
+
+    oldest_worker_started_at = heartbeat_state.get("oldest_worker_started_at")
+    if oldest_worker_started_at is None:
+        return False
+
+    started_at = execution.started_at
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=timezone.utc)
+
+    if started_at >= oldest_worker_started_at:
+        return False
+    return (now - oldest_worker_started_at).total_seconds() >= RESTART_ORPHAN_GRACE_SECONDS
 
 
 async def cleanup_stuck_executions() -> dict[str, Any]:
@@ -51,6 +130,8 @@ async def cleanup_stuck_executions() -> dict[str, Any]:
     now = datetime.now(timezone.utc)
 
     try:
+        heartbeat_state = await _load_worker_heartbeat_state(now)
+
         # Collect data for WebSocket broadcasts (published after session closes)
         pubsub_updates: list[dict] = []
 
@@ -81,6 +162,9 @@ async def cleanup_stuck_executions() -> dict[str, Any]:
             )
             running_stuck = []
             for execution, wf_timeout in running_result.all():
+                if _is_restart_orphan(execution, now=now, heartbeat_state=heartbeat_state):
+                    running_stuck.append(execution)
+                    continue
                 # timeout_seconds == 0 means no timeout — skip entirely
                 if wf_timeout is not None and wf_timeout == 0:
                     continue
@@ -118,10 +202,16 @@ async def cleanup_stuck_executions() -> dict[str, Any]:
 
                     elif execution.status == ExecutionStatus.RUNNING.value:
                         elapsed_min = int((now - execution.started_at).total_seconds() / 60) if execution.started_at else RUNNING_TIMEOUT_MINUTES
-                        timeout_reason = (
-                            f"Stuck in RUNNING status for {elapsed_min}+ minutes. "
-                            "Likely worker crash or workflow hang."
-                        )
+                        if _is_restart_orphan(execution, now=now, heartbeat_state=heartbeat_state):
+                            timeout_reason = (
+                                f"Stuck in RUNNING status for {elapsed_min}+ minutes. "
+                                "Execution predates all current worker heartbeats and is not claimed by any live worker."
+                            )
+                        else:
+                            timeout_reason = (
+                                f"Stuck in RUNNING status for {elapsed_min}+ minutes. "
+                                "Likely worker crash or workflow hang."
+                            )
                         final_status = ExecutionStatus.TIMEOUT
                         results["running_timeouts"] += 1
 

--- a/api/tests/unit/core/test_module_cache_sync.py
+++ b/api/tests/unit/core/test_module_cache_sync.py
@@ -11,7 +11,6 @@ def test_s3_client_disabled_when_provider_is_azure_blob(monkeypatch):
     module_cache_sync._s3_client = None
 
     assert module_cache_sync._get_s3_client() is None
-    assert module_cache_sync._s3_available is False
 
 
 def test_object_storage_provider_prefers_blob_when_blob_configured(monkeypatch):

--- a/api/tests/unit/core/test_module_cache_sync.py
+++ b/api/tests/unit/core/test_module_cache_sync.py
@@ -1,0 +1,24 @@
+import importlib
+
+
+def test_s3_client_disabled_when_provider_is_azure_blob(monkeypatch):
+    monkeypatch.setenv("BIFROST_OBJECT_STORAGE_PROVIDER", "azure_blob")
+    monkeypatch.setenv("BIFROST_S3_ACCESS_KEY", "access")
+    monkeypatch.setenv("BIFROST_S3_SECRET_KEY", "secret")
+
+    module_cache_sync = importlib.import_module("src.core.module_cache_sync")
+    module_cache_sync._s3_available = None
+    module_cache_sync._s3_client = None
+
+    assert module_cache_sync._get_s3_client() is None
+    assert module_cache_sync._s3_available is False
+
+
+def test_object_storage_provider_prefers_blob_when_blob_configured(monkeypatch):
+    monkeypatch.delenv("BIFROST_OBJECT_STORAGE_PROVIDER", raising=False)
+    monkeypatch.setenv("BIFROST_AZURE_BLOB_ACCOUNT_URL", "https://example.blob.core.windows.net")
+    monkeypatch.setenv("BIFROST_AZURE_BLOB_CONTAINER", "bifrost-objects")
+
+    module_cache_sync = importlib.import_module("src.core.module_cache_sync")
+
+    assert module_cache_sync._object_storage_provider() == "azure_blob"

--- a/api/tests/unit/jobs/schedulers/test_execution_cleanup.py
+++ b/api/tests/unit/jobs/schedulers/test_execution_cleanup.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+from src.jobs.schedulers.execution_cleanup import _is_restart_orphan
+
+
+def test_is_restart_orphan_when_execution_predates_current_workers():
+    now = datetime.now(timezone.utc)
+    execution = SimpleNamespace(
+        id=uuid4(),
+        started_at=now - timedelta(minutes=15),
+    )
+    heartbeat_state = {
+        "active_execution_ids": set(),
+        "oldest_worker_started_at": now - timedelta(minutes=5),
+        "heartbeat_count": 3,
+    }
+
+    assert _is_restart_orphan(execution, now=now, heartbeat_state=heartbeat_state)
+
+
+def test_is_restart_orphan_keeps_execution_claimed_by_heartbeat():
+    now = datetime.now(timezone.utc)
+    execution_id = uuid4()
+    execution = SimpleNamespace(
+        id=execution_id,
+        started_at=now - timedelta(minutes=15),
+    )
+    heartbeat_state = {
+        "active_execution_ids": {str(execution_id)},
+        "oldest_worker_started_at": now - timedelta(minutes=5),
+        "heartbeat_count": 3,
+    }
+
+    assert not _is_restart_orphan(execution, now=now, heartbeat_state=heartbeat_state)
+
+
+def test_is_restart_orphan_waits_for_worker_grace_period():
+    now = datetime.now(timezone.utc)
+    execution = SimpleNamespace(
+        id=uuid4(),
+        started_at=now - timedelta(minutes=15),
+    )
+    heartbeat_state = {
+        "active_execution_ids": set(),
+        "oldest_worker_started_at": now - timedelta(seconds=30),
+        "heartbeat_count": 3,
+    }
+
+    assert not _is_restart_orphan(execution, now=now, heartbeat_state=heartbeat_state)


### PR DESCRIPTION
## Summary
- mark Running executions as timed out when they predate all current worker heartbeats and are not claimed by any live worker
- hard-disable S3 module fallback unless the object storage provider is S3, with Blob-configured deployments defaulting to Azure Blob
- add focused unit coverage for restart-orphan detection and Blob-vs-S3 fallback selection

## Verification
- `.venv\Scripts\python.exe -m pytest api\tests\unit\core\test_module_cache_sync.py api\tests\unit\jobs\schedulers\test_execution_cleanup.py -q`
- `.venv\Scripts\python.exe -m ruff check api\src\core\module_cache_sync.py api\src\jobs\schedulers\execution_cleanup.py api\tests\unit\core\test_module_cache_sync.py api\tests\unit\jobs\schedulers\test_execution_cleanup.py`