### PR TITLE
Fix Azure Blob list pagination causing /api/files/list 500s on PoC

### DIFF
--- a/api/src/services/file_storage/azure_blob_client.py
+++ b/api/src/services/file_storage/azure_blob_client.py
@@ -132,9 +132,12 @@ class AzureBlobStorageClient:
         del Bucket
         await self._ensure_client()
 
-        pager = self._container_client.list_blobs(name_starts_with=Prefix).by_page(
+        list_kwargs: dict[str, Any] = {"name_starts_with": Prefix}
+        if MaxKeys is not None:
+            list_kwargs["results_per_page"] = MaxKeys
+
+        pager = self._container_client.list_blobs(**list_kwargs).by_page(
             continuation_token=ContinuationToken,
-            results_per_page=MaxKeys,
         )
         try:
             page = await anext(pager)

--- a/api/tests/unit/services/test_file_storage_backend_selection.py
+++ b/api/tests/unit/services/test_file_storage_backend_selection.py
@@ -72,12 +72,11 @@ def _client_with_blob_names(names, *, next_token=None):
             self._blobs = blobs
 
         def by_page(self, **kwargs):
-            page_size = kwargs["results_per_page"]
-            blobs = self._blobs[:page_size] if page_size else self._blobs
-            return FakePager(blobs)
+            del kwargs
+            return FakePager(self._blobs)
 
     class FakeContainer:
-        def list_blobs(self, name_starts_with=""):
+        def list_blobs(self, name_starts_with="", results_per_page=None):
             blobs = [
                 SimpleNamespace(
                     name=name,
@@ -88,6 +87,8 @@ def _client_with_blob_names(names, *, next_token=None):
                 for name in names
                 if name.startswith(name_starts_with)
             ]
+            if results_per_page is not None:
+                blobs = blobs[:results_per_page]
             return FakePaged(blobs)
 
     client._container_client = FakeContainer()


### PR DESCRIPTION
## Summary

- Move \esults_per_page\ from \AsyncItemPaged.by_page()\ to \list_blobs()\ in the Azure Blob storage adapter
- Azure SDK 12.29.0 only accepts \continuation_token\ on \y_page()\; passing \esults_per_page\ there raised \TypeError\ and returned 500 on every \POST /api/files/list\ with \include_metadata: true\ (CLI sync path)
- Update unit test mock to match the real SDK surface

## Root cause

AKS logs showed hourly 500s:

\\\
Unhandled exception on POST /api/files/list: AsyncItemPaged.by_page() got an unexpected keyword argument 'results_per_page'
\\\

PoC uses \object_storage_provider: azure_blob\; SeaweedFS/S3 dev stacks were unaffected.

## Test plan

- [x] \pytest api/tests/unit/services/test_file_storage_backend_selection.py\
- [ ] CI green
- [ ] After merge + infra image promotion: confirm \POST /api/files/list\ returns 200 on PoC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small adapter fix aligned with the Azure SDK; S3/Seaweed paths unchanged and covered by existing unit tests.
> 
> **Overview**
> Fixes **Azure Blob** S3-shaped listing so **`MaxKeys`** maps to **`results_per_page` on `list_blobs()`**, not on **`by_page()`**. Azure SDK 12.29+ only accepts **`continuation_token`** on **`by_page()`**; the old call raised **`TypeError`** and broke **`POST /api/files/list`** (including metadata) on PoC stacks using **`azure_blob`**.
> 
> Unit test fakes were updated so **`list_blobs`** honors **`results_per_page`** and **`by_page`** no longer expects that kwarg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dafda741f100b248a893a31cb717e597936cf916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->