### PR TITLE
feat: DLQ CLI and summary backfill idempotency

### DIFF
--- a/api/alembic/versions/20260501a_summary_backfill_idempotency.py
+++ b/api/alembic/versions/20260501a_summary_backfill_idempotency.py
@@ -1,7 +1,7 @@
 """Add processed run tracking to summary backfill jobs.
 
 Revision ID: 20260501a_bf_idempotency
-Revises: 20260420_hmac_scheme
+Revises: 20260524_oauth_user_cascade
 Create Date: 2026-05-01
 """
 
@@ -12,7 +12,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20260501a_bf_idempotency"
-down_revision: str | None = "20260420_hmac_scheme"
+down_revision: str | None = "20260524_oauth_user_cascade"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/api/alembic/versions/20260501a_summary_backfill_idempotency.py
+++ b/api/alembic/versions/20260501a_summary_backfill_idempotency.py
@@ -1,0 +1,33 @@
+"""Add processed run tracking to summary backfill jobs.
+
+Revision ID: 20260501a_bf_idempotency
+Revises: 20260420_hmac_scheme
+Create Date: 2026-05-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260501a_bf_idempotency"
+down_revision: str | None = "20260420_hmac_scheme"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "summary_backfill_jobs",
+        sa.Column(
+            "processed_run_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("summary_backfill_jobs", "processed_run_ids")

--- a/api/src/jobs/dlq_cli.py
+++ b/api/src/jobs/dlq_cli.py
@@ -1,0 +1,158 @@
+"""Operational CLI for RabbitMQ poison queues.
+
+Run inside the API/worker environment:
+
+    python -m src.jobs.dlq_cli inspect workflow-executions --limit 10
+    python -m src.jobs.dlq_cli replay workflow-executions --limit 5 --dry-run
+    python -m src.jobs.dlq_cli discard workflow-executions --limit 5 --reason "bad payload"
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+from typing import Any
+
+import aio_pika
+
+from src.config import get_settings
+from src.jobs.rabbitmq import _message_headers
+
+logger = logging.getLogger(__name__)
+
+
+def decode_message(body: bytes) -> dict[str, Any] | str:
+    try:
+        parsed = json.loads(body.decode())
+        return parsed if isinstance(parsed, dict) else {"value": parsed}
+    except Exception:
+        return body.decode(errors="replace")
+
+
+async def _connect():
+    return await aio_pika.connect_robust(get_settings().rabbitmq_url)
+
+
+async def inspect(queue: str, limit: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    connection = await _connect()
+    async with connection:
+        channel = await connection.channel()
+        poison = await channel.declare_queue(f"{queue}-poison", durable=True)
+        for _ in range(limit):
+            message = await poison.get(fail=False, no_ack=False)
+            if message is None:
+                break
+            rows.append(_describe(queue, message))
+            await message.nack(requeue=True)
+        await channel.close()
+    return rows
+
+
+async def replay(queue: str, limit: int, dry_run: bool) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    connection = await _connect()
+    async with connection:
+        channel = await connection.channel()
+        poison = await channel.declare_queue(f"{queue}-poison", durable=True)
+        await channel.declare_queue(queue, durable=True)
+        for _ in range(limit):
+            message = await poison.get(fail=False, no_ack=False)
+            if message is None:
+                break
+            row = _describe(queue, message)
+            rows.append(row)
+            if dry_run:
+                await message.nack(requeue=True)
+                continue
+            body = decode_message(message.body)
+            publish_body = body if isinstance(body, dict) else {"_malformed_body": body}
+            replay_count = int((message.headers or {}).get("x-replayed-count") or 0) + 1
+            headers = _message_headers(
+                publish_body,
+                queue,
+                message_id=message.message_id,
+                headers=dict(message.headers or {}),
+                retry_count=0,
+                replay_count=replay_count,
+            )
+            await channel.default_exchange.publish(
+                aio_pika.Message(
+                    body=json.dumps(publish_body).encode(),
+                    delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                    message_id=message.message_id,
+                    correlation_id=message.correlation_id,
+                    headers=headers,
+                ),
+                routing_key=queue,
+            )
+            await message.ack()
+            logger.info("Replayed poison message", extra={"queue": queue, **row})
+        await channel.close()
+    return rows
+
+
+async def discard(queue: str, limit: int, reason: str, dry_run: bool) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    connection = await _connect()
+    async with connection:
+        channel = await connection.channel()
+        poison = await channel.declare_queue(f"{queue}-poison", durable=True)
+        for _ in range(limit):
+            message = await poison.get(fail=False, no_ack=False)
+            if message is None:
+                break
+            row = _describe(queue, message)
+            rows.append(row)
+            if dry_run:
+                await message.nack(requeue=True)
+            else:
+                await message.ack()
+                logger.warning(
+                    "Discarded poison message",
+                    extra={"queue": queue, "discard_reason": reason, **row},
+                )
+        await channel.close()
+    return rows
+
+
+def _describe(queue: str, message) -> dict[str, Any]:
+    headers = dict(message.headers or {})
+    return {
+        "queue": queue,
+        "poison_queue": f"{queue}-poison",
+        "message_id": message.message_id,
+        "correlation_id": message.correlation_id,
+        "idempotency_key": headers.get("x-idempotency-key"),
+        "retry_count": headers.get("x-retry-count", 0),
+        "replay_count": headers.get("x-replayed-count", 0),
+        "origin_queue": headers.get("x-origin-queue"),
+        "dead_letter": headers.get("x-death"),
+        "headers": headers,
+        "body": decode_message(message.body),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Inspect/replay/discard Bifrost RabbitMQ poison queues")
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("inspect", "replay", "discard"):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("queue")
+        cmd.add_argument("--limit", type=int, default=10)
+        cmd.add_argument("--dry-run", action="store_true")
+    sub.choices["discard"].add_argument("--reason", required=True)
+    args = parser.parse_args(argv)
+
+    if args.command == "inspect":
+        rows = asyncio.run(inspect(args.queue, args.limit))
+    elif args.command == "replay":
+        rows = asyncio.run(replay(args.queue, args.limit, args.dry_run))
+    else:
+        rows = asyncio.run(discard(args.queue, args.limit, args.reason, args.dry_run))
+    print(json.dumps(rows, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/api/src/jobs/dlq_cli.py
+++ b/api/src/jobs/dlq_cli.py
@@ -33,18 +33,33 @@ async def _connect():
     return await aio_pika.connect_robust(get_settings().rabbitmq_url)
 
 
+async def _fetch_poison_messages(poison, limit: int) -> list[Any]:
+    messages: list[Any] = []
+    for _ in range(limit):
+        message = await poison.get(fail=False, no_ack=False)
+        if message is None:
+            break
+        messages.append(message)
+    return messages
+
+
+async def _requeue_messages(messages: list[Any]) -> None:
+    for message in messages:
+        await message.nack(requeue=True)
+
+
+async def _ensure_main_queue(channel, queue_name: str) -> None:
+    await channel.declare_queue(queue_name, passive=True)
+
+
 async def inspect(queue: str, limit: int) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
     connection = await _connect()
     async with connection:
         channel = await connection.channel()
         poison = await channel.declare_queue(f"{queue}-poison", durable=True)
-        for _ in range(limit):
-            message = await poison.get(fail=False, no_ack=False)
-            if message is None:
-                break
-            rows.append(_describe(queue, message))
-            await message.nack(requeue=True)
+        messages = await _fetch_poison_messages(poison, limit)
+        rows = [_describe(queue, message) for message in messages]
+        await _requeue_messages(messages)
         await channel.close()
     return rows
 
@@ -55,15 +70,12 @@ async def replay(queue: str, limit: int, dry_run: bool) -> list[dict[str, Any]]:
     async with connection:
         channel = await connection.channel()
         poison = await channel.declare_queue(f"{queue}-poison", durable=True)
-        await channel.declare_queue(queue, durable=True)
-        for _ in range(limit):
-            message = await poison.get(fail=False, no_ack=False)
-            if message is None:
-                break
+        await _ensure_main_queue(channel, queue)
+        messages = await _fetch_poison_messages(poison, limit)
+        for message in messages:
             row = _describe(queue, message)
             rows.append(row)
             if dry_run:
-                await message.nack(requeue=True)
                 continue
             body = decode_message(message.body)
             publish_body = body if isinstance(body, dict) else {"_malformed_body": body}
@@ -88,6 +100,8 @@ async def replay(queue: str, limit: int, dry_run: bool) -> list[dict[str, Any]]:
             )
             await message.ack()
             logger.info("Replayed poison message", extra={"queue": queue, **row})
+        if dry_run:
+            await _requeue_messages(messages)
         await channel.close()
     return rows
 
@@ -98,20 +112,19 @@ async def discard(queue: str, limit: int, reason: str, dry_run: bool) -> list[di
     async with connection:
         channel = await connection.channel()
         poison = await channel.declare_queue(f"{queue}-poison", durable=True)
-        for _ in range(limit):
-            message = await poison.get(fail=False, no_ack=False)
-            if message is None:
-                break
+        messages = await _fetch_poison_messages(poison, limit)
+        for message in messages:
             row = _describe(queue, message)
             rows.append(row)
             if dry_run:
-                await message.nack(requeue=True)
-            else:
-                await message.ack()
-                logger.warning(
-                    "Discarded poison message",
-                    extra={"queue": queue, "discard_reason": reason, **row},
-                )
+                continue
+            await message.ack()
+            logger.warning(
+                "Discarded poison message",
+                extra={"queue": queue, "discard_reason": reason, **row},
+            )
+        if dry_run:
+            await _requeue_messages(messages)
         await channel.close()
     return rows
 

--- a/api/src/models/orm/summary_backfill_job.py
+++ b/api/src/models/orm/summary_backfill_job.py
@@ -10,7 +10,8 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-from sqlalchemy import DateTime, Integer, Numeric, String
+from sqlalchemy import DateTime, Integer, Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -40,6 +41,9 @@ class SummaryBackfillJob(Base):
     )
     actual_cost_usd: Mapped[Decimal] = mapped_column(
         Numeric(10, 4), nullable=False, default=Decimal("0")
+    )
+    processed_run_ids: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'::jsonb")
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/api/src/services/execution/backfill_tracker.py
+++ b/api/src/services/execution/backfill_tracker.py
@@ -53,6 +53,14 @@ async def record_backfill_outcome(
                 # Admin cancelled the job — keep processing the per-run summary
                 # (no harm in it) but don't touch the terminal counters.
                 return
+            processed = set(job.processed_run_ids or [])
+            run_key = str(run_id)
+            if run_key in processed:
+                logger.info(
+                    "Ignoring duplicate backfill outcome",
+                    extra={"job_id": str(job_id), "run_id": run_key},
+                )
+                return
 
             if succeeded:
                 job.succeeded = (job.succeeded or 0) + 1
@@ -63,6 +71,7 @@ async def record_backfill_outcome(
                     ) + cost
             else:
                 job.failed = (job.failed or 0) + 1
+            job.processed_run_ids = sorted(processed | {run_key})
 
             finished = (job.succeeded + job.failed) >= job.total
             if finished and job.status == "running":

--- a/api/src/services/execution/backfill_tracker.py
+++ b/api/src/services/execution/backfill_tracker.py
@@ -37,9 +37,9 @@ async def record_backfill_outcome(
         async with session_factory() as db:
             job = (
                 await db.execute(
-                    select(SummaryBackfillJob).where(
-                        SummaryBackfillJob.id == job_id
-                    )
+                    select(SummaryBackfillJob)
+                    .where(SummaryBackfillJob.id == job_id)
+                    .with_for_update()
                 )
             ).scalar_one_or_none()
             if job is None:

--- a/api/tests/unit/jobs/test_dlq_cli.py
+++ b/api/tests/unit/jobs/test_dlq_cli.py
@@ -1,0 +1,33 @@
+"""Tests for the DLQ operational CLI helpers."""
+
+from src.jobs.dlq_cli import decode_message, _describe
+
+
+class FakePoisonMessage:
+    body = b'{"execution_id":"abc"}'
+    message_id = "abc"
+    correlation_id = "corr"
+    headers = {
+        "x-idempotency-key": "abc",
+        "x-retry-count": 3,
+        "x-replayed-count": 1,
+        "x-origin-queue": "workflow-executions",
+    }
+
+
+def test_decode_message_handles_valid_json():
+    assert decode_message(b'{"ok": true}') == {"ok": True}
+
+
+def test_decode_message_handles_malformed_body():
+    assert decode_message(b"{not-json") == "{not-json"
+
+
+def test_describe_includes_operational_metadata():
+    row = _describe("workflow-executions", FakePoisonMessage())
+
+    assert row["poison_queue"] == "workflow-executions-poison"
+    assert row["idempotency_key"] == "abc"
+    assert row["retry_count"] == 3
+    assert row["replay_count"] == 1
+    assert row["body"] == {"execution_id": "abc"}

--- a/api/tests/unit/jobs/test_dlq_cli.py
+++ b/api/tests/unit/jobs/test_dlq_cli.py
@@ -1,6 +1,8 @@
 """Tests for the DLQ operational CLI helpers."""
 
-from src.jobs.dlq_cli import decode_message, _describe
+import pytest
+
+from src.jobs.dlq_cli import decode_message, _describe, _fetch_poison_messages, _requeue_messages
 
 
 class FakePoisonMessage:
@@ -31,3 +33,43 @@ def test_describe_includes_operational_metadata():
     assert row["retry_count"] == 3
     assert row["replay_count"] == 1
     assert row["body"] == {"execution_id": "abc"}
+
+
+class FakePoisonQueue:
+    def __init__(self, messages):
+        self._messages = list(messages)
+
+    async def get(self, *, fail: bool, no_ack: bool):
+        del fail, no_ack
+        if not self._messages:
+            return None
+        return self._messages.pop(0)
+
+
+class FakeMessage:
+    def __init__(self, message_id: str):
+        self.message_id = message_id
+        self.nacked = False
+
+    async def nack(self, *, requeue: bool):
+        assert requeue is True
+        self.nacked = True
+
+
+@pytest.mark.asyncio
+async def test_fetch_poison_messages_stops_at_limit_and_empty_queue():
+    queue = FakePoisonQueue([FakeMessage("one"), FakeMessage("two")])
+
+    messages = await _fetch_poison_messages(queue, limit=3)
+
+    assert [message.message_id for message in messages] == ["one", "two"]
+    assert await _fetch_poison_messages(queue, limit=1) == []
+
+
+@pytest.mark.asyncio
+async def test_requeue_messages_nacks_each_message_once():
+    messages = [FakeMessage("one"), FakeMessage("two")]
+
+    await _requeue_messages(messages)
+
+    assert all(message.nacked for message in messages)

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -1,0 +1,122 @@
+# Message Delivery Operations
+
+Bifrost RabbitMQ consumers use explicit delivery outcomes instead of relying on
+implicit `message.process(requeue=False)` behavior.
+
+## Queues and Idempotency
+
+| Queue | Idempotency key | Terminal duplicate behavior |
+| --- | --- | --- |
+| `workflow-executions` | `execution_id` | Existing durable execution row is acked as a duplicate. Missing Redis pending state is a no-op duplicate unless sync result delivery is waiting. |
+| `agent-runs` | `run_id` | Completed, failed, cancelled, and timeout rows are acked as duplicates. Fresh running rows are acked as duplicates. |
+| `agent-summarization` | `run_id` | Summary state on the run is authoritative; deterministic failures are recorded on the run rather than retried forever. |
+| `agent-summarization-backfill` | `run_id:backfill_job_id` | Backfill accounting is handled by the backfill tracker; replay still uses the same run/job idempotency key. |
+| `agent-tuning-chat` | `turn_id` | User turns carry a stable `turn_id`; redelivery does not append the same user turn twice and can continue reply generation. |
+| `package-installations` | `operation_id` | Each worker records completed package operations in Redis; repeated broadcasts become success/no-op. |
+
+Every publisher sets:
+
+- `message_id`
+- `x-idempotency-key`
+- `x-origin-queue`
+- `x-schema-version`
+- `x-enqueued-at`
+- `x-retry-count`
+- `x-replayed-count`
+
+## Delivery Outcomes
+
+Consumers classify work with explicit exceptions:
+
+- `DuplicateMessage`: ack as a duplicate/no-op.
+- `DomainFailureHandled`: ack after durable domain state is recorded.
+- `RetryableConsumerError`: publish to a delayed retry queue, then ack the original only after retry publish succeeds.
+- `PermanentConsumerError` and `MalformedMessage`: publish to poison, then ack the original.
+- `ConsumerShutdown`: schedule retry or requeue before the channel closes.
+
+Unhandled exceptions are treated as retryable infrastructure failures by the
+base framework and are logged with queue, message id, idempotency key, retry
+count, replay count, redelivery flag, and processing duration.
+
+## Retry Policy
+
+Each base queue has retry queues:
+
+- `<queue>-retry-1`: 10 seconds
+- `<queue>-retry-2`: 60 seconds
+- `<queue>-retry-3`: 5 minutes
+- `<queue>-retry-4`: 30 minutes
+
+Retry queues dead-letter back to the main queue after TTL. `x-retry-count`
+increments on each retry. When retry attempts are exhausted, the message is
+published to `<queue>-poison` with `x-poison-reason` and `x-poisoned-at`.
+
+Examples of retryable failures:
+
+- Redis or Postgres connectivity failures.
+- Process-pool admission rejection or memory pressure.
+- RabbitMQ publish failure while processing a handler.
+- Provider 429/5xx when retry is safe.
+
+Examples of permanent failures:
+
+- Malformed JSON.
+- Missing required IDs.
+- Invalid UUIDs.
+- Unknown or impossible operation/state.
+
+Workflow code failures and agent/tool errors that are already recorded in
+domain state are domain failures, not broker-delivery failures.
+
+## Backpressure and Shutdown
+
+RabbitMQ QoS still uses `prefetch_count`, but each `BaseConsumer` also has an
+in-process semaphore:
+
+- `BIFROST_WORKFLOW_CONSUMER_CONCURRENCY` default `10`
+- `BIFROST_AGENT_RUN_CONSUMER_CONCURRENCY` default `4`
+- `BIFROST_TUNE_CHAT_CONSUMER_CONCURRENCY` default `2`
+- summarization and package broadcast stay at one-at-a-time per worker
+
+On shutdown, consumers stop accepting new deliveries, wait up to
+`BIFROST_CONSUMER_SHUTDOWN_TIMEOUT_SECONDS` for active message tasks, then
+cancel/retry in-flight work as safely as the current claim state allows.
+
+## Recovery
+
+Workflow executions are acknowledged after the process pool accepts them.
+If a worker crashes after that point, the existing
+`execution_cleanup` scheduler is the durable recovery path: it marks stale
+`Pending`, `Running`, and `Cancelling` executions as timed out/cancelled and
+publishes normal execution/history updates. It respects workflow-specific
+timeouts with grace.
+
+Agent runs use durable `agent_runs` rows. Fresh `running` rows are treated as
+active duplicates. Rows older than `BIFROST_CONSUMER_STALE_RUNNING_SECONDS`
+are reset to `queued` and can be processed again if the Redis context still
+exists; terminal rows are never re-run by normal redelivery.
+
+## DLQ Tool
+
+Run inside the API or worker environment:
+
+```bash
+python -m src.jobs.dlq_cli inspect workflow-executions --limit 10
+python -m src.jobs.dlq_cli replay workflow-executions --limit 5 --dry-run
+python -m src.jobs.dlq_cli replay workflow-executions --limit 5
+python -m src.jobs.dlq_cli discard workflow-executions --limit 5 --reason "bad legacy payload"
+```
+
+Inspect shows decoded body, headers, retry/replay counts, original queue,
+message id, idempotency key, and dead-letter metadata. Replay increments
+`x-replayed-count`, preserves the idempotency key, and publishes back to the
+original queue. Consumers still enforce normal idempotency, so replay is safe
+for messages that died before a durable domain claim and harmless for already
+completed duplicates.
+
+## Known Limits
+
+Broadcast queues are exclusive auto-delete queues. They are fanout delivery
+channels, not durable replay channels for workers that were offline at publish
+time. Package install/uninstall safety comes from operation-level idempotency,
+not from durable per-worker backlog retention.


### PR DESCRIPTION
## Summary
Cherry-picked from stale \codex/message-queue-hardening\ work onto current main.

Main already has RabbitMQ delivery outcomes (#194+); this adds:
- \dlq_cli\ for inspect/replay/discard poison queues
- Backfill \processed_run_ids\ migration + tracker dedupe
- \docs/message-delivery.md\ operator reference

## Test plan
- [ ] \./test.sh tests/unit/jobs/test_dlq_cli.py\
- [ ] Migration applies on test stack

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replay and discard mutate poison-queue messages and can re-drive worker processing; backfill counter changes affect job completion and cost totals, though consumers still enforce message idempotency.
> 
> **Overview**
> Adds an operational **`dlq_cli`** module to **inspect**, **replay** (with dry-run), and **discard** messages on RabbitMQ **`<queue>-poison`** queues, reusing **`_message_headers`** so replays bump **`x-replayed-count`** and keep idempotency keys. **Inspect** and dry-run paths **nack/requeue** so poison depth is unchanged unless messages are replayed or discarded.
> 
> Summary backfill jobs get a **`processed_run_ids`** JSONB column (Alembic + ORM). **`record_backfill_outcome`** now **locks the job row**, skips duplicate run IDs, and only then updates succeeded/failed counters and cost—preventing double-counting on message redelivery.
> 
> **`docs/message-delivery.md`** documents queue idempotency, retry/poison behavior, recovery, and the new CLI for operators. Unit tests cover **`dlq_cli`** decode/describe/fetch/requeue helpers only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6593d65c55549837f75a32c8983b361a446f7b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->