### PR TITLE
fix: run system-triggered workflows in provider org scope

### DIFF
--- a/api/bifrost/_context.py
+++ b/api/bifrost/_context.py
@@ -130,6 +130,8 @@ def resolve_scope(scope: str | None) -> str | None:
 
     If explicit scope differs from default scope, requires provider org context.
     """
+    if scope == "global":
+        scope = None
     default = get_default_scope()
     if scope is None:
         return default

--- a/api/bifrost/_context.py
+++ b/api/bifrost/_context.py
@@ -131,6 +131,9 @@ def resolve_scope(scope: str | None) -> str | None:
     If explicit scope differs from default scope, requires provider org context.
     """
     if scope == "global":
+        ctx = _execution_context.get()
+        if ctx is None:
+            return "global"  # CLI mode — preserve explicit global scope token
         scope = None
     default = get_default_scope()
     if scope is None:

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -23,6 +23,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from src.core.constants import PROVIDER_ORG_ID
 from src.core.log_safety import log_safe
 from src.models.enums import EventDeliveryStatus, EventSourceType, EventStatus
 from src.models.orm.events import (
@@ -571,7 +572,7 @@ class EventProcessor:
 
         workflow_org_id = workflow.organization_id
         event_source_org_id = event.event_source.organization_id if event.event_source else None
-        execution_org_id = workflow_org_id or event_source_org_id
+        execution_org_id = workflow_org_id or event_source_org_id or PROVIDER_ORG_ID
 
         # Use the centralized system execution helper. Org-scoped workflows keep
         # their own scope; global workflows inherit the triggering event source
@@ -580,7 +581,7 @@ class EventProcessor:
             workflow_id=str(workflow.id),
             parameters=parameters,
             source="Event System",
-            org_id=str(execution_org_id) if execution_org_id else None,
+            org_id=str(execution_org_id),
         )
 
         # Store the execution ID on the delivery for tracking

--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -18,7 +18,7 @@ import logging
 import uuid
 from typing import Any
 
-from src.core.constants import SYSTEM_USER_ID, SYSTEM_USER_EMAIL
+from src.core.constants import PROVIDER_ORG_ID, SYSTEM_USER_ID, SYSTEM_USER_EMAIL
 from src.core.log_safety import log_safe
 from src.core.redis_client import get_redis_client
 from src.jobs.rabbitmq import publish_message
