### PR TITLE
docs: MTG agent guide (Persona A/B, shared dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ Tool-neutral guidance for AI coding agents in `MTG-Thomas/bifrost`. This fork tr
 
 **New teammates and workspace-only work:** start with MTG onboarding, not this file alone.
 
-- [Develop at MTG (Windows)](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/develop-at-mtg-windows.md) — Persona A (default) and Persona B overview
-- `MTG-Thomas/bifrost-workspace` + `AGENTS.md` — automation authoring against shared dev
+- [Develop at MTG (Windows)](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/develop-at-mtg-windows.md) — Persona A (default) and Persona B overview (`MTG-Thomas/bifrost-ops`)
+- [Bifrost workspace agent guide](https://github.com/MTG-Thomas/bifrost-workspace/blob/main/AGENTS.md) — automation authoring against `https://dev.bifrost.midtowntg.com` (`MTG-Thomas/bifrost-workspace`)
 
 ## Personas
 
@@ -90,7 +90,7 @@ Do not expose secret values in chat, logs, test fixtures, screenshots, or commit
 
 - `CLAUDE.md` — upstream-style platform commands, manifest rules, verification checklist
 - `CONTRIBUTING.md` — human-facing PR expectations
-- `MTG-Thomas/bifrost-ops/docs/develop-at-mtg-windows.md` — team onboarding (Windows-first)
-- `MTG-Thomas/bifrost-ops/docs/proxmox-shared-dev-roadmap.md` — shared lab + Entra direction
+- [Develop at MTG (Windows)](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/develop-at-mtg-windows.md) — team onboarding (Windows-first)
+- [Proxmox shared dev roadmap](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/proxmox-shared-dev-roadmap.md) — shared lab + Entra direction
 - `.claude/skills/` — upstream maintainer workflows (release, issues); **ignore for MTG day-to-day**
 - `api/tests/README.md` — test structure and fixture notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,38 +1,34 @@
-# Bifrost Agent Guide
+# Bifrost Agent Guide (MTG)
 
-This is the tool-neutral guidance for AI coding agents working in this repo. `CLAUDE.md` remains the detailed Bifrost playbook, but agents that support `AGENTS.md` should start here.
+Tool-neutral guidance for AI coding agents in `MTG-Thomas/bifrost`. This fork tracks [upstream](https://github.com/jackmusick/bifrost); `CLAUDE.md` remains the detailed **platform** playbook for Persona B work.
 
-## Read First
+**New teammates and workspace-only work:** start with MTG onboarding, not this file alone.
+
+- [Develop at MTG (Windows)](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/develop-at-mtg-windows.md) — Persona A (default) and Persona B overview
+- `MTG-Thomas/bifrost-workspace` + `AGENTS.md` — automation authoring against shared dev
+
+## Personas
+
+| Persona | Repo | Runtime | Verification |
+| --- | --- | --- | --- |
+| **A — Workspace author** | `bifrost-workspace` | `https://dev.bifrost.midtowntg.com` | Scoped sync, dev execution, PR CI — **no local Docker** |
+| **B — Platform engineer** | `bifrost` (this repo) | Shared Linux dev VM on `pve-t340` or CI | `./test.sh` on the VM; see [Proxmox shared dev roadmap](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/proxmox-shared-dev-roadmap.md) |
+
+Assume **Persona A** unless the task clearly changes `api/`, `client/`, migrations, or platform MCP/CLI surfaces.
+
+## Read First (Persona B)
 
 - Work from the current checkout state. Do not revert user or other-agent changes unless explicitly asked.
 - Use `rg` for search, inspect nearby code before editing, and follow existing patterns.
 - Keep changes narrow and reviewable. Avoid drive-by refactors, dead code, commented-out code, and unrequested fallback paths.
-- Treat `.bifrost/` as export-only. Mutate platform entities through the CLI or MCP surfaces described in `docs/llm.txt`.
+- Treat `.bifrost/` as export-only. Mutate platform entities through the CLI or MCP tools — not by hand-editing manifest YAML.
 - New MCP tools must be thin HTTP wrappers around REST endpoints. Do not add direct ORM/repository access in MCP tools.
 
-## Local Coordination
+## Development Environment (Persona B only)
 
-This machine may have several Codex threads working in the same repos. Before meaningful edits, claim your scope with:
+Platform work runs in **Docker on a Linux host** (shared `pve-t340` dev guest or CI). Do **not** ask Windows teammates to install Docker Desktop for routine work.
 
-Windows/PowerShell on this workstation:
-
-```powershell
-C:\Users\ThomasBray\.codex\bin\codex-agent-coordinator.ps1 claim --owner "<thread-or-role>" --repo "<repo-path>" --scope "<path-or-task>" --note "<short note>"
-```
-
-Portable command shape for other environments:
-
-```bash
-~/.codex/bin/codex-agent-coordinator claim --owner "<thread-or-role>" --repo "<repo-path>" --scope "<path-or-task>" --note "<short note>"
-```
-
-Check `status` and `conflicts` when working near active agents. Release the claim after meaningful work. The coordinator is warning-only local state under `%USERPROFILE%\.codex`; never add coordination files to the repo unless asked.
-
-## Development Environment
-
-Everything runs in Docker. Do not start host-side FastAPI, Vite, pytest, Postgres, Redis, RabbitMQ, or MinIO processes for normal development.
-
-Use the repo scripts:
+On the Linux dev host:
 
 ```bash
 ./debug.sh             # Boot the per-worktree dev stack
@@ -47,40 +43,54 @@ Use the repo scripts:
 
 Hot reload is expected. Do not restart containers for ordinary code changes. Use targeted restarts only when dependencies, migrations, or generated API types require them.
 
+Do not start host-side FastAPI, Vite, pytest, Postgres, Redis, RabbitMQ, or MinIO **on Windows** for platform verification.
+
+## Local Coordination (optional)
+
+Multiple Codex threads on one machine may use the local coordinator (warning-only, not in git):
+
+```powershell
+# If installed on the operator machine:
+& "$env:USERPROFILE\.codex\bin\codex-agent-coordinator.ps1" claim `
+  --owner "<thread-or-role>" --repo "<repo-path>" --scope "<path>" --note "<short note>"
+```
+
+Release claims after meaningful work. Skip entirely if the operator does not use Codex.
+
 ## Code Boundaries
 
-- Backend API is FastAPI/Python. Keep HTTP handlers thin and put business logic in the shared/service layer used by existing code.
-- Request and response contracts should use Pydantic models.
+- Backend API is FastAPI/Python. Keep HTTP handlers thin and put business logic in the shared/service layer.
+- Request and response contracts use Pydantic models in `api/shared/models.py`.
 - Frontend API types are generated from OpenAPI. Do not hand-write endpoint response types.
 - If API contracts change, run type generation from `client/` while the dev stack is running.
-- Manifest, CLI, and MCP surfaces must stay in sync when DTOs change. Run the DTO parity test called out in `CLAUDE.md`.
+- Manifest, CLI, and MCP surfaces must stay in sync when DTOs change. Run the DTO parity test in `CLAUDE.md`.
 
-## Testing And Verification
+## Testing And Verification (Persona B)
 
-Route testing through an e2e testing VM on `pve-t340` unless the user explicitly asks for a local-only check. Do not treat host-side runs on the operator workstation as the verification bar for Bifrost changes.
+- Primary bar: `./test.sh` on the **shared Linux dev environment** or **GitHub Actions** on `MTG-Thomas/bifrost`.
+- Do not treat a Windows laptop without the stack as the platform verification environment.
 
-On the VM, use `./test.sh`; do not run raw host `pytest` for repo tests. The script manages the Dockerized test dependencies and writes result artifacts.
+Match verification to the change (see `CLAUDE.md` for detail):
 
-Match verification to the change:
+- Backend logic: `api/tests/unit/`
+- Endpoint, queue, DB, or workflow behavior: `api/tests/e2e/`
+- React components: sibling `*.test.tsx`
+- Functional frontend modules under `client/src/lib/**` or `client/src/services/**`: sibling `*.test.ts`
+- User-facing UI flows: Playwright in `client/e2e/`
 
-- Backend logic: focused unit tests under `api/tests/unit/`.
-- Endpoint, queue, DB, or workflow behavior: e2e tests under `api/tests/e2e/`.
-- React components: sibling `*.test.tsx`.
-- Functional frontend modules under `client/src/lib/**` or `client/src/services/**`: sibling `*.test.ts`.
-- User-facing UI flows: Playwright happy-path coverage in `client/e2e/`.
-
-Before calling significant work complete, run the relevant checks from `CLAUDE.md` and report anything skipped with the reason.
+Before calling significant platform work complete, run the relevant checks from `CLAUDE.md` and report anything skipped with the reason.
 
 ## Security And Sensitive Paths
 
 Use extra care around auth, execution, multi-tenancy filters, migrations, secrets, manifest round-trips, and audit logging. Call out sensitive-path changes in summaries and PR descriptions.
 
-Do not expose secret values in chat, logs, test fixtures, screenshots, or committed files. Prefer live shape/status validation over copying credentials.
+Do not expose secret values in chat, logs, test fixtures, screenshots, or committed files.
 
 ## Useful References
 
-- `CLAUDE.md` - detailed repo rules, commands, and Bifrost-specific invariants.
-- `CONTRIBUTING.md` - human-facing PR and contribution expectations.
-- `docs/llm.txt` - CLI and MCP command reference for LLMs.
-- `.claude/skills/` - Claude-specific skills that document Bifrost setup, testing, release, security, and build workflows.
-- `api/tests/README.md` - test structure and fixture notes.
+- `CLAUDE.md` — upstream-style platform commands, manifest rules, verification checklist
+- `CONTRIBUTING.md` — human-facing PR expectations
+- `MTG-Thomas/bifrost-ops/docs/develop-at-mtg-windows.md` — team onboarding (Windows-first)
+- `MTG-Thomas/bifrost-ops/docs/proxmox-shared-dev-roadmap.md` — shared lab + Entra direction
+- `.claude/skills/` — upstream maintainer workflows (release, issues); **ignore for MTG day-to-day**
+- `api/tests/README.md` — test structure and fixture notes


### PR DESCRIPTION
## Summary
- Replace upstream-maintainer AGENTS.md defaults with MTG team onboarding
- Persona A (workspace, no laptop Docker) vs Persona B (platform on pve-t340/CI)
- Link bifrost-ops develop-at-mtg-windows and proxmox roadmap

## Test plan
- [ ] Docs only — review links and persona boundaries

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent onboarding; no runtime, auth, or application code.
> 
> **Overview**
> **`AGENTS.md`** is retargeted from generic upstream agent defaults to **MTG team onboarding**, framing this fork vs [upstream](https://github.com/jackmusick/bifrost) and pointing new contributors to **bifrost-ops** and **bifrost-workspace** before diving in.
> 
> The guide now splits work into **Persona A** (workspace automation on shared dev, no laptop Docker) and **Persona B** (platform changes in this repo, verified on **`pve-t340`/CI** via `./test.sh`), with a default assumption of Persona A unless the task touches `api/`, `client/`, migrations, or platform MCP/CLI.
> 
> Platform sections are relabeled and tightened: Docker-on-Linux-only expectations, explicit “don’t verify on Windows,” optional Codex coordinator usage, and **Useful References** swapped for MTG links while marking `.claude/skills/` as non–day-to-day for the team.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3201485ed6185268d7c9fabfe3477c41aedbd1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidance with clarified persona responsibilities, workspace vs platform boundaries, and environment setup instructions for improved consistency and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->