### PR TITLE
docs: governance, CoC, and DCO for OpenSSF Silver (#290)

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -197,9 +197,9 @@
   "roles_responsibilities_status": "Met",
   "roles_responsibilities_justification": "Maintainer, contributor, and code-owner roles are defined in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md and https://github.com/MTG-Thomas/bifrost/blob/main/.github/CODEOWNERS.",
   "access_continuity_status": "Met",
-  "access_continuity_justification": "Access continuity and succession expectations are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md (org owners, CODEOWNERS, branch protection).",
+  "access_continuity_justification": "Backup maintainers Doug Eckhart and Eric Atlas (@MTG-Thomas org members) and succession steps are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
   "bus_factor_status": "Met",
-  "bus_factor_justification": "Multiple maintainers via @MTG-Thomas CODEOWNERS and org-owner backup path are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
+  "bus_factor_justification": "Multiple @MTG-Thomas maintainers with named backups (Doug Eckhart, Eric Atlas) and org-owner paths are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
   "contributors_unassociated_status": "Met",
   "contributors_unassociated_justification": "External contributors are explicitly welcome via PR/issue flow; see https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md and https://github.com/MTG-Thomas/bifrost/blob/main/CONTRIBUTING.md."
 }

--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -187,5 +187,19 @@
   "OSPS-VM-02.01_status": "Met",
   "OSPS-VM-02.01_justification": "SECURITY.md documents two reporting channels: GitHub's private vulnerability advisory flow (preferred). Linked from repo root.",
   "OSPS-BR-01.03_status": "Met",
-  "OSPS-BR-01.03_justification": "pull_request triggers run with read-only GITHUB_TOKEN by default; deploy/release workflows fire only on push to main or tag events (verified in .github/workflows/ci.yml). External-contributor PRs cannot access secrets."
+  "OSPS-BR-01.03_justification": "pull_request triggers run with read-only GITHUB_TOKEN by default; deploy/release workflows fire only on push to main or tag events (verified in .github/workflows/ci.yml). External-contributor PRs cannot access secrets.",
+  "dco_status": "Met",
+  "dco_justification": "Developer Certificate of Origin 1.1 and Signed-off-by requirements are documented in https://github.com/MTG-Thomas/bifrost/blob/main/CONTRIBUTING.md.",
+  "governance_status": "Met",
+  "governance_justification": "MTG fork governance (roles, decisions, continuity) is documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
+  "code_of_conduct_status": "Met",
+  "code_of_conduct_justification": "Contributor Covenant 2.1 is published at https://github.com/MTG-Thomas/bifrost/blob/main/CODE_OF_CONDUCT.md with enforcement contacts.",
+  "roles_responsibilities_status": "Met",
+  "roles_responsibilities_justification": "Maintainer, contributor, and code-owner roles are defined in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md and https://github.com/MTG-Thomas/bifrost/blob/main/.github/CODEOWNERS.",
+  "access_continuity_status": "Met",
+  "access_continuity_justification": "Access continuity and succession expectations are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md (org owners, CODEOWNERS, branch protection).",
+  "bus_factor_status": "Met",
+  "bus_factor_justification": "Multiple maintainers via @MTG-Thomas CODEOWNERS and org-owner backup path are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
+  "contributors_unassociated_status": "Met",
+  "contributors_unassociated_justification": "External contributors are explicitly welcome via PR/issue flow; see https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md and https://github.com/MTG-Thomas/bifrost/blob/main/CONTRIBUTING.md."
 }

--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -195,11 +195,11 @@
   "code_of_conduct_status": "Met",
   "code_of_conduct_justification": "Contributor Covenant 2.1 is published at https://github.com/MTG-Thomas/bifrost/blob/main/CODE_OF_CONDUCT.md with enforcement contacts.",
   "roles_responsibilities_status": "Met",
-  "roles_responsibilities_justification": "Maintainer, contributor, and code-owner roles are defined in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md and https://github.com/MTG-Thomas/bifrost/blob/main/.github/CODEOWNERS.",
+  "roles_responsibilities_justification": "Primary maintainer Thomas Bray and backup maintainers Doug Eckhart and Eric Atlas are named in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md with https://github.com/MTG-Thomas/bifrost/blob/main/.github/CODEOWNERS.",
   "access_continuity_status": "Met",
-  "access_continuity_justification": "Backup maintainers Doug Eckhart and Eric Atlas (@MTG-Thomas org members) and succession steps are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
+  "access_continuity_justification": "Primary maintainer Thomas Bray (@MTG-Thomas) and backup maintainers Doug Eckhart (@MTGDeckhart) and Eric Atlas (@eric-midtowntg-com) are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
   "bus_factor_status": "Met",
-  "bus_factor_justification": "Multiple @MTG-Thomas maintainers with named backups (Doug Eckhart, Eric Atlas) and org-owner paths are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
+  "bus_factor_justification": "Named primary and backup maintainers (Thomas Bray, Doug Eckhart, Eric Atlas) plus org-owner paths are documented in https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md.",
   "contributors_unassociated_status": "Met",
   "contributors_unassociated_justification": "External contributors are explicitly welcome via PR/issue flow; see https://github.com/MTG-Thomas/bifrost/blob/main/GOVERNANCE.md and https://github.com/MTG-Thomas/bifrost/blob/main/CONTRIBUTING.md."
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,10 @@ Do not expose secret values in chat, logs, test fixtures, screenshots, or commit
 ## Useful References
 
 - `CLAUDE.md` — upstream-style platform commands, manifest rules, verification checklist