@@ -98,6 +98,7 @@ async def enqueue_workflow_execution(
     sync: bool = False,
     api_key_id: str | None = None,
     file_path: str | None = None,
+    org_id_override: str | None = None,
 ) -> str:
     """
     Enqueue a workflow for async execution.
@@ -114,6 +115,7 @@ async def enqueue_workflow_execution(
         sync: If True, worker will push result to Redis for caller to BLPOP
         api_key_id: Optional workflow ID whose API key triggered this execution
         file_path: Optional file path (for fast direct loading, avoids filesystem scan)
+        org_id_override: Optional org scope for queueing when context.organization is unset
 
     Returns:
         execution_id: UUID of the queued execution
@@ -122,11 +124,17 @@ async def enqueue_workflow_execution(
     if execution_id is None:
         execution_id = str(uuid.uuid4())
 
+    effective_org_id = (
+        org_id_override
+        if org_id_override is not None
+        else context.org_id
+    )
+
     await _publish_pending(
         execution_id=execution_id,
         workflow_id=workflow_id,
         parameters=parameters,
-        org_id=context.org_id,
+        org_id=effective_org_id,
         user_id=context.user_id,
         user_name=context.name,
         user_email=context.email,
@@ -143,7 +151,7 @@ async def enqueue_workflow_execution(
         extra={
             "execution_id": execution_id,
             "workflow_id": workflow_id,
-            "org_id": context.org_id
+            "org_id": effective_org_id
         }
     )
 
@@ -247,11 +255,16 @@ async def enqueue_system_workflow_execution(
 
     from src.config import get_settings
 
+    # System-triggered runs default to the provider org so MSP-wide integrations
+    # and cross-scope SDK calls work without requiring every schedule/webhook to
+    # restate the provider org explicitly.
+    effective_org_id = org_id or str(PROVIDER_ORG_ID)
+
     context = ExecutionContext(
         user_id=SYSTEM_USER_ID,
         email=SYSTEM_USER_EMAIL,
         name=source,
-        scope=f"ORG:{org_id}" if org_id else "GLOBAL",
+        scope=f"ORG:{effective_org_id}",
         organization=None,
         is_platform_admin=True,
         is_function_key=False,
@@ -265,4 +278,5 @@ async def enqueue_system_workflow_execution(
         workflow_id=workflow_id,
         parameters=parameters,
         execution_id=execution_id,  # Pass explicitly to avoid double generation
+        org_id_override=effective_org_id,
     )

--- a/api/tests/unit/services/execution/test_async_executor.py
+++ b/api/tests/unit/services/execution/test_async_executor.py
@@ -63,3 +63,44 @@ async def test_publish_pending_includes_file_path_when_present():
     _, message = pub.await_args.args
     assert message["file_path"] == "workflows/foo.py"
     assert message["sync"] is True
+
+
+@pytest.mark.asyncio
+async def test_enqueue_system_workflow_execution_defaults_to_provider_org():
+    with (
+        patch(
+            "src.services.execution.async_executor.enqueue_workflow_execution",
+            new=AsyncMock(return_value="exec-1"),
+        ) as enqueue,
+    ):
+        from src.services.execution.async_executor import enqueue_system_workflow_execution
+
+        execution_id = await enqueue_system_workflow_execution(
+            workflow_id="wf-1",
+            parameters={"apply": True},
+            source="Event System",
+        )
+
+    assert execution_id == "exec-1"
+    enqueue.assert_awaited_once()
+    assert enqueue.await_args.kwargs["org_id_override"] == "00000000-0000-0000-0000-000000000002"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_system_workflow_execution_preserves_explicit_org():
+    with (
+        patch(
+            "src.services.execution.async_executor.enqueue_workflow_execution",
+            new=AsyncMock(return_value="exec-2"),
+        ) as enqueue,
+    ):
+        from src.services.execution.async_executor import enqueue_system_workflow_execution
+
+        await enqueue_system_workflow_execution(
+            workflow_id="wf-1",
+            parameters={},
+            source="Event System",
+            org_id="11111111-1111-1111-1111-111111111111",
+        )
+
+    assert enqueue.await_args.kwargs["org_id_override"] == "11111111-1111-1111-1111-111111111111"

--- a/api/tests/unit/services/test_event_processor_agents.py
+++ b/api/tests/unit/services/test_event_processor_agents.py
@@ -260,3 +260,27 @@ async def test_queue_workflow_execution_prefers_workflow_org():
 
         mock_enqueue.assert_awaited_once()
         assert mock_enqueue.call_args.kwargs["org_id"] == str(workflow_org_id)
+
+
+@pytest.mark.asyncio
+async def test_queue_workflow_execution_defaults_to_provider_org():
+    """Global workflow + global event source should still run in provider org."""
+    processor = _create_processor()
+
+    workflow = MagicMock()
+    workflow.id = uuid.uuid4()
+    workflow.organization_id = None
+    delivery = _make_delivery(target_type="workflow", workflow=workflow)
+    event = _make_event(event_source_org_id=None)
+
+    mock_enqueue = AsyncMock(return_value=str(uuid.uuid4()))
+    fake_async_executor = _fake_module(
+        "src.services.execution.async_executor",
+        enqueue_system_workflow_execution=mock_enqueue,
+    )
+
+    with patch.dict(sys.modules, {"src.services.execution.async_executor": fake_async_executor}):
+        await processor._queue_workflow_execution(delivery, event)
+
+        mock_enqueue.assert_awaited_once()
+        assert mock_enqueue.call_args.kwargs["org_id"] == "00000000-0000-0000-0000-000000000002"

--- a/api/tests/unit/test_scope_override.py
+++ b/api/tests/unit/test_scope_override.py
@@ -148,6 +148,26 @@ class TestResolveScope:
         result = resolve_scope(None)
         assert result is None
 
+    def test_global_string_matches_default_global_scope(self):
+        from bifrost._context import resolve_scope, set_execution_context, clear_execution_context
+
+        ctx = ExecutionContext(
+            user_id="u1",
+            email="e@e.com",
+            name="Test",
+            scope="GLOBAL",
+            organization=None,
+            is_platform_admin=True,
+            is_function_key=False,
+            execution_id="exec-1",
+        )
+        set_execution_context(ctx)
+        try:
+            assert resolve_scope("global") is None
+            assert resolve_scope(None) is None
+        finally:
+            clear_execution_context()
+
 
 class TestOrganizationIsProvider:
     """Test that is_provider field exists and defaults correctly."""

--- a/api/tests/unit/test_scope_override.py
+++ b/api/tests/unit/test_scope_override.py
@@ -168,6 +168,12 @@ class TestResolveScope:
         finally:
             clear_execution_context()
 
+    def test_global_string_preserved_in_cli_mode(self):
+        from bifrost._context import resolve_scope, clear_execution_context
+
+        clear_execution_context()
+        assert resolve_scope("global") == "global"
+
 
 class TestOrganizationIsProvider:
     """Test that is_provider field exists and defaults correctly."""


### PR DESCRIPTION
## Summary
- Fix system workflow enqueue dropping org scope when `ExecutionContext.organization` is unset, which caused scheduled/event runs to execute as Global and fail MSP-wide `scope=global` SDK calls.
- Default system-triggered executions to the Provider org and pass org scope explicitly into Redis pending state.
- Treat SDK `scope=global` as default global scope (`None`) for compatibility with existing workspace integrations code.

## Test plan
- [x] `pytest tests/unit/test_scope_override.py tests/unit/services/execution/test_async_executor.py tests/unit/services/test_event_processor_agents.py`
- [ ] Merge and promote API/worker images to dev via bifrost-infra
- [ ] Confirm next `reconcile_ninjaone_alert_tickets` schedule run executes under Provider and succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org scope for automated workflow enqueue and Redis pending metadata, which affects credentials and SDK scope for schedules/webhooks; behavior is covered by new unit tests but impacts production execution paths.
> 
> **Overview**
> Fixes **system-triggered** workflow runs (schedules, webhooks, event deliveries) losing org scope when `ExecutionContext.organization` is unset, which caused executions to behave as **Global** and break MSP-wide SDK calls that pass `scope=global`.
> 
> **Execution queueing:** `enqueue_system_workflow_execution` now defaults missing `org_id` to the **provider org**, sets scope to `ORG:{id}` instead of `GLOBAL`, and passes **`org_id_override`** into `enqueue_workflow_execution` so Redis pending state always carries the effective org. Event processor `_queue_workflow_execution` falls back to `PROVIDER_ORG_ID` when both workflow and event source are global.
> 
> **SDK:** `resolve_scope("global")` maps to default global scope (`None`) in workflow context, while CLI mode still preserves the literal `"global"` token for compatibility with existing integrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df89355292e06e789ba72b319ce696bd280fd230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->