### PR TITLE
chore(release): MTG-owned semver line starting at v1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI. Includes :build (create and debug artifacts) and :setup (install CLI, authenticate, configure MCP).",
-  "version": "0.9.2-dev.5",
+  "version": "1.0.0",
   "author": {
-    "name": "Jack Musick",
-    "url": "https://github.com/jackmusick/bifrost"
+    "name": "Midtown Technology Group",
+    "url": "https://github.com/MTG-Thomas"
   },
-  "homepage": "https://github.com/jackmusick/bifrost",
-  "repository": "https://github.com/jackmusick/bifrost",
+  "homepage": "https://github.com/MTG-Thomas/bifrost",
+  "repository": "https://github.com/MTG-Thomas/bifrost",
   "license": "AGPL-3.0"
 }

--- a/.claude/skills/bifrost-release/SKILL.md
+++ b/.claude/skills/bifrost-release/SKILL.md
@@ -5,6 +5,12 @@ description: Build and release Bifrost. Use when pushing commits to main, cuttin
 
 # Bifrost Release
 
+## MTG fork versioning
+
+On `MTG-Thomas/bifrost`, semver is **MTG-owned** starting at `v1.0.0`. Do not
+continue upstream `0.9.x` numbering. See `docs/VERSIONING.md`. Dev builds use
+MTG tags only — CI does not fetch upstream release tags.
+
 ## Step 1: Ask which workflow
 
 > "Are you doing a **dev push** (push commits → CI builds `:dev`) or a **full release** (version tag → GitHub Release + `:latest`)?"
@@ -85,8 +91,8 @@ git push origin main
 
 > "Pushed. CI will now:
 > 1. Run **unit tests** (fast ~2 min) — if they pass:
-> 2. Build and push `ghcr.io/jackmusick/bifrost-api:dev` and `ghcr.io/jackmusick/bifrost-client:dev`
-> 3. Also tag `ghcr.io/jackmusick/bifrost-api:<git-describe>` for traceability
+> 2. Build and push `ghcr.io/mtg-thomas/bifrost-api:dev` and `ghcr.io/mtg-thomas/bifrost-client:dev`
+> 3. Also tag `ghcr.io/mtg-thomas/bifrost-api:<git-describe>` for traceability
 >
 > E2E tests run in parallel but don't block the build.
 >
@@ -95,7 +101,7 @@ git push origin main
 > kubectl rollout restart deployment/bifrost-api deployment/bifrost-worker deployment/bifrost-scheduler deployment/bifrost-client -n bifrost
 > ```
 >
-> Watch CI: https://github.com/jackmusick/bifrost/actions"
+> Watch CI: https://github.com/MTG-Thomas/bifrost/actions"
 
 ---
 
@@ -316,11 +322,11 @@ gh release edit <tag> --notes-file /tmp/release-notes-<tag>.md
 > "Tag `<tag>` pushed. CI will now:
 > 1. Run **unit tests + E2E tests** (both required for a release, ~12 min total)
 > 2. Build and push images:
->    - `ghcr.io/jackmusick/bifrost-api:<version>` (e.g., `2.1.0`)
->    - `ghcr.io/jackmusick/bifrost-api:2.1` and `ghcr.io/jackmusick/bifrost-api:2`
->    - `ghcr.io/jackmusick/bifrost-api:latest`
+>    - `ghcr.io/mtg-thomas/bifrost-api:<version>` (e.g., `2.1.0`)
+>    - `ghcr.io/mtg-thomas/bifrost-api:2.1` and `ghcr.io/mtg-thomas/bifrost-api:2`
+>    - `ghcr.io/mtg-thomas/bifrost-api:latest`
 >    - Same for `bifrost-client`
-> 3. Create a GitHub Release at https://github.com/jackmusick/bifrost/releases
+> 3. Create a GitHub Release at https://github.com/MTG-Thomas/bifrost/releases
 >
 > After CI completes, K8s pods on `:latest` or `:<version>` will need a rollout:
 > ```bash
@@ -329,7 +335,7 @@ gh release edit <tag> --notes-file /tmp/release-notes-<tag>.md
 >
 > CLI users on `:latest` will automatically get the new version next `pipx install`.
 >
