### PR TITLE
fix: reject parameters alias on workflow execute requests

### DIFF
--- a/api/src/models/contracts/executions.py
+++ b/api/src/models/contracts/executions.py
@@ -109,6 +109,8 @@ class WorkflowExecution(BaseModel):
 
 class WorkflowExecutionRequest(BaseModel):
     """Request model for executing a workflow"""
+    model_config = ConfigDict(extra="forbid")
+
     workflow_id: str | None = Field(default=None, description="Workflow UUID or name. Names resolve using org-scoped lookup (org-specific > global). Required if code not provided.")
     input_data: dict[str, Any] = Field(default_factory=dict, description="Workflow input parameters")
     form_id: str | None = Field(default=None, description="Optional form ID that triggered this execution")
@@ -134,6 +136,15 @@ class WorkflowExecutionRequest(BaseModel):
             "Mutually exclusive with scheduled_at."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_parameters_alias(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "parameters" in data:
+            raise ValueError(
+                "Use 'input_data' instead of 'parameters' for workflow execution inputs"
+            )
+        return data
 
     @model_validator(mode="after")
     def validate_request(self) -> "WorkflowExecutionRequest":

--- a/api/tests/e2e/api/test_embed_workflow_execution.py
+++ b/api/tests/e2e/api/test_embed_workflow_execution.py
@@ -76,7 +76,7 @@ class TestEmbedWorkflowExecution:
             headers={"Authorization": f"Bearer {embed_session['embed_token']}"},
             json={
                 "workflow_id": "nonexistent-workflow-for-auth-test",
-                "parameters": {},
+                "input_data": {},
             },
         )
         # Should get 404 (workflow not found) rather than 401/403 (unauthorized)

--- a/api/tests/e2e/api/test_executions.py
+++ b/api/tests/e2e/api/test_executions.py
@@ -86,6 +86,35 @@ async def e2e_exec_async_workflow(delay_seconds: int = 1):
 
 
 @pytest.mark.e2e
+class TestExecuteRequestValidation:
+    """Reject invalid /api/workflows/execute payloads before execution."""
+
+    def test_rejects_parameters_field(self, e2e_client, platform_admin):
+        response = e2e_client.post(
+            "/api/workflows/execute",
+            headers=platform_admin.headers,
+            json={
+                "workflow_id": str(uuid.uuid4()),
+                "parameters": {"start_date": "2026-01-01"},
+            },
+        )
+        assert response.status_code == 422, response.text
+        assert "input_data" in response.text.lower()
+        assert "parameters" in response.text.lower()
+
+    def test_accepts_input_data(self, e2e_client, platform_admin, sync_workflow):
+        response = e2e_client.post(
+            "/api/workflows/execute",
+            headers=platform_admin.headers,
+            json={
+                "workflow_id": sync_workflow["id"],
+                "input_data": {"message": "validation test", "count": 1},
+            },
+        )
+        assert response.status_code in (200, 202), response.text
+
+
+@pytest.mark.e2e
 class TestSyncExecution:
     """Test synchronous workflow execution."""
 

--- a/api/tests/unit/models/test_executions_contract.py
+++ b/api/tests/unit/models/test_executions_contract.py
@@ -81,3 +81,24 @@ def test_rejects_code_with_scheduled_at():
 def test_rejects_code_with_delay_seconds():
     with pytest.raises(ValidationError, match="code"):
         WorkflowExecutionRequest(code="cHJpbnQoMSk=", delay_seconds=60)
+
+
+def test_rejects_parameters_alias():
+    with pytest.raises(ValidationError, match="input_data.*parameters"):
+        WorkflowExecutionRequest(
+            workflow_id="wf",
+            parameters={"start_date": "2026-01-01"},
+        )
+
+
+def test_accepts_input_data():
+    req = WorkflowExecutionRequest(
+        workflow_id="wf",
+        input_data={"start_date": "2026-01-01"},
+    )
+    assert req.input_data == {"start_date": "2026-01-01"}
+
+
+def test_rejects_unknown_top_level_fields():
+    with pytest.raises(ValidationError, match="extra"):
+        WorkflowExecutionRequest(workflow_id="wf", unknown_field="x")


### PR DESCRIPTION
## Summary
- Set `WorkflowExecutionRequest` to `extra=forbid` and reject `parameters` with a clear validation error pointing callers at `input_data`
- Add unit and e2e regression coverage so execution inputs cannot be silently dropped
- Fix embed workflow e2e test that incorrectly sent `parameters`

Fixes #99

## Test plan
- [ ] `./test.sh tests/unit/models/test_executions_contract.py -v`
- [ ] `./test.sh e2e api/tests/e2e/api/test_executions.py -v`
- [ ] `./test.sh e2e api/tests/e2e/api/test_embed_workflow_execution.py -v`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change on the execute endpoint; may break misconfigured clients using `parameters`, which is intentional.
> 
> **Overview**
> **`/api/workflows/execute`** now enforces a stricter request body on `WorkflowExecutionRequest`: unknown top-level keys are rejected (`extra="forbid"`), and sending **`parameters`** returns **422** with an explicit message to use **`input_data`** instead—so execution inputs are not silently ignored.
> 
> Unit and e2e tests cover the **`parameters`** rejection, valid **`input_data`**, and unknown fields; the embed workflow auth e2e test was updated to send **`input_data`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7d4bb6d515e8f8c3e51e07bd2466e249f7df74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->