### PR TITLE
fix: reconcile integration OAuth status after token recovery

### DIFF
--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -726,6 +726,8 @@ async def sdk_integrations_get(
                 response_data["oauth"] = await _build_oauth_data(
                     integration.oauth_provider, token, entity_id, resolve_url_template, decrypt_secret,
                     oauth_scope=request.oauth_scope,
+                    db=db,
+                    org_uuid=org_uuid,
                 )
 
             logger.info(f"SDK retrieved integration '{log_safe(request.name)}' (org mapping) for user {current_user.email}")
@@ -762,6 +764,8 @@ async def sdk_integrations_get(
             response_data["oauth"] = await _build_oauth_data(
                 integration.oauth_provider, token, entity_id, resolve_url_template, decrypt_secret,
                 oauth_scope=request.oauth_scope,
+                db=db,
+                org_uuid=org_uuid,
             )
 
         logger.info(f"SDK retrieved integration '{log_safe(request.name)}' (defaults) for user {current_user.email}")
@@ -779,6 +783,8 @@ async def _build_oauth_data(
     resolve_url_template: Any,
     decrypt_secret: Any,
     oauth_scope: str | None = None,
+    db: Any | None = None,
+    org_uuid: UUID | None = None,
 ) -> SDKIntegrationsOAuthData:
     """Build OAuth data dict from provider and token for CLI response.
 
@@ -789,6 +795,9 @@ async def _build_oauth_data(
         resolve_url_template: Function to resolve {entity_id} in URLs
         decrypt_secret: Function to decrypt encrypted values
         oauth_scope: Override scope for token request (triggers fresh token fetch)
+        db: Optional DB session — when set, successful auto-refresh persists the
+            recovered token and clears stale integration-level provider failure
+        org_uuid: Organization scope for token persistence during auto-refresh
     """
     # Decrypt client secret (needed for both stored tokens and auto-refresh)
     client_secret = None
@@ -843,6 +852,25 @@ async def _build_oauth_data(
                         else str(expires_at_dt)
                     )
                 logger.info("Auto-refresh token successful")
+                if db is not None and access_token:
+                    from src.core.security import encrypt_secret
+                    from src.services.oauth_provider import persist_integration_oauth_recovery
+
+                    scope_list = scopes.split() if scopes else (provider.scopes or [])
+                    await persist_integration_oauth_recovery(
+                        db,
+                        provider=provider,
+                        org_uuid=org_uuid,
+                        stored_token=token,
+                        encrypted_access_token=encrypt_secret(access_token).encode(),
+                        expires_at=(
+                            expires_at_dt
+                            if expires_at_dt and hasattr(expires_at_dt, "isoformat")
+                            else None
+                        ),
+                        scopes=scope_list,
+                    )
+                    await db.commit()
             else:
                 error_msg = result.get("error_description", result.get("error", "Unknown error"))
                 logger.error(f"Auto-refresh token failed: {log_safe(error_msg)}")
@@ -1231,6 +1259,9 @@ async def sdk_integrations_refresh_token(
                 token_obj.encrypted_refresh_token = outcome["encrypted_refresh_token"]
             if expires_at_dt and hasattr(expires_at_dt, "isoformat"):
                 token_obj.expires_at = expires_at_dt
+            token_obj.status = "completed"
+            token_obj.status_message = None
+            token_obj.last_refresh_at = datetime.now(timezone.utc)
         else:
             new_token = OAuthToken(
                 organization_id=org_uuid,
@@ -1239,6 +1270,9 @@ async def sdk_integrations_refresh_token(
                 encrypted_refresh_token=outcome.get("encrypted_refresh_token"),
                 expires_at=expires_at_dt if expires_at_dt and hasattr(expires_at_dt, "isoformat") else None,
                 scopes=provider.scopes or [],
+                status="completed",
+                status_message=None,
+                last_refresh_at=datetime.now(timezone.utc),
             )
             db.add(new_token)
 

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -736,6 +736,10 @@ async def get_integration(
         provider = integration.oauth_provider
         token = await get_integration_level_token(ctx.db, provider.id)
         status_val, status_message = resolve_integration_oauth_status(provider, token)
+        if token and token.last_refresh_at:
+            last_refresh_at = token.last_refresh_at
+        else:
+            last_refresh_at = provider.last_token_refresh
         oauth_config = OAuthConfigSummary(
             provider_name=provider.provider_name,
             oauth_flow_type=provider.oauth_flow_type,
@@ -746,7 +750,7 @@ async def get_integration(
             status=status_val,
             status_message=status_message,
             expires_at=token.expires_at if token else None,
-            last_refresh_at=token.last_refresh_at if token else provider.last_token_refresh,
+            last_refresh_at=last_refresh_at,
             has_refresh_token=token.encrypted_refresh_token is not None if token else False,
             entity_id_source=provider.entity_id_source,
         )

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -47,6 +47,11 @@ from src.models import (
 from src.models.orm import Config as ConfigModel
 from src.models.orm import IntegrationConfigSchema
 from src.models.orm import OAuthToken
+from src.services.integration_config_schema import (
+    integration_to_response,
+    parse_config_schema_items,
+    validate_config_schema_type,
+)
 from src.services.oauth_provider import get_url_resolution_defaults, resolve_url_template
 from src.services.oauth_state import encode_state, remember_nonce
 
@@ -171,6 +176,7 @@ class IntegrationsRepository:
         # Add config schema items to the normalized table
         if request.config_schema:
             for idx, item in enumerate(request.config_schema):
+                validate_config_schema_type(item.type)
                 schema_item = IntegrationConfigSchema(
                     key=item.key,
                     type=item.type,
@@ -224,6 +230,7 @@ class IntegrationsRepository:
 
             # Update existing or add new schema items
             for idx, item_data in enumerate(request.config_schema):
+                validate_config_schema_type(item_data.type)
                 if item_data.key in existing_by_key:
                     # Update existing
                     existing = existing_by_key[item_data.key]
@@ -683,7 +690,7 @@ async def create_integration(
     integration = await repo.create_integration(request)
     logger.info(f"Created integration: {log_safe(integration.name)}")
 
-    return IntegrationResponse.model_validate(integration)
+    return integration_to_response(integration)
 
 
 @router.get(
@@ -700,7 +707,7 @@ async def list_integrations(
     repo = IntegrationsRepository(ctx.db)
     integrations = await repo.list_integrations()
 
-    items = [IntegrationResponse.model_validate(i) for i in integrations]
+    items = [integration_to_response(i) for i in integrations]
     return IntegrationListResponse(items=items, total=len(items))
 
 
@@ -728,9 +735,14 @@ async def get_integration(
     # Build OAuth config summary if OAuth provider exists
     oauth_config = None
     if integration.oauth_provider:
+        from src.services.oauth_provider import (
+            get_integration_level_token,
+            resolve_integration_oauth_status,
+        )
+
         provider = integration.oauth_provider
-        # Get token data if available (for expires_at and has_refresh_token)
-        token = provider.tokens[0] if provider.tokens else None
+        token = await get_integration_level_token(ctx.db, provider.id)
+        status_val, status_message = resolve_integration_oauth_status(provider, token)
         oauth_config = OAuthConfigSummary(
             provider_name=provider.provider_name,
             oauth_flow_type=provider.oauth_flow_type,
@@ -738,10 +750,10 @@ async def get_integration(
             authorization_url=provider.authorization_url,
             token_url=provider.token_url or "",
             scopes=provider.scopes or [],
-            status=provider.status or "not_connected",
-            status_message=provider.status_message,
+            status=status_val,
+            status_message=status_message,
             expires_at=token.expires_at if token else None,
-            last_refresh_at=provider.last_token_refresh,
+            last_refresh_at=token.last_refresh_at if token else provider.last_token_refresh,
             has_refresh_token=token.encrypted_refresh_token is not None if token else False,
             entity_id_source=provider.entity_id_source,
         )
@@ -757,12 +769,14 @@ async def get_integration(
         )
 
     # Convert ORM config_schema items to Pydantic models
-    config_schema_items = None
+    config_schema_items, schema_warnings = parse_config_schema_items(
+        integration.config_schema,
+        integration_name=integration.name,
+    )
     if integration.config_schema:
-        config_schema_items = [
-            ConfigSchemaItem.model_validate(item)
-            for item in integration.config_schema
-        ]
+        config_schema_out = config_schema_items
+    else:
+        config_schema_out = None
 
     # Get integration-level default config values
     config_defaults = await repo.get_integration_defaults(integration.id)
@@ -771,13 +785,14 @@ async def get_integration(
         id=integration.id,
         name=integration.name,
         list_entities_data_provider_id=integration.list_entities_data_provider_id,
-        config_schema=config_schema_items,
+        config_schema=config_schema_out,
         config_defaults=config_defaults if config_defaults else None,
         entity_id=integration.entity_id,
         entity_id_name=integration.entity_id_name,
         default_entity_id=integration.default_entity_id,
         has_oauth_config=integration.has_oauth_config,
         is_deleted=integration.is_deleted,
+        validation_warning="; ".join(schema_warnings) if schema_warnings else None,
         created_at=integration.created_at,
         updated_at=integration.updated_at,
         mappings=mapping_responses,
@@ -806,7 +821,7 @@ async def get_integration_by_name(
             detail="Integration not found",
         )
 
-    return IntegrationResponse.model_validate(integration)
+    return integration_to_response(integration)
 
 
 @router.put(
@@ -832,7 +847,7 @@ async def update_integration(
         )
 
     logger.info(f"Updated integration: {log_safe(integration.name)}")
-    return IntegrationResponse.model_validate(integration)
+    return integration_to_response(integration)
 
 
 @router.delete(

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -47,11 +47,6 @@ from src.models import (
 from src.models.orm import Config as ConfigModel
 from src.models.orm import IntegrationConfigSchema
 from src.models.orm import OAuthToken
-from src.services.integration_config_schema import (
-    integration_to_response,
-    parse_config_schema_items,
-    validate_config_schema_type,
-)
 from src.services.oauth_provider import get_url_resolution_defaults, resolve_url_template
 from src.services.oauth_state import encode_state, remember_nonce
 
@@ -176,7 +171,6 @@ class IntegrationsRepository:
         # Add config schema items to the normalized table
         if request.config_schema:
             for idx, item in enumerate(request.config_schema):
-                validate_config_schema_type(item.type)
                 schema_item = IntegrationConfigSchema(
                     key=item.key,
                     type=item.type,
@@ -230,7 +224,6 @@ class IntegrationsRepository:
 
             # Update existing or add new schema items
             for idx, item_data in enumerate(request.config_schema):
-                validate_config_schema_type(item_data.type)
                 if item_data.key in existing_by_key:
                     # Update existing
                     existing = existing_by_key[item_data.key]
@@ -690,7 +683,7 @@ async def create_integration(
     integration = await repo.create_integration(request)
     logger.info(f"Created integration: {log_safe(integration.name)}")
 
-    return integration_to_response(integration)
+    return IntegrationResponse.model_validate(integration)
 
 
 @router.get(
@@ -707,7 +700,7 @@ async def list_integrations(
     repo = IntegrationsRepository(ctx.db)
     integrations = await repo.list_integrations()
 
-    items = [integration_to_response(i) for i in integrations]
+    items = [IntegrationResponse.model_validate(i) for i in integrations]
     return IntegrationListResponse(items=items, total=len(items))
 
 
@@ -769,14 +762,12 @@ async def get_integration(
         )
 
     # Convert ORM config_schema items to Pydantic models
-    config_schema_items, schema_warnings = parse_config_schema_items(
-        integration.config_schema,
-        integration_name=integration.name,
-    )
+    config_schema_items = None
     if integration.config_schema:
-        config_schema_out = config_schema_items
-    else:
-        config_schema_out = None
+        config_schema_items = [
+            ConfigSchemaItem.model_validate(item)
+            for item in integration.config_schema
+        ]
 
     # Get integration-level default config values
     config_defaults = await repo.get_integration_defaults(integration.id)
@@ -785,14 +776,13 @@ async def get_integration(
         id=integration.id,
         name=integration.name,
         list_entities_data_provider_id=integration.list_entities_data_provider_id,
-        config_schema=config_schema_out,
+        config_schema=config_schema_items,
         config_defaults=config_defaults if config_defaults else None,
         entity_id=integration.entity_id,
         entity_id_name=integration.entity_id_name,
         default_entity_id=integration.default_entity_id,
         has_oauth_config=integration.has_oauth_config,
         is_deleted=integration.is_deleted,
-        validation_warning="; ".join(schema_warnings) if schema_warnings else None,
         created_at=integration.created_at,
         updated_at=integration.updated_at,
         mappings=mapping_responses,
@@ -821,7 +811,7 @@ async def get_integration_by_name(
             detail="Integration not found",
         )
 
-    return integration_to_response(integration)
+    return IntegrationResponse.model_validate(integration)
 
 
 @router.put(
@@ -847,7 +837,7 @@ async def update_integration(
         )
 
     logger.info(f"Updated integration: {log_safe(integration.name)}")
-    return integration_to_response(integration)
+    return IntegrationResponse.model_validate(integration)
 
 
 @router.delete(

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -690,6 +690,105 @@ async def refresh_oauth_token_http(td: dict[str, Any]) -> dict[str, Any]:
         return outcome
 
 
+def resolve_integration_oauth_status(
+    provider: "OAuthProvider",
+    token: "OAuthToken | None",
+) -> tuple[str, str | None]:
+    """Reconcile integration-level OAuth status for admin UI display.
+
+    ``OAuthProvider.status`` records the last integration-level refresh
+    outcome and can remain ``failed`` after a later token recovery. When a
+    healthy integration-level token row exists, prefer its status (matching
+    ``_mapping_to_response`` which reads ``OAuthToken.status`` for per-row
+    connections).
+    """
+    in_progress = provider.status in ("waiting_callback", "testing")
+    if in_progress and not token:
+        return provider.status, provider.status_message
+
+    if token and token.encrypted_access_token:
+        token_status = token.status or "not_connected"
+        if token_status == "completed":
+            return "completed", None
+        if token_status == "failed":
+            return "failed", token.status_message
+        # Populated token without explicit status (legacy rows)
+        return "completed", None
+
+    return provider.status or "not_connected", provider.status_message
+
+
+async def persist_integration_oauth_recovery(
+    db: "AsyncSession",
+    *,
+    provider: "OAuthProvider",
+    org_uuid: UUID | None,
+    stored_token: "OAuthToken | None",
+    encrypted_access_token: bytes,
+    expires_at: datetime | None,
+    encrypted_refresh_token: bytes | None = None,
+    scopes: list[str] | None = None,
+) -> "OAuthToken":
+    """Persist a recovered integration OAuth token and clear stale provider failure."""
+    from src.services.oauth_scope_resolution import get_oauth_token_for_scope
+
+    now = datetime.now(timezone.utc)
+    token_obj = stored_token
+    if token_obj is None:
+        token_obj = await get_oauth_token_for_scope(db, provider.id, org_uuid)
+
+    if token_obj:
+        token_obj.encrypted_access_token = encrypted_access_token
+        if encrypted_refresh_token is not None:
+            token_obj.encrypted_refresh_token = encrypted_refresh_token
+        if expires_at is not None:
+            token_obj.expires_at = expires_at
+        if scopes is not None:
+            token_obj.scopes = scopes
+    else:
+        from src.models.orm.oauth import OAuthToken
+
+        token_obj = OAuthToken(
+            organization_id=org_uuid,
+            provider_id=provider.id,
+            encrypted_access_token=encrypted_access_token,
+            encrypted_refresh_token=encrypted_refresh_token,
+            expires_at=expires_at,
+            scopes=scopes or provider.scopes or [],
+        )
+        db.add(token_obj)
+
+    token_obj.status = "completed"
+    token_obj.status_message = None
+    token_obj.last_refresh_at = now
+
+    provider.status = "completed"
+    provider.status_message = None
+    provider.last_token_refresh = now
+
+    await db.flush()
+    return token_obj
+
+
+async def get_integration_level_token(
+    db: "AsyncSession",
+    provider_id: UUID,
+) -> "OAuthToken | None":
+    """Return the most recent integration-level (org_id IS NULL) OAuth token."""
+    from src.models.orm.oauth import OAuthToken
+
+    result = await db.execute(
+        select(OAuthToken)
+        .where(
+            OAuthToken.provider_id == provider_id,
+            OAuthToken.organization_id.is_(None),
+            OAuthToken.user_id.is_(None),
+        )
+        .order_by(OAuthToken.created_at.desc(), OAuthToken.id.desc())
+    )
+    return result.scalars().first()
+
+
 async def get_token_for_org(
     db: "AsyncSession",
     integration_id: UUID,

--- a/api/tests/unit/routers/test_cli_auto_refresh.py
+++ b/api/tests/unit/routers/test_cli_auto_refresh.py
@@ -3,6 +3,7 @@
 import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, AsyncMock, patch
+from uuid import uuid4
 
 # Note: should_auto_refresh_token is imported inside each test to ensure
 # proper import from the cli module after all fixtures are loaded
@@ -430,3 +431,66 @@ class TestBuildOAuthDataAutoRefresh:
             )
 
             assert result.access_token == "exchange-customer-token"
+
+    @pytest.mark.asyncio
+    async def test_build_oauth_data_auto_refresh_persists_recovery_when_db_provided(self):
+        """Successful auto-refresh should clear stale provider failure when db is passed."""
+        from src.routers.cli import _build_oauth_data
+
+        provider = MagicMock()
+        provider.id = uuid4()
+        provider.provider_name = "Microsoft CSP"
+        provider.client_id = "test-client-id"
+        provider.token_url = "https://login.microsoftonline.com/{entity_id}/oauth2/v2.0/token"
+        provider.token_url_defaults = {}
+        provider.oauth_flow_type = "client_credentials"
+        provider.authorization_url = None
+        provider.scopes = ["https://graph.microsoft.com/.default"]
+        provider.encrypted_client_secret = "encrypted-secret"
+        provider.audience = None
+        provider.status = "failed"
+        provider.status_message = "Token refresh failed: bad entity_id"
+
+        token = MagicMock()
+        token.status = "failed"
+
+        db = MagicMock()
+        db.commit = AsyncMock()
+
+        def resolve_url_template(url, entity_id, defaults):
+            return url.replace("{entity_id}", entity_id)
+
+        def decrypt_secret(value):
+            return "decrypted-client-secret"
+
+        mock_token_response = {
+            "access_token": "fresh-access-token",
+            "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        }
+
+        with (
+            patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
+            patch(
+                "src.services.oauth_provider.persist_integration_oauth_recovery",
+                new_callable=AsyncMock,
+            ) as mock_persist,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get_client_credentials_token = AsyncMock(
+                return_value=(True, mock_token_response)
+            )
+            mock_client_class.return_value = mock_instance
+
+            result = await _build_oauth_data(
+                provider,
+                token,
+                "customer-tenant-123",
+                resolve_url_template,
+                decrypt_secret,
+                db=db,
+                org_uuid=None,
+            )
+
+            assert result.access_token == "fresh-access-token"
+            mock_persist.assert_awaited_once()
+            db.commit.assert_awaited_once()

--- a/api/tests/unit/test_integration_oauth_status.py
+++ b/api/tests/unit/test_integration_oauth_status.py
@@ -1,0 +1,129 @@
+"""Unit tests for integration-level OAuth status reconciliation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.oauth_provider import resolve_integration_oauth_status
+
+
+def _provider(*, status: str, status_message: str | None = None):
+    return SimpleNamespace(status=status, status_message=status_message)
+
+
+def _token(
+    *,
+    status: str = "completed",
+    status_message: str | None = None,
+    has_access_token: bool = True,
+):
+    return SimpleNamespace(
+        status=status,
+        status_message=status_message,
+        encrypted_access_token=b"encrypted" if has_access_token else None,
+    )
+
+
+class TestResolveIntegrationOAuthStatus:
+    def test_completed_token_overrides_stale_provider_failure(self):
+        provider = _provider(status="failed", status_message="Token refresh failed: bad entity_id")
+        token = _token(status="completed")
+
+        status, message = resolve_integration_oauth_status(provider, token)
+
+        assert status == "completed"
+        assert message is None
+
+    def test_failed_token_keeps_failure_message(self):
+        provider = _provider(status="completed")
+        token = _token(status="failed", status_message="Refresh token revoked")
+
+        status, message = resolve_integration_oauth_status(provider, token)
+
+        assert status == "failed"
+        assert message == "Refresh token revoked"
+
+    def test_in_progress_provider_status_without_token(self):
+        provider = _provider(status="waiting_callback", status_message="Awaiting user authorization")
+
+        status, message = resolve_integration_oauth_status(provider, None)
+
+        assert status == "waiting_callback"
+        assert message == "Awaiting user authorization"
+
+    def test_provider_failure_without_token(self):
+        provider = _provider(status="failed", status_message="No refresh token available")
+
+        status, message = resolve_integration_oauth_status(provider, None)
+
+        assert status == "failed"
+        assert message == "No refresh token available"
+
+    def test_legacy_token_without_status_is_connected(self):
+        provider = _provider(status="failed", status_message="Old scheduler failure")
+        token = _token(status="not_connected")
+
+        status, message = resolve_integration_oauth_status(provider, token)
+
+        assert status == "completed"
+        assert message is None
+
+    def test_no_token_defaults_to_not_connected(self):
+        provider = _provider(status="not_connected")
+
+        status, message = resolve_integration_oauth_status(provider, None)
+
+        assert status == "not_connected"
+        assert message is None
+
+
+@pytest.mark.asyncio
+async def test_persist_integration_oauth_recovery_clears_stale_provider_failure():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from src.services.oauth_provider import persist_integration_oauth_recovery
+
+    provider = SimpleNamespace(
+        status="failed",
+        status_message="Token refresh failed: bad entity_id",
+        last_token_refresh=None,
+        scopes=["scope"],
+    )
+    token = SimpleNamespace(
+        encrypted_access_token=b"old-token",
+        encrypted_refresh_token=None,
+        expires_at=None,
+        scopes=[],
+        status="failed",
+        status_message="Token refresh failed: bad entity_id",
+        last_refresh_at=None,
+    )
+    db = MagicMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+
+    with patch(
+        "src.services.oauth_scope_resolution.get_oauth_token_for_scope",
+        new_callable=AsyncMock,
+        return_value=token,
+    ):
+        result = await persist_integration_oauth_recovery(
+            db,
+            provider=provider,
+            org_uuid=None,
+            stored_token=token,
+            encrypted_access_token=b"new-token",
+            expires_at=datetime.now(timezone.utc),
+        )
+
+    assert result is token
+    assert provider.status == "completed"
+    assert provider.status_message is None
+    assert token.status == "completed"
+    assert token.status_message is None
+    assert token.encrypted_access_token == b"new-token"
+    db.flush.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Resolve integration detail `oauth_config.status` from the integration-level token instead of stale `provider.status`
- Persist recovered tokens and clear stale failure state when SDK auto-refresh succeeds
- Add unit coverage for reconciliation and auto-refresh persistence

Fixes #42

## Test plan
- [ ] `./test.sh tests/unit/test_integration_oauth_status.py -v`
- [ ] `./test.sh tests/unit/routers/test_cli_auto_refresh.py -v`
- [ ] Manual: after a failed refresh leaves `provider.status=failed`, SDK `integrations/get` should show Connected in Integration Detail

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token persistence and status display for integration-level and SDK refresh paths; incorrect reconciliation could misreport connection health but does not alter auth gates.
> 
> **Overview**
> Fixes **stale “failed” OAuth state** on integration detail and SDK paths after tokens are recovered without a full reconnect.
> 
> **Admin integration detail** now loads the latest **integration-level** token (`org_id` / `user_id` null) and derives `oauth_config.status`, message, and `last_refresh_at` via **`resolve_integration_oauth_status`**, so a healthy token row wins over a leftover `OAuthProvider.status=failed`.
> 
> **SDK `integrations/get` auto-refresh** passes the DB session into **`_build_oauth_data`**; on success it **`persist_integration_oauth_recovery`** (encrypted access token, scopes, `completed` on token + provider) and commits. **`integrations/refresh_token`** also sets token `status`, clears `status_message`, and records **`last_refresh_at`** on successful refresh.
> 
> New unit tests cover status reconciliation, recovery persistence, and CLI auto-refresh calling persist when `db` is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28193b747a95644f49150a1a9e7640f2ceb95911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->