### PR TITLE
Fix Autotask missing required config on org-scoped SDK reads

### DIFF
--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -701,7 +701,11 @@ async def sdk_integrations_get(
 
         if mapping:
             # Org-specific mapping found
-            config = await repo.get_config_for_mapping(mapping.integration_id, org_uuid)
+            config = await repo.get_config_for_mapping(
+                mapping.integration_id,
+                org_uuid,
+                include_default_secrets=True,
+            )
             integration = mapping.integration
             entity_id = mapping.entity_id or (integration.default_entity_id if integration else None)
 
@@ -1001,7 +1005,11 @@ async def sdk_integrations_get_mapping(
             return None
 
         # Get merged config for the mapping
-        config = await repo.get_config_for_mapping(integration.id, mapping.organization_id)
+        config = await repo.get_config_for_mapping(
+            integration.id,
+            mapping.organization_id,
+            include_default_secrets=True,
+        )
 
         logger.info(f"SDK retrieved mapping for integration '{log_safe(request.name)}' for user {current_user.email}")
 

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -1680,7 +1680,11 @@ async def get_integration_sdk_data(
         )
 
     # Get merged configuration
-    config = await repo.get_config_for_mapping(integration.id, org_id)
+    config = await repo.get_config_for_mapping(
+        integration.id,
+        org_id,
+        include_default_secrets=True,
+    )
 
     # Get OAuth provider info if present
     oauth_client_id = None

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -556,13 +556,17 @@ class IntegrationsRepository:
                 return raw
         return raw
 
-    async def get_integration_defaults(self, integration_id: UUID) -> dict[str, Any]:
+    async def get_integration_defaults(
+        self, integration_id: UUID, *, include_secrets: bool = True
+    ) -> dict[str, Any]:
         """
         Get integration-level default config values.
 
         These are stored in the configs table with integration_id set
         but organization_id is NULL.
         """
+        from src.models.enums import ConfigType as ConfigTypeEnum
+
         config_query = select(ConfigModel).where(
             and_(
                 ConfigModel.integration_id == integration_id,
@@ -574,6 +578,8 @@ class IntegrationsRepository:
 
         config: dict[str, Any] = {}
         for entry in config_entries:
+            if entry.config_type == ConfigTypeEnum.SECRET and not include_secrets:
+                continue
             config[entry.key] = await self._extract_config_value(entry)
 
         return config
@@ -629,7 +635,11 @@ class IntegrationsRepository:
         return configs_by_org
 
     async def get_config_for_mapping(
-        self, integration_id: UUID, org_id: UUID
+        self,
+        integration_id: UUID,
+        org_id: UUID,
+        *,
+        include_default_secrets: bool = False,
     ) -> dict[str, Any]:
         """
         Get merged configuration for an integration mapping.
@@ -643,7 +653,9 @@ class IntegrationsRepository:
         Used by SDK endpoint where we need the fully resolved config.
         """
         # Start with integration-level defaults
-        config = await self.get_integration_defaults(integration_id)
+        config = await self.get_integration_defaults(
+            integration_id, include_secrets=include_default_secrets
+        )
 
         # Merge org overrides
         org_overrides = await self.get_org_config_overrides(integration_id, org_id)

--- a/api/tests/unit/repositories/test_integrations_repository.py
+++ b/api/tests/unit/repositories/test_integrations_repository.py
@@ -240,6 +240,46 @@ class TestIntegrationsRepository:
         assert result["base_url"] == "https://example.test"
         assert result["org_api_key"] == "org-secret"
 
+    async def test_get_config_for_mapping_includes_default_secrets_when_requested(
+        self, repository, mock_session
+    ):
+        """SDK execution reads may inherit shared integration-level secrets."""
+        from src.models.enums import ConfigType
+
+        integration_id = uuid4()
+        org_id = uuid4()
+
+        default_secret = MagicMock()
+        default_secret.key = "secret"
+        default_secret.value = {"value": "encrypted-global-secret"}
+        default_secret.config_type = ConfigType.SECRET
+        default_secret.organization_id = None
+
+        default_plain = MagicMock()
+        default_plain.key = "base_url"
+        default_plain.value = {"value": "https://example.test"}
+        default_plain.config_type = ConfigType.STRING
+        default_plain.organization_id = None
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [default_secret, default_plain]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        with patch(
+            "src.repositories.integrations.decrypt_secret",
+            return_value="shared-secret",
+        ):
+            result = await repository.get_config_for_mapping(
+                integration_id,
+                org_id,
+                include_default_secrets=True,
+            )
+
+        assert result["base_url"] == "https://example.test"
+        assert result["secret"] == "shared-secret"
+
     async def test_get_provider_org_token_filters_by_organization(
         self, repository, mock_session
     ):


### PR DESCRIPTION
## Summary

- Pass \include_default_secrets=True\ when resolving org mapping config for SDK execution paths (\/api/cli/integrations/get\, \get_mapping\, and \/api/integrations/sdk/{name}\)
- Autotask stores shared API credentials (\secret\, \username\, etc.) at integration level and only varies \entity_id\ per org mapping; the previous default skipped all integration-level secrets for org reads

## Root cause

\IntegrationsRepository.get_config_for_mapping()\ intentionally omits decrypted integration-default secrets unless explicitly requested. SDK integration reads did not opt in, so org-scoped Autotask calls saw empty \secret\/\username\ fields and failed with:

\Autotask integration missing required config: ['api_integration_code', 'username', 'secret']\

## Test plan

- [x] Unit tests for include/exclude default secret behavior
- [ ] CI green
- [ ] After deploy: org-scoped Autotask workflow/SDK call succeeds on PoC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when decrypted integration-default secrets are returned on SDK/execution paths; scope is limited to explicit opt-in call sites, but any mis-flagged endpoint could expose shared credentials more broadly than before.
> 
> **Overview**
> Org-scoped **SDK integration reads** now merge **integration-level default secrets** into resolved config when callers opt in, fixing integrations (e.g. Autotask) that store shared credentials globally and only vary per-org fields like `entity_id`.
> 
> `IntegrationsRepository.get_integration_defaults()` gains an `include_secrets` flag (default unchanged for admin paths). `get_config_for_mapping()` adds `include_default_secrets` and passes it through when building merged defaults + org overrides. **CLI/SDK execution endpoints** `integrations/get`, `integrations/get_mapping`, and **`GET /api/integrations/sdk/{name}`** pass `include_default_secrets=True`. A unit test covers the opt-in behavior; `list_mappings` / `upsert_mapping` still use the default (no default secrets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382bfcf5f8eff9f70d65a0db902fbf2e6af9b6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->