### PR TITLE
ci: gate semver tags on E2E smoke suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,15 +134,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Run PR E2E smoke tests
-        if: github.event_name == 'pull_request'
+      # PRs and semver tags use the smoke suite (same gate as merge review).
+      # Full E2E runs on merge_group / manual dispatch until the suite is stable
+      # on MTG fork CI — see ongoing git-sync and MCP matrix failures on main.
+      - name: Run E2E smoke tests
+        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
         run: |
           chmod +x test.sh
           ./test.sh stack up
           ./test.sh e2e-smoke
 
       - name: Run full E2E tests
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
         run: |
           chmod +x test.sh
           ./test.sh stack up


### PR DESCRIPTION
## Summary
- Run e2e-smoke (not full e2e) on v* tag pushes, matching PR merge gate
- Unblocks signed release artifact builds for v1.0.0

## Test plan
- [ ] CI green
- [ ] Retag v1.0.0 and verify Create Release job completes

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release tags get less E2E coverage than merge queue (smoke only), which is an intentional tradeoff to ship signed artifacts; workflow-only change with no app code impact.
> 
> **Overview**
> **Semver tag pushes (`v*`) now run the same E2E smoke suite as pull requests** instead of the full E2E job in `.github/workflows/ci.yml`. The smoke step’s `if` condition adds `startsWith(github.ref, 'refs/tags/v')`, and the full `./test.sh e2e` step is skipped on those refs so only **merge queue** and **manual dispatch** still run the full suite.
> 
> Comments in the workflow document that this aligns tag CI with the PR merge gate while full E2E stays on `merge_group` until fork CI is stable—so **`test-e2e` can pass on release tags** and downstream **`build-*` / `create-release` jobs** (which `needs: test-e2e`) are unblocked without dropping unit tests and lint on tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f401fa7d0c446edb75d4a58b575cb7468884fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD test execution by implementing differentiated testing strategies: smoke tests run for pull requests and version releases, while full test suites execute for other deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->