### PR TITLE
fix: compare CLI sync using content_hash instead of storage ETag

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -84,19 +84,30 @@ _FORCE_INCLUDE_PATTERNS = [
 
 def _normalize_line_endings(data: bytes) -> bytes:
     """Normalize CRLF to LF for text files. Binary files pass through unchanged."""
-    if b"\x00" in data[:8192]:
-        return data
-    return data.replace(b"\r\n", b"\n")
+    from shared.sync_content_hash import normalize_line_endings
+
+    return normalize_line_endings(data)
 
 
 def _hash_for_cache(raw_bytes: bytes) -> str:
     """md5 of post-normalization bytes — must match what the server stores.
 
-    Watch normalizes CRLF to LF before pushing, so S3 stores normalized bytes
-    and S3's ETag is md5 of those. Any hash we compare against a server ETag
-    must be computed on the same normalized bytes.
+    Watch normalizes CRLF to LF before pushing, so object storage stores
+    normalized bytes for CLI-driven sync. Any hash we compare against server
+    content must be computed on the same normalized bytes.
     """
-    return hashlib.md5(_normalize_line_endings(raw_bytes)).hexdigest()
+    from shared.sync_content_hash import compute_sync_content_hash
+
+    return compute_sync_content_hash(raw_bytes)
+
+
+def _server_sync_hash(server_info: dict[str, str]) -> str | None:
+    """Prefer API content_hash; fall back to legacy storage etag metadata."""
+    content_hash = server_info.get("content_hash")
+    if content_hash:
+        return content_hash
+    etag = server_info.get("etag")
+    return etag or None
 
 
 def _is_bifrost_path(path: str) -> bool:
@@ -2729,9 +2740,9 @@ async def _watch_and_push(
         if seed_resp.status_code == 200:
             seed_data = seed_resp.json()
             state.seed_known_hashes({
-                item["path"]: item["etag"]
+                item["path"]: item.get("content_hash") or item["etag"]
                 for item in seed_data.get("files_metadata", [])
-                if item.get("path") and item.get("etag")
+                if item.get("path") and (item.get("content_hash") or item.get("etag"))
             })
     except Exception as e:
         # Hash cache seeding is an optimization — cold start just falls back to byte-compare
@@ -2905,6 +2916,7 @@ async def _sync_files(
             for item in data.get("files_metadata", []):
                 server_metadata[item["path"]] = {
                     "etag": item["etag"],
+                    "content_hash": item.get("content_hash", ""),
                     "last_modified": item["last_modified"],
                     "updated_by": item.get("updated_by", ""),
                 }
@@ -2927,7 +2939,7 @@ async def _sync_files(
 
     for repo_path, content in regular_files.items():
         rel = _strip_repo_prefix(repo_path, repo_prefix)
-        local_md5 = hashlib.md5(base64.b64decode(content)).hexdigest()
+        local_hash = hashlib.md5(base64.b64decode(content)).hexdigest()
         server_info = server_metadata.get(repo_path)
 
         if server_info is None:
@@ -2944,7 +2956,7 @@ async def _sync_files(
                 "rel": rel,
                 "_content": content,
             })
-        elif server_info["etag"] != local_md5:
+        elif _server_sync_hash(server_info) != local_hash:
             matched_server_paths.add(repo_path)
             # Content differs — check timestamps
             local_file = path / rel

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -2939,7 +2939,7 @@ async def _sync_files(
 
     for repo_path, content in regular_files.items():
         rel = _strip_repo_prefix(repo_path, repo_prefix)
-        local_hash = hashlib.md5(base64.b64decode(content)).hexdigest()
+        local_hash = _hash_for_cache(base64.b64decode(content))
         server_info = server_metadata.get(repo_path)
 
         if server_info is None:

--- a/api/shared/sync_content_hash.py
+++ b/api/shared/sync_content_hash.py
@@ -19,4 +19,4 @@ def normalize_line_endings(data: bytes) -> bytes:
 
 def compute_sync_content_hash(raw_bytes: bytes) -> str:
     """Return md5 hex digest of normalized bytes — matches bifrost CLI sync."""
-    return hashlib.md5(normalize_line_endings(raw_bytes)).hexdigest()
+    return hashlib.md5(normalize_line_endings(raw_bytes)).hexdigest()  # NOSONAR - content fingerprint, not crypto

--- a/api/shared/sync_content_hash.py
+++ b/api/shared/sync_content_hash.py
@@ -1,0 +1,22 @@
+"""Content hash used by CLI sync/pull/watch to compare local and server files.
+
+Storage providers expose opaque ETags (especially Azure Blob) that do not match
+the normalized MD5 the CLI computes after CRLF normalization. Use this helper
+everywhere sync semantics need a stable content fingerprint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def normalize_line_endings(data: bytes) -> bytes:
+    """Normalize CRLF to LF for text files. Binary files pass through unchanged."""
+    if b"\x00" in data[:8192]:
+        return data
+    return data.replace(b"\r\n", b"\n")
+
+
+def compute_sync_content_hash(raw_bytes: bytes) -> str:
+    """Return md5 hex digest of normalized bytes — matches bifrost CLI sync."""
+    return hashlib.md5(normalize_line_endings(raw_bytes)).hexdigest()

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -382,7 +382,9 @@ async def list_files_simple(
                 if not path.startswith(".git/")
             }
 
-            # Look up updated_by and indexed content for sync hash metadata
+            # Look up updated_by and indexed text for sync-hash metadata.
+            # FileIndex.content_hash is SHA-256 (github_sync); CLI sync uses
+            # normalized MD5 via compute_sync_content_hash — compute on the fly.
             from src.models.orm.file_index import FileIndex
 
             fi_result = await db.execute(

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -168,6 +168,10 @@ class FileListMetadataItem(BaseModel):
     etag: str
     last_modified: str  # ISO 8601
     updated_by: str | None = None
+    content_hash: str | None = Field(
+        default=None,
+        description="Normalized MD5 content hash for CLI sync comparisons",
+    )
 
 
 class FileListResponse(BaseModel):
@@ -378,15 +382,23 @@ async def list_files_simple(
                 if not path.startswith(".git/")
             }
 
-            # Look up updated_by from file_index
+            # Look up updated_by and indexed content for sync hash metadata
             from src.models.orm.file_index import FileIndex
 
             fi_result = await db.execute(
-                select(FileIndex.path, FileIndex.updated_by).where(
+                select(FileIndex.path, FileIndex.updated_by, FileIndex.content).where(
                     FileIndex.path.in_(list(s3_metadata.keys()))
                 )
             )
-            author_lookup = {row.path: row.updated_by for row in fi_result.all()}
+            index_lookup = {
+                row.path: {
+                    "updated_by": row.updated_by,
+                    "content": row.content,
+                }
+                for row in fi_result.all()
+            }
+
+            from shared.sync_content_hash import compute_sync_content_hash
 
             return FileListResponse(
                 files=sorted(s3_metadata.keys()),
@@ -395,7 +407,12 @@ async def list_files_simple(
                         path=path,
                         etag=meta.etag,
                         last_modified=meta.last_modified.isoformat(),
-                        updated_by=author_lookup.get(path),
+                        updated_by=index_lookup.get(path, {}).get("updated_by"),
+                        content_hash=(
+                            compute_sync_content_hash(index_lookup[path]["content"].encode("utf-8"))
+                            if index_lookup.get(path, {}).get("content")
+                            else None
+                        ),
                     )
                     for path, meta in sorted(s3_metadata.items())
                 ],

--- a/api/tests/unit/cli/test_sync_content_hash_comparison.py
+++ b/api/tests/unit/cli/test_sync_content_hash_comparison.py
@@ -1,0 +1,94 @@
+"""CLI sync should compare normalized content hashes, not storage ETags."""
+
+from __future__ import annotations
+
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from bifrost import cli
+
+
+class _Response:
+    def __init__(self, status_code: int, body: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+        self.text = ""
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _SyncClient:
+    def __init__(
+        self,
+        *,
+        server_path: str,
+        content_hash: str | None,
+        storage_etag: str,
+        last_modified: str | None = None,
+    ) -> None:
+        self.server_path = server_path
+        self.content_hash = content_hash
+        self.storage_etag = storage_etag
+        self.last_modified = last_modified or datetime(2000, 1, 1, tzinfo=timezone.utc).isoformat()
+
+    async def post(self, endpoint: str, json: dict[str, Any]) -> _Response:
+        if endpoint == "/api/files/list":
+            item = {
+                "path": self.server_path,
+                "etag": self.storage_etag,
+                "last_modified": self.last_modified,
+                "updated_by": "tester",
+            }
+            if self.content_hash is not None:
+                item["content_hash"] = self.content_hash
+            return _Response(200, {"files_metadata": [item]})
+        if endpoint == "/api/files/write":
+            return _Response(204)
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+
+@pytest.fixture
+def workspace(tmp_path: pathlib.Path) -> pathlib.Path:
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_unchanged_when_content_hash_matches(workspace: pathlib.Path) -> None:
+    rel = "example.py"
+    local_bytes = b"print('same')\n"
+    (workspace / rel).write_bytes(local_bytes)
+    content_hash = cli._hash_for_cache(local_bytes)
+
+    client = _SyncClient(
+        server_path=rel,
+        content_hash=content_hash,
+        storage_etag="azure-opaque-etag",
+    )
+
+    rc = await cli._sync_files(str(workspace), force=True, client=client)
+
+    assert rc == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_pushes_when_content_hash_differs_even_if_storage_etag_matches(
+    workspace: pathlib.Path,
+) -> None:
+    rel = "example.py"
+    local_bytes = b"print('local')\n"
+    (workspace / rel).write_bytes(local_bytes)
+    stale_hash = cli._hash_for_cache(b"print('server')\n")
+
+    client = _SyncClient(
+        server_path=rel,
+        content_hash=stale_hash,
+        storage_etag=cli._hash_for_cache(local_bytes),
+    )
+
+    rc = await cli._sync_files(str(workspace), force=True, client=client)
+
+    assert rc == 0

--- a/api/tests/unit/shared/test_sync_content_hash.py
+++ b/api/tests/unit/shared/test_sync_content_hash.py
@@ -1,0 +1,16 @@
+from shared.sync_content_hash import compute_sync_content_hash, normalize_line_endings
+
+
+def test_normalize_line_endings_collapses_crlf():
+    assert normalize_line_endings(b"a\r\nb") == b"a\nb"
+
+
+def test_normalize_line_endings_preserves_binary():
+    binary = b"\x00\xff\r\n"
+    assert normalize_line_endings(binary) == binary
+
+
+def test_compute_sync_content_hash_matches_cli_semantics():
+    crlf = b"line one\r\nline two\r\n"
+    lf = b"line one\nline two\n"
+    assert compute_sync_content_hash(crlf) == compute_sync_content_hash(lf)


### PR DESCRIPTION
## Summary

- Adds shared `compute_sync_content_hash()` (normalized MD5) for stable cross-provider sync comparisons
- Extends `/api/files/list` metadata with optional `content_hash` derived from indexed file content
- Updates CLI sync/pull/watch to prefer `content_hash` over storage `etag`, with legacy etag fallback

Fixes #283

## Context

Azure Blob cutover on dev/PoC exposed that storage ETags are not content MD5s. The CLI was using list metadata `etag` as a fingerprint, causing incorrect unchanged/changed detection and noisy or misleading push behavior.

## Test plan

- [x] `pytest tests/unit/shared/test_sync_content_hash.py`
- [x] `pytest tests/unit/cli/test_sync_content_hash_comparison.py`
- [x] `pytest tests/unit/test_watch_hash_cache.py`
- [ ] Deploy to dev and verify `bifrost sync features/ninjaone --force` skips unchanged files when git matches server
- [ ] Verify `/api/files/list` returns `content_hash` for indexed `.py` workflow files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sync decides unchanged vs changed files across the CLI and files list API; behavior is mitigated by etag fallback and new tests, but unindexed files may omit content_hash until indexed.
> 
> **Overview**
> Introduces a shared **normalized MD5** (`compute_sync_content_hash`) so CLI **sync**, **pull**, and **watch** compare stable content fingerprints instead of storage **ETags** (which break on providers like Azure Blob).
> 
> **`/api/files/list`** metadata now includes optional **`content_hash`**, computed from indexed file text when listing the cloud workspace. The CLI prefers **`content_hash`** and falls back to **`etag`** for older servers.
> 
> Local/server diffing in sync uses the same hash path as watch (CRLF normalization unchanged in behavior, now shared). Unit tests cover the helper and sync skip/push when etag and content disagree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59456bfa7d8bdbd582243bc363426d6f30234e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->