-- `CONTRIBUTING.md` — human-facing PR expectations
+- `CONTRIBUTING.md` — human-facing PR expectations, DCO, and governance links
+- [GOVERNANCE.md](./GOVERNANCE.md) — maintainer roles, culture, continuity
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) — community standards
+- [docs/security/openssf-best-practices-badge.md](docs/security/openssf-best-practices-badge.md) — BadgeApp tiers and submit flow
 - [Develop at MTG (Windows)](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/develop-at-mtg-windows.md) — team onboarding (Windows-first)
 - [Proxmox shared dev roadmap](https://github.com/MTG-Thomas/bifrost-ops/blob/main/docs/proxmox-shared-dev-roadmap.md) — shared lab + Entra direction
 - `.claude/skills/` — upstream maintainer workflows (release, issues); **ignore for MTG day-to-day**

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+For this project, community spaces include the `MTG-Thomas/bifrost` GitHub
+repository (issues, pull requests, discussions, and reviews), related MTG Bifrost
+repositories when working on coordinated changes, and public channels where
+participants identify themselves as contributing to Bifrost.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement:
+
+- **Preferred:** contact a [repository maintainer](https://github.com/MTG-Thomas/bifrost) through GitHub (issue comment with request for private follow-up, or organization contact as listed on [MTG-Thomas](https://github.com/MTG-Thomas)).
+- **Safety-sensitive reports:** use [GitHub private vulnerability reporting](https://github.com/MTG-Thomas/bifrost/security/advisories/new) when the concern overlaps with security or you need a non-public channel.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of
+actions.
+
+**Consequence:** A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -66,7 +66,8 @@ participants identify themselves as contributing to Bifrost.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement:
 
-- **Preferred:** contact a [repository maintainer](https://github.com/MTG-Thomas/bifrost) through GitHub (issue comment with request for private follow-up, or organization contact as listed on [MTG-Thomas](https://github.com/MTG-Thomas)).
+- **Maintainers:** Doug Eckhart and Eric Atlas (`@MTG-Thomas` org members), and other repository maintainers listed in [GOVERNANCE.md](GOVERNANCE.md).
+- **Preferred:** contact a maintainer through GitHub (issue comment with request for private follow-up, or organization contact as listed on [MTG-Thomas](https://github.com/MTG-Thomas)).
 - **Safety-sensitive reports:** use [GitHub private vulnerability reporting](https://github.com/MTG-Thomas/bifrost/security/advisories/new) when the concern overlaps with security or you need a non-public channel.
 
 All complaints will be reviewed and investigated promptly and fairly.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -66,7 +66,7 @@ participants identify themselves as contributing to Bifrost.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement:
 
-- **Maintainers:** Doug Eckhart and Eric Atlas (`@MTG-Thomas` org members), and other repository maintainers listed in [GOVERNANCE.md](GOVERNANCE.md).
+- **Maintainers:** [Thomas Bray](https://github.com/MTG-Thomas) (primary), [Doug Eckhart](https://github.com/MTGDeckhart), and [Eric Atlas](https://github.com/eric-midtowntg-com). See [GOVERNANCE.md](GOVERNANCE.md) for roles and backup succession.
 - **Preferred:** contact a maintainer through GitHub (issue comment with request for private follow-up, or organization contact as listed on [MTG-Thomas](https://github.com/MTG-Thomas)).
 - **Safety-sensitive reports:** use [GitHub private vulnerability reporting](https://github.com/MTG-Thomas/bifrost/security/advisories/new) when the concern overlaps with security or you need a non-public channel.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,6 +12,19 @@ identity and orientation.
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
 
+## Project culture
+
+In addition to the standards below, MTG Bifrost contributors and maintainers aim
+for a **positive, progress-oriented** environment. We are building software at a
+moment when teams can increasingly **control their own destiny** — owning the
+fork, the roadmap, and the operator outcomes — and we treat that as energizing,
+not merely operational.
+
+We **presume best intent** when someone's motivation is unclear, and we seek
+clarification before assuming bad faith. Maintainers commit to these norms
+explicitly and to **holding one another accountable**; see
+[GOVERNANCE.md](GOVERNANCE.md#culture-and-maintainer-standards).
+
 ## Our Standards
 
 Examples of behavior that contributes to a positive environment for our

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,11 @@ Thanks for contributing. This doc is the friendly front door — it covers the *
 Community and project governance:
 
 - [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
-- [GOVERNANCE.md](./GOVERNANCE.md)
+- [GOVERNANCE.md](./GOVERNANCE.md) — roles, culture, backup maintainers, access continuity
+
+We aim for a positive, progress-oriented culture and presume best intent unless
+evidence says otherwise; maintainers hold one another accountable to that bar
+(see GOVERNANCE.md § Culture and maintainer standards).
 
 ## Developer Certificate of Origin (DCO)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,59 @@
 
 Thanks for contributing. This doc is the friendly front door — it covers the *spirit* of how we work. Tool-neutral agent guidance lives in [`AGENTS.md`](./AGENTS.md), the detailed Bifrost playbook lives in [`CLAUDE.md`](./CLAUDE.md), and Claude-specific workflow skills live under [`.claude/skills/`](./.claude/skills/).
 
+Community and project governance:
+
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- [GOVERNANCE.md](./GOVERNANCE.md)
+
+## Developer Certificate of Origin (DCO)
+
+By contributing to `MTG-Thomas/bifrost`, you certify that your contribution
+complies with the [Developer Certificate of Origin, version 1.1](https://developercertificate.org/):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right
+    to submit it under the open source license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate open source license and I have
+    the right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same open source
+    license (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person who
+    certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are public
+    and that a record of the contribution (including all personal information I
+    submit with it, including my sign-off) is maintained indefinitely and may
+    be redistributed consistent with this project or the open source license(s)
+    involved.
+```
+
+**Sign-off:** append a `Signed-off-by` line to each commit message:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Git can add this automatically: `git commit -s`. Squash merges should retain DCO
+sign-off in the final commit message or PR description when GitHub DCO probot is
+enabled.
+
 ## Before you open a PR
 
 - [ ] Dev stack is running (`./debug.sh`) and your change works end-to-end in the browser at `http://localhost:3000`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ evidence says otherwise; maintainers hold one another accountable to that bar
 By contributing to `MTG-Thomas/bifrost`, you certify that your contribution
 complies with the [Developer Certificate of Origin, version 1.1](https://developercertificate.org/):
 
-```
+```text
 Developer Certificate of Origin
 Version 1.1
 
@@ -51,7 +51,7 @@ By making a contribution to this project, I certify that:
 
 **Sign-off:** append a `Signed-off-by` line to each commit message:
 
-```
+```text
 Signed-off-by: Your Name <your.email@example.com>
 ```
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,8 +30,8 @@ governance here applies to the MTG fork only.
 | Role | Who | Responsibilities |
 |------|-----|------------------|
 | **Organization owners** | GitHub owners of the `MTG-Thomas` org | Org settings, billing, security defaults (2FA, secret scanning), backup org admins |
-| **Repository maintainers** | Members of `@MTG-Thomas` with merge access to this repo | Triage issues/PRs, enforce branch protection, cut semver releases, CoC enforcement |
-| **Backup maintainers** | Doug Eckhart and Eric Atlas (`@MTG-Thomas` org members) | Assume stewardship if the primary maintainer is unavailable; same responsibilities as repository maintainers |
+| **Primary maintainer** | [Thomas Bray](https://github.com/MTG-Thomas) | Day-to-day triage, releases, OpenSSF badge stewardship, CoC enforcement |
+| **Backup maintainers** | [Doug Eckhart](https://github.com/MTGDeckhart), [Eric Atlas](https://github.com/eric-midtowntg-com) | Assume stewardship if the primary maintainer is unavailable; same responsibilities as the primary maintainer |
 | **Code owners** | See [.github/CODEOWNERS](.github/CODEOWNERS) | Required review on changes under owned paths (currently default `@MTG-Thomas`) |
 | **Contributors** | Anyone who opens issues or PRs | Propose changes; follow [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
 | **Automation** | GitHub Actions, Dependabot, Scorecard, CodeQL | CI gates on `main`; no direct merge without passing checks where configured |
@@ -77,15 +77,16 @@ or release credentials.
 
 Current mechanisms:
 
+- **Primary maintainer:** [Thomas Bray](https://github.com/MTG-Thomas).
+- **Named backup maintainers:** [Doug Eckhart](https://github.com/MTGDeckhart) and [Eric Atlas](https://github.com/eric-midtowntg-com) (Midtown org members with merge access).
 - **Multiple org owners** on `MTG-Thomas` (GitHub organization settings).
-- **Named backup maintainers** — Doug Eckhart and Eric Atlas (both `@MTG-Thomas` org members with merge access).
 - **Team-based ownership** via `@MTG-Thomas` in [CODEOWNERS](.github/CODEOWNERS).
 - **Branch protection on `main`** — required reviews and CI before merge.
 - **Documented operator paths** in [bifrost-ops](https://github.com/MTG-Thomas/bifrost-ops) (Windows onboarding, shared dev VM, release runbooks).
 
-If a maintainer leaves or is unavailable:
+If the primary maintainer leaves or is unavailable:
 
-1. **Doug Eckhart** or **Eric Atlas** assumes day-to-day stewardship (issues, PRs, releases) as backup maintainers.
+1. [Doug Eckhart](https://github.com/MTGDeckhart) or [Eric Atlas](https://github.com/eric-midtowntg-com) assumes day-to-day stewardship (issues, PRs, releases).
 2. Remaining org owners reassign BadgeApp project ownership and any org-only credentials through GitHub org admin settings (document owner in internal ops notes; not stored in this repo).
 3. Emergency merges follow the same PR + review rule except where GitHub org policy allows break-glass admin merge with post-incident review.
 
@@ -112,3 +113,4 @@ If a maintainer leaves or is unavailable:
 |------|--------|
 | 2026-05-29 | Initial draft for OpenSSF Silver #290 |
 | 2026-05-29 | Named backup maintainers (Doug Eckhart, Eric Atlas); Jack Musick as informal upstream advisor |
+| 2026-05-29 | Thomas Bray as primary maintainer; GitHub profile links for all maintainers |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,6 +25,33 @@ fork (API, client, workers, CI, and core docs). It is distinct from:
 Upstream lineage is documented in release notes and [VERSIONING.md](docs/VERSIONING.md);
 governance here applies to the MTG fork only.
 
+## Culture and maintainer standards
+
+We aim to run this project with **optimism about what we are building together**.
+Open source and modern tooling mean teams can **control their software destiny** —
+shape the platform, ship fixes, and improve operator life without waiting on a vendor
+roadmap. That is worth being excited about.
+
+By default we:
+
+- **Lead with positivity and progress** — celebrate forward motion, credit good work,
+  and frame feedback as a path to something better.
+- **Presume best intent** — when motivation is unclear, assume people are trying to
+  help until there is explicit evidence to the contrary. Ask clarifying questions
+  before escalating.
+- **Keep disagreement substantive** — challenge ideas and implementation on merit;
+  do not question character without cause.
+
+**Maintainers** model these norms in issues, pull requests, releases, and public
+communication. They also have a **duty to hold one another accountable** to them:
+if a maintainer's tone or behavior falls short of this section or
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), other maintainers address it directly
+(with private feedback first when appropriate), then through the CoC escalation
+paths if needed. The bar for maintainers is higher, not lower.
+
+Contributors are encouraged to adopt the same spirit. Conduct enforcement for
+everyone remains as described in the Code of Conduct.
+
 ## Roles and responsibilities
 
 | Role | Who | Responsibilities |
@@ -114,3 +141,4 @@ If the primary maintainer leaves or is unavailable:
 | 2026-05-29 | Initial draft for OpenSSF Silver #290 |
 | 2026-05-29 | Named backup maintainers (Doug Eckhart, Eric Atlas); Jack Musick as informal upstream advisor |
 | 2026-05-29 | Thomas Bray as primary maintainer; GitHub profile links for all maintainers |
+| 2026-05-29 | Culture section: positivity, progress, best intent, maintainer mutual accountability |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,114 @@
+# Governance — MTG-Thomas/bifrost
+
+**Status:** early draft (OpenSSF Silver / issue #290). Expect revision as MTG
+operator roles and org policy are confirmed.
+
+This document describes how the Midtown Technology Group (MTG) fork of Bifrost
+is maintained, who can make decisions, and how we preserve project continuity.
+
+Related documents:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — day-to-day contributor workflow
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards
+- [SECURITY.md](SECURITY.md) — vulnerability reporting
+- [docs/VERSIONING.md](docs/VERSIONING.md) — MTG semver and releases
+
+## Project scope
+
+`MTG-Thomas/bifrost` is the **platform/runtime** repository for the MTG Bifrost
+fork (API, client, workers, CI, and core docs). It is distinct from:
+
+- `MTG-Thomas/bifrost-workspace` — MSP workspace workflows and integrations
+- `MTG-Thomas/bifrost-infra` — deployment and cloud infrastructure
+- `MTG-Thomas/bifrost-ops` — operator runbooks and team onboarding
+
+Upstream lineage is documented in release notes and [VERSIONING.md](docs/VERSIONING.md);
+governance here applies to the MTG fork only.
+
+## Roles and responsibilities
+
+| Role | Who | Responsibilities |
+|------|-----|------------------|
+| **Organization owners** | GitHub owners of the `MTG-Thomas` org | Org settings, billing, security defaults (2FA, secret scanning), backup org admins |
+| **Repository maintainers** | Members of `@MTG-Thomas` with merge access to this repo | Triage issues/PRs, enforce branch protection, cut semver releases, CoC enforcement |
+| **Code owners** | See [.github/CODEOWNERS](.github/CODEOWNERS) | Required review on changes under owned paths (currently default `@MTG-Thomas`) |
+| **Contributors** | Anyone who opens issues or PRs | Propose changes; follow [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
+| **Automation** | GitHub Actions, Dependabot, Scorecard, CodeQL | CI gates on `main`; no direct merge without passing checks where configured |
+
+Maintainers are expected to:
+
+- Keep `main` protected and release tags auditable (see [bifrost-release skill](.claude/skills/bifrost-release/SKILL.md)).
+- Respond to security reports per [SECURITY.md](SECURITY.md).
+- Prefer issues and PRs for substantive decisions (transparent record).
+
+## Decision process
+
+1. **Track work in GitHub Issues** — if it is not an issue, it is not on the roadmap ([CONTRIBUTING.md](CONTRIBUTING.md)).
+2. **Implement via pull request** — all changes land through PR review; direct pushes to `main` are disallowed by branch protection.
+3. **Review** — at least one approval from a code owner / maintainer; sensitive paths called out in CONTRIBUTING receive extra scrutiny.
+4. **Merge** — squash or merge per repo settings after required CI checks pass.
+5. **Release** — semver tags on `MTG-Thomas/bifrost` only; human release notes for OpenSSF criteria (see release skill).
+
+Larger or contentious changes should use a design note under `docs/superpowers/specs/` or a dedicated issue thread before large diffs.
+
+## Contributions from unassociated contributors
+
+This project **accepts meaningful contributions from people who are not MTG
+employees or org members**. You do not need org membership to:
+
+- Open issues and discuss design
+- Submit pull requests
+- Pick up [`help wanted`](https://github.com/MTG-Thomas/bifrost/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or [`good first issue`](https://github.com/MTG-Thomas/bifrost/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) work
+
+External contributors merge through the same PR review path as maintainers.
+Credit appears in commit history and release notes when applicable.
+
+## Developer Certificate of Origin
+
+Contributions require DCO sign-off per [CONTRIBUTING.md](CONTRIBUTING.md) (Developer
+Certificate of Origin 1.1). Maintainers may reject commits that lack valid
+`Signed-off-by` lines or equivalent GitHub DCO integration when enabled.
+
+## Access continuity and bus factor
+
+**Goal:** no single person is the only holder of merge access, org admin access,
+or release credentials.
+
+Current mechanisms (draft — verify against live GitHub settings):
+
+- **Multiple org owners** on `MTG-Thomas` (GitHub organization settings).
+- **Team-based ownership** via `@MTG-Thomas` in [CODEOWNERS](.github/CODEOWNERS).
+- **Branch protection on `main`** — required reviews and CI before merge.
+- **Documented operator paths** in [bifrost-ops](https://github.com/MTG-Thomas/bifrost-ops) (Windows onboarding, shared dev VM, release runbooks).
+
+If a maintainer leaves or is unavailable:
+
+1. Remaining org owners assign issue/PR stewardship to another maintainer.
+2. Release tags and BadgeApp project ownership are transferred through org admin
+   settings (document owner in internal ops notes; not stored in this repo).
+3. Emergency merges follow the same PR + review rule except where GitHub org
+   policy allows break-glass admin merge with post-incident review.
+
+**Open item for MTG review:** name explicit backup maintainers and the internal
+contact for org-owner succession (edit this section after operator sign-off).
+
+## Security and conduct escalation
+
+- **Vulnerabilities:** [SECURITY.md](SECURITY.md) — private GitHub advisories only.
+- **Code of Conduct:** [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — maintainer contact paths listed there.
+
+## Related automation and evidence
+
+| Concern | Evidence |
+|---------|----------|
+| CI on every PR | [.github/workflows/ci.yml](.github/workflows/ci.yml) |
+| Code review | Branch protection + CODEOWNERS |
+| Dependency updates | [.github/dependabot.yml](.github/dependabot.yml) |
+| OpenSSF badge | [docs/security/openssf-best-practices-badge.md](docs/security/openssf-best-practices-badge.md) |
+| Semver releases | [docs/VERSIONING.md](docs/VERSIONING.md), [v1.0.0 release](https://github.com/MTG-Thomas/bifrost/releases/tag/v1.0.0) |
+
+## Revision history
+
+| Date | Change |
+|------|--------|
+| 2026-05-29 | Initial draft for OpenSSF Silver #290 |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,6 +31,7 @@ governance here applies to the MTG fork only.
 |------|-----|------------------|
 | **Organization owners** | GitHub owners of the `MTG-Thomas` org | Org settings, billing, security defaults (2FA, secret scanning), backup org admins |
 | **Repository maintainers** | Members of `@MTG-Thomas` with merge access to this repo | Triage issues/PRs, enforce branch protection, cut semver releases, CoC enforcement |
+| **Backup maintainers** | Doug Eckhart and Eric Atlas (`@MTG-Thomas` org members) | Assume stewardship if the primary maintainer is unavailable; same responsibilities as repository maintainers |
 | **Code owners** | See [.github/CODEOWNERS](.github/CODEOWNERS) | Required review on changes under owned paths (currently default `@MTG-Thomas`) |
 | **Contributors** | Anyone who opens issues or PRs | Propose changes; follow [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
 | **Automation** | GitHub Actions, Dependabot, Scorecard, CodeQL | CI gates on `main`; no direct merge without passing checks where configured |
@@ -74,23 +75,21 @@ Certificate of Origin 1.1). Maintainers may reject commits that lack valid
 **Goal:** no single person is the only holder of merge access, org admin access,
 or release credentials.
 
-Current mechanisms (draft — verify against live GitHub settings):
+Current mechanisms:
 
 - **Multiple org owners** on `MTG-Thomas` (GitHub organization settings).
+- **Named backup maintainers** — Doug Eckhart and Eric Atlas (both `@MTG-Thomas` org members with merge access).
 - **Team-based ownership** via `@MTG-Thomas` in [CODEOWNERS](.github/CODEOWNERS).
 - **Branch protection on `main`** — required reviews and CI before merge.
 - **Documented operator paths** in [bifrost-ops](https://github.com/MTG-Thomas/bifrost-ops) (Windows onboarding, shared dev VM, release runbooks).
 
 If a maintainer leaves or is unavailable:
 
-1. Remaining org owners assign issue/PR stewardship to another maintainer.
-2. Release tags and BadgeApp project ownership are transferred through org admin
-   settings (document owner in internal ops notes; not stored in this repo).
-3. Emergency merges follow the same PR + review rule except where GitHub org
-   policy allows break-glass admin merge with post-incident review.
+1. **Doug Eckhart** or **Eric Atlas** assumes day-to-day stewardship (issues, PRs, releases) as backup maintainers.
+2. Remaining org owners reassign BadgeApp project ownership and any org-only credentials through GitHub org admin settings (document owner in internal ops notes; not stored in this repo).
+3. Emergency merges follow the same PR + review rule except where GitHub org policy allows break-glass admin merge with post-incident review.
 
-**Open item for MTG review:** name explicit backup maintainers and the internal
-contact for org-owner succession (edit this section after operator sign-off).
+**Informal upstream advisor:** [Jack Musick](https://github.com/jackmusick) (original Bifrost creator) is not an MTG fork maintainer but may assist with architectural or release questions in a pinch.
 
 ## Security and conduct escalation
 
@@ -112,3 +111,4 @@ contact for org-owner succession (edit this section after operator sign-off).
 | Date | Change |
 |------|--------|
 | 2026-05-29 | Initial draft for OpenSSF Silver #290 |
+| 2026-05-29 | Named backup maintainers (Doug Eckhart, Eric Atlas); Jack Musick as informal upstream advisor |

--- a/README.md
+++ b/README.md
@@ -268,7 +268,14 @@ Install cosign: https://docs.sigstore.dev/cosign/system_config/installation/
 
 ## Contributing
 
-This is intended to be a community-driven project built to ensure the Integration Services industry has the tools it needs without vendor lock-in or extractive pricing. However for the time being, while I work out the kinks, contributions and issues will be closed. Stay tuned!
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for workflow,
+testing expectations, and the Developer Certificate of Origin (DCO). See
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [GOVERNANCE.md](GOVERNANCE.md) for
+community and maintainer policy.
+
+- [Open issues](https://github.com/MTG-Thomas/bifrost/issues)
+- [`help wanted`](https://github.com/MTG-Thomas/bifrost/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [`good first issue`](https://github.com/MTG-Thomas/bifrost/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 ## License
 

--- a/docs/security/openssf-best-practices-badge.md
+++ b/docs/security/openssf-best-practices-badge.md
@@ -3,7 +3,50 @@
 Project **13022**: https://www.bestpractices.dev/en/projects/13022
 
 Upstream earned Passing as [project 12665](https://www.bestpractices.dev/en/projects/12665).
-The MTG fork reuses that evidence via `.bestpractices.json` at the repo root.
+The MTG fork maintains its own `.bestpractices.json` at the repo root and tracks
+semver releases from **v1.0.0** ([VERSIONING.md](../VERSIONING.md)).
+
+## Current status
+
+| Tier | Typical progress | Notes |
+|------|------------------|-------|
+| **Passing** | 100% | Met after v1.0.0 tag, release notes, and JSON refresh ([#298](https://github.com/MTG-Thomas/bifrost/pull/298)) |
+| **Baseline tier 1 (OSPS)** | ~65%+ | OSPS answers import on the **baseline-1** form, not Passing or Silver |
+| **Silver** | In progress | Governance/docs/coverage rings ([#286](https://github.com/MTG-Thomas/bifrost/issues/286)–[#293](https://github.com/MTG-Thomas/bifrost/issues/293), [#290](https://github.com/MTG-Thomas/bifrost/issues/290)) |
+
+Badge in README:
+
+```markdown
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13022/badge)](https://www.bestpractices.dev/en/projects/13022)
+```
+
+## BadgeApp forms (separate pages)
+
+BadgeApp does **not** share one form across tiers. After merging `.bestpractices.json`
+to `main`, sign in and run **Save (and continue) 🤖** on each tier you are updating:
+
+| Tier | Edit URL |
+|------|----------|
+| Passing | https://www.bestpractices.dev/en/projects/13022/passing/edit |
+| Baseline tier 1 (OSPS) | https://www.bestpractices.dev/en/projects/13022/baseline-1/edit |
+| Silver | https://www.bestpractices.dev/en/projects/13022/silver/edit |
+
+**Common mistake:** Saving only on Passing or Silver does not apply OSPS baseline
+answers — use **baseline-1** for those fields. Silver metal criteria (governance,
+documentation depth, coverage, signed releases) need matching entries in
+`.bestpractices.json` *and* a Silver form save.
+
+## Regenerate answers
+
+```powershell
+python .\scripts\generate-bestpractices-json.py
+```
+
+Commit the regenerated `.bestpractices.json` to `main` before BadgeApp import.
+
+Governance-related Silver fields are justified from [GOVERNANCE.md](../../GOVERNANCE.md),
+[CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md), and [CONTRIBUTING.md](../../CONTRIBUTING.md)
+(DCO section).
 
 ## Submit answers (pick one path)
 
@@ -11,16 +54,9 @@ The MTG fork reuses that evidence via `.bestpractices.json` at the repo root.
 
 1. Merge `.bestpractices.json` on `main` (must be visible to BadgeApp).
 2. Sign in at [bestpractices.dev](https://www.bestpractices.dev/).
-3. Open the Passing edit page:
-   https://www.bestpractices.dev/en/projects/13022/passing/edit
+3. Open the edit page for the tier you are updating (table above).
 4. Click **Save (and continue) 🤖** so BadgeApp imports the repo file and runs
    its own detectors.
-
-Regenerate the file after repo changes:
-
-```powershell
-python .\scripts\generate-bestpractices-json.py
-```
 
 ### Path B — direct API-style submit
 
@@ -30,23 +66,14 @@ python .\scripts\generate-bestpractices-json.py
 
 ```powershell
 $env:BADGE_COOKIE = '<paste cookie value>'
+$env:BADGE_LEVEL = 'passing'   # or baseline-1, silver
 python .\scripts\submit-openssf-badge.py
 ```
 
-Cookie lifetime is ~48 hours.
+Cookie lifetime is ~48 hours. `BADGE_LEVEL` defaults to `passing`.
 
-## Known gap before 100% Passing
+## Related issues
 
-`MTG-Thomas/bifrost` has **no semver git tags or GitHub Releases yet**. Several
-Passing criteria (`version_tags`, `version_unique`, `release_notes`,
-`release_notes_vulns`) need at least one tagged release with notes. The release
-workflow and `bifrost-release` skill are ready; cut the first fork tag, then
-re-run generation/submission.
-
-## After Passing
-
-Add to `README.md`:
-
-```markdown
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13022/badge)](https://www.bestpractices.dev/en/projects/13022)
-```
+- [#289](https://github.com/MTG-Thomas/bifrost/issues/289) — Passing badge (closed)
+- [#290](https://github.com/MTG-Thomas/bifrost/issues/290) — governance, CoC, DCO for Silver
+- [#294](https://github.com/MTG-Thomas/bifrost/pull/294) — MTG semver / v1.0.0 line

--- a/scripts/generate-bestpractices-json.py
+++ b/scripts/generate-bestpractices-json.py
@@ -173,16 +173,18 @@ def main() -> None:
             f"{BASE}/blob/main/CODE_OF_CONDUCT.md with enforcement contacts."
         ),
         "roles_responsibilities_justification": (
-            f"Maintainer, contributor, and code-owner roles are defined in "
-            f"{BASE}/blob/main/GOVERNANCE.md and {BASE}/blob/main/.github/CODEOWNERS."
+            f"Primary maintainer Thomas Bray and backup maintainers Doug Eckhart and "
+            f"Eric Atlas are named in {BASE}/blob/main/GOVERNANCE.md with "
+            f"{BASE}/blob/main/.github/CODEOWNERS."
         ),
         "access_continuity_justification": (
-            f"Backup maintainers Doug Eckhart and Eric Atlas (@MTG-Thomas org members) "
-            f"and succession steps are documented in {BASE}/blob/main/GOVERNANCE.md."
+            f"Primary maintainer Thomas Bray (@MTG-Thomas) and backup maintainers "
+            f"Doug Eckhart (@MTGDeckhart) and Eric Atlas (@eric-midtowntg-com) "
+            f"are documented in {BASE}/blob/main/GOVERNANCE.md."
         ),
         "bus_factor_justification": (
-            f"Multiple @MTG-Thomas maintainers with named backups (Doug Eckhart, Eric Atlas) "
-            f"and org-owner paths are documented in {BASE}/blob/main/GOVERNANCE.md."
+            f"Named primary and backup maintainers (Thomas Bray, Doug Eckhart, Eric Atlas) "
+            f"plus org-owner paths are documented in {BASE}/blob/main/GOVERNANCE.md."
         ),
         "contributors_unassociated_justification": (
             f"External contributors are explicitly welcome via PR/issue flow; see "

--- a/scripts/generate-bestpractices-json.py
+++ b/scripts/generate-bestpractices-json.py
@@ -177,12 +177,12 @@ def main() -> None:
             f"{BASE}/blob/main/GOVERNANCE.md and {BASE}/blob/main/.github/CODEOWNERS."
         ),
         "access_continuity_justification": (
-            f"Access continuity and succession expectations are documented in "
-            f"{BASE}/blob/main/GOVERNANCE.md (org owners, CODEOWNERS, branch protection)."
+            f"Backup maintainers Doug Eckhart and Eric Atlas (@MTG-Thomas org members) "
+            f"and succession steps are documented in {BASE}/blob/main/GOVERNANCE.md."
         ),
         "bus_factor_justification": (
-            f"Multiple maintainers via @MTG-Thomas CODEOWNERS and org-owner backup "
-            f"path are documented in {BASE}/blob/main/GOVERNANCE.md."
+            f"Multiple @MTG-Thomas maintainers with named backups (Doug Eckhart, Eric Atlas) "
+            f"and org-owner paths are documented in {BASE}/blob/main/GOVERNANCE.md."
         ),
         "contributors_unassociated_justification": (
             f"External contributors are explicitly welcome via PR/issue flow; see "

--- a/scripts/generate-bestpractices-json.py
+++ b/scripts/generate-bestpractices-json.py
@@ -160,6 +160,34 @@ def main() -> None:
             f"CodeQL runs on every push to main, every PR, and weekly cron "
             f"({BASE}/blob/main/.github/workflows/codeql.yml)."
         ),
+        "dco_justification": (
+            f"Developer Certificate of Origin 1.1 and Signed-off-by requirements "
+            f"are documented in {BASE}/blob/main/CONTRIBUTING.md."
+        ),
+        "governance_justification": (
+            f"MTG fork governance (roles, decisions, continuity) is documented in "
+            f"{BASE}/blob/main/GOVERNANCE.md."
+        ),
+        "code_of_conduct_justification": (
+            f"Contributor Covenant 2.1 is published at "
+            f"{BASE}/blob/main/CODE_OF_CONDUCT.md with enforcement contacts."
+        ),
+        "roles_responsibilities_justification": (
+            f"Maintainer, contributor, and code-owner roles are defined in "
+            f"{BASE}/blob/main/GOVERNANCE.md and {BASE}/blob/main/.github/CODEOWNERS."
+        ),
+        "access_continuity_justification": (
+            f"Access continuity and succession expectations are documented in "
+            f"{BASE}/blob/main/GOVERNANCE.md (org owners, CODEOWNERS, branch protection)."
+        ),
+        "bus_factor_justification": (
+            f"Multiple maintainers via @MTG-Thomas CODEOWNERS and org-owner backup "
+            f"path are documented in {BASE}/blob/main/GOVERNANCE.md."
+        ),
+        "contributors_unassociated_justification": (
+            f"External contributors are explicitly welcome via PR/issue flow; see "
+            f"{BASE}/blob/main/GOVERNANCE.md and {BASE}/blob/main/CONTRIBUTING.md."
+        ),
     }
 
     release_pending_statuses: set[str] = set()

--- a/scripts/submit-openssf-badge.py
+++ b/scripts/submit-openssf-badge.py
@@ -15,7 +15,8 @@ from pathlib import Path
 COOKIE_NAME = "_BadgeApp_session"
 BASE_URL = "https://www.bestpractices.dev"
 PROJECT_ID = 13022
-LEVEL = "passing"
+LEVEL = os.environ.get("BADGE_LEVEL", "passing").strip().lower() or "passing"
+VALID_LEVELS = frozenset({"passing", "baseline-1", "silver"})
 HTTP_TIMEOUT_SECONDS = 20
 REDIRECT_CODES = {301, 302, 303, 307, 308}
 ROOT = Path(__file__).resolve().parents[1]
@@ -150,6 +151,13 @@ def submit(
 
 
 def main() -> int:
+    if LEVEL not in VALID_LEVELS:
+        print(
+            f"BADGE_LEVEL must be one of: {', '.join(sorted(VALID_LEVELS))}",
+            file=sys.stderr,
+        )
+        return 1
+
     cookie = os.environ.get("BADGE_COOKIE", "").strip()
     if not cookie:
         print(
@@ -157,6 +165,7 @@ def main() -> int:
             "Chrome: DevTools → Application → Cookies → www.bestpractices.dev\n"
             "Alternative: merge .bestpractices.json to main, open\n"
             f"{BASE_URL}/en/projects/{PROJECT_ID}/{LEVEL}/edit\n"
+            f"(BADGE_LEVEL: passing | baseline-1 | silver)\n"
             "and click Save (and continue) 🤖",
             file=sys.stderr,
         )

--- a/scripts/submit-openssf-badge.py
+++ b/scripts/submit-openssf-badge.py
@@ -17,6 +17,7 @@ BASE_URL = "https://www.bestpractices.dev"
 PROJECT_ID = 13022
 LEVEL = os.environ.get("BADGE_LEVEL", "passing").strip().lower() or "passing"
 VALID_LEVELS = frozenset({"passing", "baseline-1", "silver"})
+VALID_LEVELS_HELP = ", ".join(sorted(VALID_LEVELS))
 HTTP_TIMEOUT_SECONDS = 20
 REDIRECT_CODES = {301, 302, 303, 307, 308}
 ROOT = Path(__file__).resolve().parents[1]
@@ -153,7 +154,7 @@ def submit(
 def main() -> int:
     if LEVEL not in VALID_LEVELS:
         print(
-            f"BADGE_LEVEL must be one of: {', '.join(sorted(VALID_LEVELS))}",
+            f"BADGE_LEVEL must be one of: {VALID_LEVELS_HELP}",
             file=sys.stderr,
         )
         return 1
@@ -165,7 +166,7 @@ def main() -> int:
             "Chrome: DevTools → Application → Cookies → www.bestpractices.dev\n"
             "Alternative: merge .bestpractices.json to main, open\n"
             f"{BASE_URL}/en/projects/{PROJECT_ID}/{LEVEL}/edit\n"
-            f"(BADGE_LEVEL: passing | baseline-1 | silver)\n"
+            f"(BADGE_LEVEL: {VALID_LEVELS_HELP})\n"
             "and click Save (and continue) 🤖",
             file=sys.stderr,
         )


### PR DESCRIPTION
## Summary

- Add \CODE_OF_CONDUCT.md\ (Contributor Covenant 2.1) and \GOVERNANCE.md\ (maintainer roles, culture, backup succession, unassociated contributors).
- Extend \CONTRIBUTING.md\ with DCO 1.1 / Signed-off-by; fix README contributing stance.
- Regenerate \.bestpractices.json\ Silver justifications (governance, CoC, DCO, bus factor, access continuity).
- Refresh OpenSSF badge runbook for v1.0.0 and separate BadgeApp forms (passing / baseline-1 / silver); \BADGE_LEVEL\ on submit script.

**Maintainers:** Thomas Bray (primary), Doug Eckhart (@MTGDeckhart), Eric Atlas (@eric-midtowntg-com) backups; Jack Musick informal upstream advisor.

## Test plan

- [ ] Review GOVERNANCE culture section and maintainer names
- [ ] After merge: BadgeApp Save on https://www.bestpractices.dev/en/projects/13022/silver/edit
- [ ] Optionally re-save baseline-1 if Silver JSON fields affect OSPS overlap

Closes #290

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and badge-metadata only; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds **OpenSSF Silver–oriented community governance** for the MTG fork: new **Contributor Covenant 2.1** (`CODE_OF_CONDUCT.md`) with MTG-specific culture and named maintainer enforcement contacts, and **`GOVERNANCE.md`** covering roles (primary/backup maintainers), decision flow, external contributors, DCO, and bus-factor/continuity.
> 
> **`CONTRIBUTING.md`** now links CoC/governance and documents **DCO 1.1** with `Signed-off-by` / `git commit -s`. **`README.md`** replaces the “contributions closed” message with links to contributing, issues, and help-wanted labels.
> 
> **Badge tooling/docs:** `.bestpractices.json` and `generate-bestpractices-json.py` gain **Met** justifications for Silver fields (governance, CoC, DCO, roles, access continuity, bus factor, unassociated contributors). The OpenSSF runbook is updated for **v1.0.0**, separate BadgeApp forms (passing / baseline-1 / silver), and **`BADGE_LEVEL`** on `submit-openssf-badge.py`. **`AGENTS.md`** points agents at the new docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5d1ae10b42fc030b6295d76a71be92ead8e8dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct defining community standards and enforcement procedures.
  * Introduced comprehensive Governance documentation outlining project roles, decision-making processes, and access continuity.
  * Expanded Contributing guidelines with Developer Certificate of Origin (DCO) requirements and sign-off instructions.
  * Updated README with clearer contribution workflow and governance links.
  * Enhanced OpenSSF Best Practices Badge documentation with submission guidance.

* **Chores**
  * Updated tooling to support governance-related metadata and configurable badge levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->