### PR TITLE
fix: surface metrics query failures on dashboard analytics cards

### DIFF
--- a/client/src/components/charts/ExecutionsByOrgChart.tsx
+++ b/client/src/components/charts/ExecutionsByOrgChart.tsx
@@ -18,10 +18,13 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import type { OrganizationMetricsSummary } from "@/hooks/useAdminMetrics";
 import { toFiniteNumber } from "@/lib/chart-values";
+import { MetricsCardError } from "./MetricsCardError";
 
 interface ExecutionsByOrgChartProps {
 	data: OrganizationMetricsSummary[];
 	isLoading?: boolean;
+	isError?: boolean;
+	error?: unknown;
 }
 
 // Color palette for bars
@@ -41,6 +44,8 @@ const COLORS = [
 export function ExecutionsByOrgChart({
 	data,
 	isLoading,
+	isError,
+	error,
 }: ExecutionsByOrgChartProps) {
 	if (isLoading) {
 		return (
@@ -53,6 +58,25 @@ export function ExecutionsByOrgChart({
 				</CardHeader>
 				<CardContent>
 					<Skeleton className="h-[300px] w-full" />
+				</CardContent>
+			</Card>
+		);
+	}
+
+	if (isError) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle>Executions by Organization</CardTitle>
+					<CardDescription>
+						Top organizations by execution count
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<MetricsCardError
+						label="organization metrics"
+						error={error}
+					/>
 				</CardContent>
 			</Card>
 		);

--- a/client/src/components/charts/HeaviestWorkflowsTable.tsx
+++ b/client/src/components/charts/HeaviestWorkflowsTable.tsx
@@ -18,10 +18,13 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ChevronRight } from "lucide-react";
 import type { WorkflowMetricsSummary } from "@/hooks/useAdminMetrics";
+import { MetricsCardError } from "./MetricsCardError";
 
 interface HeaviestWorkflowsTableProps {
 	data: WorkflowMetricsSummary[];
 	isLoading?: boolean;
+	isError?: boolean;
+	error?: unknown;
 	sortBy: "executions" | "memory" | "duration" | "cpu";
 	onSortChange: (sort: "executions" | "memory" | "duration" | "cpu") => void;
 }
@@ -46,6 +49,8 @@ function formatDuration(ms: number): string {
 export function HeaviestWorkflowsTable({
 	data,
 	isLoading,
+	isError,
+	error,
 	sortBy,
 	onSortChange,
 }: HeaviestWorkflowsTableProps) {
@@ -62,6 +67,22 @@ export function HeaviestWorkflowsTable({
 				</CardHeader>
 				<CardContent>
 					<Skeleton className="h-[300px] w-full" />
+				</CardContent>
+			</Card>
+		);
+	}
+
+	if (isError) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle>Heaviest Workflows</CardTitle>
+					<CardDescription>
+						Workflows consuming most resources
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<MetricsCardError label="workflow metrics" error={error} />
 				</CardContent>
 			</Card>
 		);

--- a/client/src/components/charts/MetricsCardError.tsx
+++ b/client/src/components/charts/MetricsCardError.tsx
@@ -1,0 +1,20 @@
+import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { getErrorMessage } from "@/lib/api-error";
+
+interface MetricsCardErrorProps {
+	label: string;
+	error?: unknown;
+}
+
+export function MetricsCardError({ label, error }: MetricsCardErrorProps) {
+	return (
+		<Alert variant="destructive">
+			<AlertCircle className="h-4 w-4" />
+			<AlertDescription>
+				Failed to load {label}:{" "}
+				{getErrorMessage(error, "Please try again later.")}
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/client/src/components/charts/MetricsCharts.test.tsx
+++ b/client/src/components/charts/MetricsCharts.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+import { ResourceTrendChart } from "./ResourceTrendChart";
+import { ExecutionsByOrgChart } from "./ExecutionsByOrgChart";
+import { HeaviestWorkflowsTable } from "./HeaviestWorkflowsTable";
+
+describe("Platform analytics charts", () => {
+	it("ResourceTrendChart shows an error alert when the query fails", () => {
+		renderWithProviders(
+			<ResourceTrendChart
+				data={[]}
+				isError
+				error={new Error("metrics unavailable")}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/Failed to load resource metrics: metrics unavailable/i),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/No resource data available/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("ResourceTrendChart shows empty state only after a successful query", () => {
+		renderWithProviders(<ResourceTrendChart data={[]} />);
+
+		expect(
+			screen.getByText(/No resource data available/i),
+		).toBeInTheDocument();
+	});
+
+	it("ExecutionsByOrgChart shows an error alert when the query fails", () => {
+		renderWithProviders(
+			<ExecutionsByOrgChart
+				data={[]}
+				isError
+				error={new Error("forbidden")}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/Failed to load organization metrics: forbidden/i),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/No organization data available/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("HeaviestWorkflowsTable shows an error alert when the query fails", () => {
+		renderWithProviders(
+			<HeaviestWorkflowsTable
+				data={[]}
+				isError
+				error={new Error("upstream timeout")}
+				sortBy="memory"
+				onSortChange={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByText(
+				/Failed to load workflow metrics: upstream timeout/i,
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/No workflow data available/i),
+		).not.toBeInTheDocument();
+	});
+});

--- a/client/src/components/charts/ResourceTrendChart.tsx
+++ b/client/src/components/charts/ResourceTrendChart.tsx
@@ -19,10 +19,13 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ResourceMetricsEntry } from "@/hooks/useAdminMetrics";
 import { toFiniteNumber } from "@/lib/chart-values";
+import { MetricsCardError } from "./MetricsCardError";
 
 interface ResourceTrendChartProps {
 	data: ResourceMetricsEntry[];
 	isLoading?: boolean;
+	isError?: boolean;
+	error?: unknown;
 }
 
 const formatResourceTrendTooltip: Formatter = (value, name) => {
@@ -35,6 +38,8 @@ const formatResourceTrendTooltip: Formatter = (value, name) => {
 export function ResourceTrendChart({
 	data,
 	isLoading,
+	isError,
+	error,
 }: ResourceTrendChartProps) {
 	if (isLoading) {
 		return (
@@ -47,6 +52,25 @@ export function ResourceTrendChart({
 				</CardHeader>
 				<CardContent>
 					<Skeleton className="h-[300px] w-full" />
+				</CardContent>
+			</Card>
+		);
+	}
+
+	if (isError) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle>Resource Utilization</CardTitle>
+					<CardDescription>
+						Memory and CPU trends over time
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<MetricsCardError
+						label="resource metrics"
+						error={error}
+					/>
 				</CardContent>
 			</Card>
 		);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -68,15 +68,27 @@ export function Dashboard() {
 		"executions" | "memory" | "duration" | "cpu"
 	>("memory");
 
-	const { data: resourceData, isLoading: resourceLoading, refetch: refetchResource } =
-		useResourceMetrics(7, isPlatformAdmin);
-	const { data: orgData, isLoading: orgLoading, refetch: refetchOrg } = useOrganizationMetrics(
-		30,
-		10,
-		isPlatformAdmin,
-	);
-	const { data: workflowData, isLoading: workflowLoading, refetch: refetchWorkflow } =
-		useWorkflowMetrics(30, workflowSort, 20, isPlatformAdmin);
+	const {
+		data: resourceData,
+		isLoading: resourceLoading,
+		isError: resourceError,
+		error: resourceErrorDetail,
+		refetch: refetchResource,
+	} = useResourceMetrics(7, isPlatformAdmin);
+	const {
+		data: orgData,
+		isLoading: orgLoading,
+		isError: orgError,
+		error: orgErrorDetail,
+		refetch: refetchOrg,
+	} = useOrganizationMetrics(30, 10, isPlatformAdmin);
+	const {
+		data: workflowData,
+		isLoading: workflowLoading,
+		isError: workflowError,
+		error: workflowErrorDetail,
+		refetch: refetchWorkflow,
+	} = useWorkflowMetrics(30, workflowSort, 20, isPlatformAdmin);
 
 	const handleRefresh = () => {
 		refetchDashboard();
@@ -426,19 +438,25 @@ export function Dashboard() {
 
 					{/* Resource Trend Chart - Full Width */}
 					<ResourceTrendChart
-						data={resourceData?.days || []}
+						data={resourceData?.days ?? []}
 						isLoading={resourceLoading}
+						isError={resourceError}
+						error={resourceErrorDetail}
 					/>
 
 					{/* Two-column layout for org chart and workflow table */}
 					<div className="grid gap-4 lg:grid-cols-2">
 						<ExecutionsByOrgChart
-							data={orgData?.organizations || []}
+							data={orgData?.organizations ?? []}
 							isLoading={orgLoading}
+							isError={orgError}
+							error={orgErrorDetail}
 						/>
 						<HeaviestWorkflowsTable
-							data={workflowData?.workflows || []}
+							data={workflowData?.workflows ?? []}
 							isLoading={workflowLoading}
+							isError={workflowError}
+							error={workflowErrorDetail}
 							sortBy={workflowSort}
 							onSortChange={setWorkflowSort}
 						/>


### PR DESCRIPTION
## Summary
- Pass `isError`/`error` from admin metrics hooks into platform analytics chart components
- Show destructive alerts when `/api/metrics/*` queries fail; reserve empty states for successful zero-row responses
- Add `MetricsCardError` helper and vitest coverage

Fixes #44

## Test plan
- [ ] `./test.sh client unit` (`MetricsCharts.test.tsx`)
- [ ] Manual: block a metrics endpoint in devtools and confirm cards show an error alert, not `No data`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only error handling and tests on admin dashboard charts; no auth, API, or data-layer changes.
> 
> **Overview**
> Platform admin **dashboard analytics** now surfaces failed `/api/metrics/*` fetches instead of looking like empty data.
> 
> **Dashboard** passes `isError` and `error` from `useResourceMetrics`, `useOrganizationMetrics`, and `useWorkflowMetrics` into **ResourceTrendChart**, **ExecutionsByOrgChart**, and **HeaviestWorkflowsTable**. Each card checks error **before** the “no data” empty state and renders a shared **`MetricsCardError`** destructive alert with a label-specific message via `getErrorMessage`. Chart props use `?? []` for fallback arrays. **Vitest** in `MetricsCharts.test.tsx` asserts failed queries show the alert and do not show empty-state copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfefe52e93869a10d46c4fc0c5c3fb01ea1c94d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->