-> Watch CI: https://github.com/jackmusick/bifrost/actions"
+> Watch CI: https://github.com/MTG-Thomas/bifrost/actions"
 
 ### 6. Offer to draft a blog post (gobifrost `/blog` skill)
 
@@ -362,8 +368,8 @@ Follow the skill's workflow exactly — it handles preflight, voice-matching aga
 ## K8s Quick Reference
 
 **Current image tags in use** (all in namespace `bifrost`):
-- `api`, `init container`, `worker`, `scheduler` → `ghcr.io/jackmusick/bifrost-api:dev`
-- `client` → `ghcr.io/jackmusick/bifrost-client:dev`
+- `api`, `init container`, `worker`, `scheduler` → `ghcr.io/mtg-thomas/bifrost-api:dev`
+- `client` → `ghcr.io/mtg-thomas/bifrost-client:dev`
 
 **Force rollout after a push:**
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,10 +179,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch upstream release tags
-        run: |
-          git fetch --tags https://github.com/jackmusick/bifrost.git
-
       - name: Compute version
         id: version
         run: |

--- a/README.md
+++ b/README.md
@@ -239,17 +239,17 @@ Bifrost release artifacts are signed with [Sigstore](https://www.sigstore.dev/) 
 **Verify a Docker image:**
 
 ```bash
-cosign verify ghcr.io/jackmusick/bifrost-api:TAG \
-  --certificate-identity-regexp "https://github.com/jackmusick/bifrost/.*" \
+cosign verify ghcr.io/mtg-thomas/bifrost-api:TAG \
+  --certificate-identity-regexp "https://github.com/MTG-Thomas/bifrost/.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-(Same form for `ghcr.io/jackmusick/bifrost-client`.)
+(Same form for `ghcr.io/mtg-thomas/bifrost-client`.)
 
 **Inspect SLSA build provenance:**
 
 ```bash
-gh attestation verify ghcr.io/jackmusick/bifrost-api:TAG --owner jackmusick
+gh attestation verify ghcr.io/mtg-thomas/bifrost-api:TAG --owner MTG-Thomas
 ```
 
 **Verify a source tarball** (attached to GitHub Releases):
@@ -257,7 +257,7 @@ gh attestation verify ghcr.io/jackmusick/bifrost-api:TAG --owner jackmusick
 ```bash
 cosign verify-blob \
   --bundle bifrost-VERSION-source.tar.gz.sigstore \
-  --certificate-identity-regexp "https://github.com/jackmusick/bifrost/.*" \
+  --certificate-identity-regexp "https://github.com/MTG-Thomas/bifrost/.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   bifrost-VERSION-source.tar.gz
 ```

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,47 @@
+# MTG Bifrost Versioning
+
+`MTG-Thomas/bifrost` uses an **independent semver line** owned by Midtown Technology
+Group. Version numbers describe **MTG fork behavior**, not upstream release numbers.
+
+## Semver policy
+
+| Component | Meaning on this fork |
+|-----------|----------------------|
+| **MAJOR** | Breaking platform or operator-facing behavior changes |
+| **MINOR** | Backward-compatible features or substantial improvements |
+| **PATCH** | Backward-compatible fixes, security patches, small changes |
+
+Pre-release dev builds use `<next-patch>-dev.<commits-since-tag>` (see
+[dev-version-format runbook](runbooks/dev-version-format.md)).
+
+## First release baseline
+
+- **First MTG semver tag:** `v1.0.0`
+- **Upstream relationship:** documented here and in GitHub Release notes — **not**
+  encoded in the version number.
+- **Upstream lineage at `v1.0.0`:** includes platform work through upstream
+  `v0.9.1` plus MTG fork-specific changes (badges, security policy, CI/registry
+  ownership, workspace integration, and related operator tooling).
+
+Future releases increment MTG semver only. When useful, release notes may mention
+which upstream tag or commit range the MTG release incorporated.
+
+## Tags and releases
+
+1. Cut semver tags on `MTG-Thomas/bifrost` only (`vMAJOR.MINOR.PATCH`).
+2. Do **not** mirror upstream tags into this repo for dev-version computation.
+3. Fork-local prerelease tags such as `v0.9.1-mtg.1` are ignored by
+   `scripts/compute-dev-version.sh`.
+4. Before the first tag, dev versions bootstrap as `1.0.0-dev.N` from commit
+   count on `main`.
+5. Run `./scripts/release-check.sh vX.Y.Z` before tagging.
+6. Push the tag; CI builds signed images and opens a GitHub Release draft.
+7. Edit the release notes to include a **Fixed vulnerabilities** section (OpenSSF
+   Passing requirement) and an upstream baseline note when relevant.
+
+## Related files
+
+- `scripts/compute-dev-version.sh` — dev version on every `main` build
+- `scripts/release-check.sh` — pre-tag checks
+- `.claude/skills/bifrost-release/SKILL.md` — operator release flow
+- `.claude-plugin/plugin.json` — plugin manifest version (updated at tag time)

--- a/docs/runbooks/dev-version-format.md
+++ b/docs/runbooks/dev-version-format.md
@@ -13,9 +13,10 @@ When a release is cut (e.g. `v0.8.1`), the next merge to main produces
 `0.8.2-dev.1`. The next dev cycle's floor is automatically whatever
 release tag was last cut — no script changes required.
 
-Both annotated and lightweight `vMAJOR.MINOR.PATCH` tags are valid. The dev
-image workflow fetches upstream release tags before computing the version so a
-fork does not need every upstream tag manually mirrored before each sync.
+Both annotated and lightweight `vMAJOR.MINOR.PATCH` tags are valid. Dev versions
+use **MTG-Thomas/bifrost tags only** — see [VERSIONING.md](../VERSIONING.md).
+Before the first stable MTG release (`v1.0.0`), the script bootstraps to
+`1.0.0-dev.<commit-count>`.
 
 ## Where it's computed
 
@@ -64,11 +65,11 @@ After this change ships, in-flight users will see exactly one of:
 
 ## Debugging a wrong tag
 
-**Symptom: build fails with `compute-dev-version: no v* tag found in history`**
+**Symptom: dev version shows `1.0.0-dev.N` but you expected a higher base**
 
-The job cannot see any `vMAJOR.MINOR.PATCH` release tag. Check that the
-dev-build job has `fetch-depth: 0` and that its upstream-tag fetch step still
-runs before `scripts/compute-dev-version.sh`.
+No stable `vMAJOR.MINOR.PATCH` tag exists on `MTG-Thomas/bifrost` yet. Cut the
+first release (for example `v1.0.0`) or verify `fetch-depth: 0` on checkout so
+tag history is visible.
 
 **Symptom: build fails with `compute-dev-version: latest tag 'X' is not vMAJOR.MINOR.PATCH`**
 

--- a/scripts/compute-dev-version.sh
+++ b/scripts/compute-dev-version.sh
@@ -2,13 +2,17 @@
 # Compute a monotonic semver dev version for the current commit.
 #
 # Format: <next-patch>-dev.<commits-since-tag>
-# Example: latest tag v0.8.0, 47 commits ahead -> 0.8.1-dev.47
+# Example: latest tag v1.0.0, 47 commits ahead -> 1.0.1-dev.47
 #
-# Requires: a `v<MAJOR>.<MINOR>.<PATCH>` tag in history.
-# Fork-local prerelease tags such as `v0.9.1-mtg.1` are intentionally ignored
-# so they do not become the dev-version floor after a Midtown release.
-# Exits non-zero with a diagnostic on stderr if no usable tag exists.
+# MTG fork: uses tags on MTG-Thomas/bifrost only. Before the first stable
+# release, bootstraps to 1.0.0-dev.<commit-count>.
+# Fork-local prerelease tags such as `v0.9.1-mtg.1` are intentionally ignored.
 set -euo pipefail
+
+# Planned first MTG semver release when no stable tag exists yet.
+MTG_BOOTSTRAP_MAJOR=1
+MTG_BOOTSTRAP_MINOR=0
+MTG_BOOTSTRAP_PATCH=0
 
 last_tag=$(git describe \
   --tags \
@@ -16,9 +20,12 @@ last_tag=$(git describe \
   --match "v[0-9]*.[0-9]*.[0-9]*" \
   --exclude "v*-*" \
   2>/dev/null || true)
+
 if [[ -z "$last_tag" ]]; then
-  echo "compute-dev-version: no v* tag found in history" >&2
-  exit 1
+  commits=$(git rev-list --count HEAD 2>/dev/null || echo 0)
+  printf '%s.%s.%s-dev.%s\n' \
+    "$MTG_BOOTSTRAP_MAJOR" "$MTG_BOOTSTRAP_MINOR" "$MTG_BOOTSTRAP_PATCH" "$commits"
+  exit 0
 fi
 
 if ! [[ "$last_tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then

--- a/scripts/test-compute-dev-version.sh
+++ b/scripts/test-compute-dev-version.sh
@@ -58,25 +58,25 @@ run_test "fork release tag is ignored for next dev version" \
   'git commit --allow-empty -m init -q && git tag -a v0.9.0 -m v0.9.0 && git commit --allow-empty -m fork-release -q && git tag -a v0.9.1-mtg.1 -m v0.9.1-mtg.1 && git commit --allow-empty -m next -q' \
   '0.9.1-dev.2' 0
 
-run_test "only fork release tags still fails without stable base" \
+run_test "only fork release tags bootstrap to first MTG release line" \
   'git commit --allow-empty -m init -q && git tag -a v0.9.1-mtg.1 -m v0.9.1-mtg.1' \
-  '' 1
+  '1.0.0-dev.1' 0
 
 run_test "minor with double-digit patch" \
   'git commit --allow-empty -m init -q && git tag -a v1.2.10 -m v1.2.10 && git commit --allow-empty -m c1 -q' \
   '1.2.11-dev.1' 0
 
-run_test "no tags fails loudly" \
+run_test "no tags bootstraps to 1.0.0-dev.N" \
   'git commit --allow-empty -m init -q' \
-  '' 1
+  '1.0.0-dev.1' 0
 
-run_test "two-component tag is ignored" \
+run_test "two-component tag is ignored, bootstraps" \
   'git commit --allow-empty -m init -q && git tag v0.7' \
-  '' 1
+  '1.0.0-dev.1' 0
 
-run_test "non-v prefixed tag is ignored, falls back" \
+run_test "non-v prefixed tag is ignored, bootstraps" \
   'git commit --allow-empty -m init -q && git tag 1.0.0' \
-  '' 1
+  '1.0.0-dev.1' 0
 
 run_test "lightweight release tag is accepted" \
   'git commit --allow-empty -m init -q && git tag v1.0.0' \


### PR DESCRIPTION
## Summary
- Add docs/VERSIONING.md describing MTG independent semver (Model A), starting at v1.0.0
- Bootstrap dev versions as 1.0.0-dev.N before the first MTG tag; stop fetching upstream jackmusick tags in CI
- Bump plugin manifest to 1.0.0 with MTG-Thomas URLs; update release skill, dev-version runbook, and README cosign examples

Closes #289 (release mechanics — tag v1.0.0 follows merge)

## Test plan
- [x] bash ./scripts/test-compute-dev-version.sh (12 passed)
- [ ] CI green on PR
- [ ] After merge: tag v1.0.0 and publish release notes with Fixed CVEs section

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every main-build dev image is versioned and tagged in CI; wrong tagging or bootstrap logic could mislabel releases until v1.0.0 is cut, but runtime app behavior is largely unchanged.
> 
> **Overview**
> Establishes an **MTG-owned semver line** starting at **`v1.0.0`**, separate from upstream `0.9.x`, documented in new **`docs/VERSIONING.md`** and wired through operator docs (release skill, dev-version runbook).
> 
> **`scripts/compute-dev-version.sh`** now **bootstraps** to **`1.0.0-dev.<commit-count>`** when no stable `vMAJOR.MINOR.PATCH` tag exists (instead of failing); tests in **`scripts/test-compute-dev-version.sh`** were updated accordingly. **CI** drops the step that **fetched upstream `jackmusick` release tags** so dev versions use **only this repo’s tags**.
> 
> **`.claude-plugin/plugin.json`** is bumped to **`1.0.0`** with **MTG-Thomas** author/homepage/repository URLs. **README** Sigstore/cosign examples and the **bifrost-release** skill now reference **`ghcr.io/mtg-thomas`** and **`MTG-Thomas/bifrost`** instead of the upstream org/registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8a384f611f2c2ce82a9d8f97c6591e2c13ca02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioning documentation and dev build bootstrap logic for the fork.

* **Documentation**
  * Updated release notes, security verification instructions, and CI/CD workflow documentation to reflect fork ownership and registry changes.

* **Chores**
  * Bumped version to 1.0.0; updated repository metadata, author information, and container registry references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->