### PR TITLE
docs: BadgeApp automation proposal URLs (Path C)

### DIFF
--- a/docs/security/openssf-best-practices-badge.md
+++ b/docs/security/openssf-best-practices-badge.md
@@ -72,6 +72,51 @@ python .\scripts\submit-openssf-badge.py
 
 Cookie lifetime is ~48 hours. `BADGE_LEVEL` defaults to `passing`.
 
+### Path C — automation proposal URLs (review in browser)
+
+BadgeApp can pre-fill the edit form from **query parameters** on the project
+edit URL. You stay in the loop: proposals are highlighted; you review and
+click **Save** to persist. No cookie script required.
+
+Official spec: [automation-proposals.md](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/automation-proposals.md)
+
+**Baseline (OSPS) example** — section chooser, then pick baseline-1:
+
+```text
+https://www.bestpractices.dev/en/projects/13022/choose/edit?
+  osps_ac_01_01_status=Met&
+  osps_ac_01_01_justification=GitHub+org+enforces+2FA
+```
+
+**Direct section** (skip chooser):
+
+```text
+https://www.bestpractices.dev/en/projects/13022/baseline-1/edit?osps_ac_01_01_status=Met&...
+https://www.bestpractices.dev/en/projects/13022/silver/edit?governance_status=Met&...
+```
+
+Field names: criterion lowercased, `-` → `_`, plus `_status` / `_justification`.
+Status values: `?`, `Unmet`, `N/A`, `Met`.
+
+Proposals only fill **blank/unknown** fields unless you add `overrides=` globs
+(for example `overrides=osps_ac_*,governance_*`).
+
+Generate URLs from repo JSON:
+
+```powershell
+python .\scripts\generate-badge-proposal-url.py --section silver --from-json --prefix governance_ --prefix dco_ --prefix code_of_conduct_
+python .\scripts\generate-badge-proposal-url.py --section baseline-1 --field osps_ac_01_01_status=Met --field "osps_ac_01_01_justification=GitHub org enforces 2FA"
+```
+
+### Path D — read-only JSON API (verify scores, not submit)
+
+```powershell
+(Invoke-WebRequest "https://www.bestpractices.dev/projects/13022.json" -UseBasicParsing).Content
+```
+
+Public project JSON shows tier percentages; authenticated REST PUT exists but
+BadgeApp discourages blind writes — prefer Path A/C so humans review in the UI.
+
 ## Related issues
 
 - [#289](https://github.com/MTG-Thomas/bifrost/issues/289) — Passing badge (closed)

--- a/scripts/generate-badge-proposal-url.py
+++ b/scripts/generate-badge-proposal-url.py
@@ -51,7 +51,7 @@ def fields_from_json(data: dict[str, str]) -> dict[str, str]:
     for key, value in data.items():
         if key.endswith("_status") and value in {"Met", "N/A"}:
             out[key] = value
-            justification_key = key.replace("_status", "_justification")
+            justification_key = key.removesuffix("_status") + "_justification"
             justification = data.get(justification_key)
             if justification:
                 out[justification_key] = justification

--- a/scripts/generate-badge-proposal-url.py
+++ b/scripts/generate-badge-proposal-url.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Build OpenSSF BadgeApp automation-proposal URLs from .bestpractices.json.
+
+Official docs:
+https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/automation-proposals.md
+
+Example (baseline OSPS, section chooser):
+  python scripts/generate-badge-proposal-url.py --section choose \\
+    --fields osps_ac_01_01_status,osps_ac_01_01_justification \\
+    --values Met,"GitHub org enforces 2FA"
+
+Example (all Met/N/A fields from repo JSON for Silver):
+  python scripts/generate-badge-proposal-url.py --section silver --from-json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+
+BASE_URL = "https://www.bestpractices.dev"
+PROJECT_ID = 13022
+LOCALE = "en"
+ROOT = Path(__file__).resolve().parents[1]
+DATA_FILE = ROOT / ".bestpractices.json"
+
+VALID_SECTIONS = frozenset(
+    {"choose", "passing", "silver", "gold", "baseline-1", "baseline-2", "baseline-3"}
+)
+
+
+def parse_field_values(pairs: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"Expected KEY=VALUE, got {pair!r}")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"Empty key in {pair!r}")
+        out[key] = value
+    return out
+
+
+def fields_from_json(data: dict[str, str]) -> dict[str, str]:
+    """Include status/justification pairs where status is Met or N/A."""
+    out: dict[str, str] = {}
+    for key, value in data.items():
+        if key.endswith("_status") and value in {"Met", "N/A"}:
+            out[key] = value
+            justification_key = key.replace("_status", "_justification")
+            justification = data.get(justification_key)
+            if justification:
+                out[justification_key] = justification
+    return out
+
+
+def build_url(
+    section: str,
+    params: dict[str, str],
+    *,
+    overrides: str | None = None,
+) -> str:
+    if section not in VALID_SECTIONS:
+        raise ValueError(f"section must be one of: {', '.join(sorted(VALID_SECTIONS))}")
+    query: dict[str, str] = dict(params)
+    if overrides:
+        query["overrides"] = overrides
+    query_string = urllib.parse.urlencode(query, quote_via=urllib.parse.quote)
+    return f"{BASE_URL}/{LOCALE}/projects/{PROJECT_ID}/{section}/edit?{query_string}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate BadgeApp automation-proposal edit URLs."
+    )
+    parser.add_argument(
+        "--section",
+        default="choose",
+        help="Badge form section (choose, passing, silver, baseline-1, ...)",
+    )
+    parser.add_argument(
+        "--from-json",
+        action="store_true",
+        help=f"Load Met/N/A fields from {DATA_FILE.name}",
+    )
+    parser.add_argument(
+        "--field",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Proposal field (repeatable). Example: osps_ac_01_01_status=Met",
+    )
+    parser.add_argument(
+        "--overrides",
+        help="Comma-separated globs to force proposals (e.g. osps_ac_*,governance_*)",
+    )
+    parser.add_argument(
+        "--prefix",
+        action="append",
+        default=[],
+        metavar="PREFIX",
+        help="With --from-json, only include keys starting with PREFIX (repeatable)",
+    )
+    args = parser.parse_args()
+
+    params: dict[str, str] = {}
+    if args.from_json:
+        if not DATA_FILE.exists():
+            print(f"Missing {DATA_FILE}. Run generate-bestpractices-json.py first.", file=sys.stderr)
+            return 1
+        data = json.loads(DATA_FILE.read_text(encoding="utf-8"))
+        params = fields_from_json(data)
+        if args.prefix:
+            prefixes = tuple(args.prefix)
+            params = {k: v for k, v in params.items() if k.startswith(prefixes)}
+    params.update(parse_field_values(args.field))
+
+    if not params:
+        print("No proposal fields. Use --from-json and/or --field KEY=VALUE.", file=sys.stderr)
+        return 1
+
+    url = build_url(args.section, params, overrides=args.overrides)
+    print(url)
+    print(
+        f"\nOpen while signed in to BadgeApp. Review highlighted proposals, then Save.",
+        file=sys.stderr,
+    )
+    print(
+        f"Fields: {len(params)} | Section: {args.section} | Project: {PROJECT_ID}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Document official automation-proposals URL flow (query params on /projects/13022/{section}/edit).
- Add \scripts/generate-badge-proposal-url.py\ to build review URLs from \.bestpractices.json\ or explicit \osps_ac_*\ fields.

## Test plan
- [ ] \python scripts/generate-badge-proposal-url.py --section silver --from-json --prefix governance_\
- [ ] Open URL signed in; confirm highlighted proposals; Save

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a local helper script only; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds **Path C** (BadgeApp automation-proposal edit URLs via query params, human review then Save) and **Path D** (read-only `projects/13022.json` verification) to `docs/security/openssf-best-practices-badge.md`, including field naming, status values, `overrides=` globs, and PowerShell examples.
> 
> Introduces `scripts/generate-badge-proposal-url.py` to build those URLs from `.bestpractices.json` (Met/N/A status + justifications, optional `--prefix` filters) and/or explicit `--field KEY=VALUE` pairs, with `--section` and optional `--overrides`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8509738ddcf44434ff259c008aee50cf49d92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for two new OpenSSF Best Practices Badge submission methods: automation-proposal URLs and JSON API approach.

* **New Features**
  * Added a command-line tool to automatically generate BadgeApp submission URLs from project JSON files, with custom field and override support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MTG-Thomas/bifrost/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->