### PR TITLE
Detect MCP OAuth client on callback screen

### DIFF
--- a/api/src/services/mcp_server/auth.py
+++ b/api/src/services/mcp_server/auth.py
@@ -255,6 +255,7 @@ class BifrostAuthProvider:
 
         oauth_data = {
             "client_id": client_id,
+            "client_name": client_data.get("client_name"),
             "redirect_uri": redirect_uri,
             "state": state,
             "code_challenge": code_challenge,
@@ -368,7 +369,18 @@ class BifrostAuthProvider:
         # This is needed because Vite's proxy only works for XHR, not browser navigations
         accept = request.headers.get("accept", "")
         if "application/json" in accept:
-            return JSONResponse({"redirect_url": redirect_url})
+            from src.services.mcp_server.mcp_client_identity import resolve_mcp_client_label
+
+            client_label = resolve_mcp_client_label(
+                oauth_data["redirect_uri"],
+                oauth_data.get("client_name"),
+            )
+            return JSONResponse(
+                {
+                    "redirect_url": redirect_url,
+                    "mcp_client": {"label": client_label},
+                }
+            )
 
         return RedirectResponse(url=redirect_url, status_code=302)
 

--- a/api/src/services/mcp_server/mcp_client_identity.py
+++ b/api/src/services/mcp_server/mcp_client_identity.py
@@ -1,0 +1,72 @@
+"""Resolve a display label for the MCP OAuth callback screen."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+_CLIENT_NAME_LABELS = {
+    "claude": "Claude",
+    "claude code": "Claude Code",
+    "claude desktop": "Claude Desktop",
+    "codex": "Codex",
+    "cursor": "Cursor",
+    "gemini": "Gemini CLI",
+    "gemini cli": "Gemini CLI",
+    "github copilot": "GitHub Copilot",
+    "openai codex": "Codex",
+    "visual studio code": "VS Code",
+    "vscode": "VS Code",
+    "windsurf": "Windsurf",
+}
+
+_SCHEME_LABELS = {
+    "claude": "Claude Desktop",
+    "cursor": "Cursor",
+    "vscode": "VS Code",
+}
+
+_HOST_LABELS = {
+    "claude.ai": "Claude",
+    "claude.com": "Claude",
+    "cursor.com": "Cursor",
+    "vscode.dev": "VS Code",
+}
+
+
+def _normalize_client_name(client_name: object) -> str:
+    if not isinstance(client_name, str):
+        return ""
+    normalized = client_name.strip().casefold().replace("-", " ").replace("_", " ")
+    return " ".join(normalized.split())
+
+
+def _host_label(host: str) -> str | None:
+    for domain, label in _HOST_LABELS.items():
+        if host == domain or host.endswith(f".{domain}"):
+            return label
+    return None
+
+
+def _redirect_label(redirect_uri: object) -> str | None:
+    if not isinstance(redirect_uri, str):
+        return None
+
+    try:
+        parsed = urlparse(redirect_uri.strip())
+        host = (parsed.hostname or "").casefold()
+    except ValueError:
+        return None
+
+    return _SCHEME_LABELS.get(parsed.scheme.casefold()) or _host_label(host)
+
+
+def resolve_mcp_client_label(redirect_uri: object, client_name: object = None) -> str:
+    """Return a known client label without reflecting untrusted DCR metadata."""
+    redirect_label = _redirect_label(redirect_uri)
+    if redirect_label:
+        return redirect_label
+
+    return _CLIENT_NAME_LABELS.get(
+        _normalize_client_name(client_name),
+        "your MCP client",
+    )

--- a/api/tests/unit/services/test_mcp_client_identity.py
+++ b/api/tests/unit/services/test_mcp_client_identity.py
@@ -1,0 +1,35 @@
+"""Tests for MCP OAuth client display labels."""
+
+import pytest
+
+from src.services.mcp_server.mcp_client_identity import resolve_mcp_client_label
+
+
+@pytest.mark.parametrize(
+    ("redirect_uri", "client_name", "expected"),
+    [
+        ("cursor://anysphere.cursor-mcp/oauth/callback", None, "Cursor"),
+        ("https://agents.cursor.com/oauth/callback", None, "Cursor"),
+        ("https://claude.ai/api/mcp/auth_callback", None, "Claude"),
+        ("claude://oauth/callback", None, "Claude Desktop"),
+        ("http://127.0.0.1:1455/auth/callback", "codex", "Codex"),
+        ("http://localhost:8080/callback", "Claude-Code", "Claude Code"),
+        ("http://localhost:8080/callback", "Gemini_CLI", "Gemini CLI"),
+        ("http://localhost:8080/callback", "Windsurf", "Windsurf"),
+    ],
+)
+def test_resolves_known_clients(redirect_uri, client_name, expected):
+    assert resolve_mcp_client_label(redirect_uri, client_name) == expected
+
+
+@pytest.mark.parametrize(
+    ("redirect_uri", "client_name"),
+    [
+        ("http://localhost:8080/callback", "Acme Internal Agent"),
+        ("https://evil.example/cursor.com/callback", "Not Cursor"),
+        ("https://[invalid/callback", "Cursor Support Portal"),
+        (None, {"name": "Cursor"}),
+    ],
+)
+def test_unknown_or_malformed_metadata_uses_generic_label(redirect_uri, client_name):
+    assert resolve_mcp_client_label(redirect_uri, client_name) == "your MCP client"

--- a/client/src/pages/MCPCallback.test.tsx
+++ b/client/src/pages/MCPCallback.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+import { MCPCallback } from "./MCPCallback";
+
+describe("MCPCallback", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("shows the detected client after a successful callback", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					redirect_url: "cursor://callback?code=code-1",
+					mcp_client: { label: "Cursor" },
+				}),
+			}),
+		);
+
+		renderWithProviders(<MCPCallback />, {
+			initialEntries: ["/mcp/callback?internal_state=state-1"],
+		});
+
+		expect(await screen.findByText("Authorization Complete")).toBeVisible();
+		expect(
+			screen.getByText("You can close this tab and return to Cursor."),
+		).toBeVisible();
+	});
+
+	it("uses generic copy when callback metadata is malformed", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					redirect_url: "https://client.example/callback?code=code-1",
+					mcp_client: { label: { untrusted: true } },
+				}),
+			}),
+		);
+
+		renderWithProviders(<MCPCallback />, {
+			initialEntries: ["/mcp/callback?internal_state=state-1"],
+		});
+
+		expect(
+			await screen.findByText(
+				"You can close this tab and return to your MCP client.",
+			),
+		).toBeVisible();
+	});
+});

--- a/client/src/pages/MCPCallback.tsx
+++ b/client/src/pages/MCPCallback.tsx
@@ -9,8 +9,8 @@
  * 2. User is redirected to Bifrost login
  * 3. After login, browser navigates to /mcp/callback with internal_state
  * 4. This component fetches /mcp/callback via XHR (works with Vite proxy)
- * 5. Server returns redirect_url in JSON response (claude:// protocol URL)
- * 6. Component opens the URL (triggers Claude Desktop) and closes the tab
+ * 5. Server returns redirect_url plus a presentation-only MCP client label
+ * 6. Component opens the URL and tells the user which client to return to
  */
 
 import { useEffect, useState, useRef } from "react";
@@ -19,10 +19,15 @@ import { Loader2, AlertCircle, CheckCircle2 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 
+type McpClientInfo = {
+	label: string;
+};
+
 export function MCPCallback() {
 	const [searchParams] = useSearchParams();
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState(false);
+	const [mcpClient, setMcpClient] = useState<McpClientInfo | null>(null);
 	const hasHandledRef = useRef(false);
 
 	useEffect(() => {
@@ -63,13 +68,20 @@ export function MCPCallback() {
 
 				const data = await response.json();
 
+				if (
+					data.mcp_client &&
+					typeof data.mcp_client === "object" &&
+					typeof data.mcp_client.label === "string"
+				) {
+					setMcpClient({ label: data.mcp_client.label });
+				}
+
 				if (data.redirect_url) {
 					// Show success state first
 					setSuccess(true);
 
-					// Use location.replace to redirect to the protocol URL (e.g., claude://)
-					// This triggers the desktop app and doesn't trigger popup blockers
-					// The page will show the success message while the protocol handler takes over
+					// Custom-scheme callbacks (cursor://, claude://) hand off to the host app.
+					// HTTPS callbacks (claude.ai, cursor.com) still navigate so the host can finish.
 					setTimeout(() => {
 						window.location.replace(data.redirect_url);
 					}, 100);
@@ -116,7 +128,8 @@ export function MCPCallback() {
 						Authorization Complete
 					</h2>
 					<p className="text-muted-foreground">
-						You can close this tab and return to Claude Desktop.
+						You can close this tab and return to{" "}
+						{mcpClient?.label ?? "your MCP client"}.
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

- Replace the callback page's hardcoded Claude Desktop message with a label for the registered MCP client.
- Recognize known clients only through exact normalized aliases or trusted callback hosts and schemes.
- Use generic copy for unknown or malformed DCR metadata instead of reflecting arbitrary client names.
- Add backend resolver coverage and a focused React callback test.

## Security boundary

This is presentation-only OAuth callback metadata. The PR does not change PKCE, authorization-code exchange, access-token minting, refresh-token handling, or tool authorization. Final merge is sequenced after #410 so MCP token-scoping claims are present in the base and verified unchanged.

## Delivery lane

Lane 3: OAuth path, isolated worktree, narrow tests plus strict current-head CI and fresh-head review.

## Verification

- [x] `npm test -- MCPCallback.test.tsx`
- [x] `npx eslint src/pages/MCPCallback.tsx src/pages/MCPCallback.test.tsx`
- [x] `npm run tsc`
- [ ] Final current-head GitHub Actions after #410 merges into `main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OAuth token issuance, PKCE, and redirects are unchanged; only callback JSON and UI copy are affected, with labels constrained to avoid reflecting untrusted client names.
> 
> **Overview**
> The MCP OAuth **callback success screen** no longer hardcodes “Claude Desktop.” It now tells users which client to return to, using **server-resolved, presentation-only** labels.
> 
> **Backend:** OAuth state now carries `client_name` from DCR. When the React page calls `/mcp/callback` with `Accept: application/json`, the response adds `mcp_client.label` from a new `resolve_mcp_client_label` helper. Labels come only from **trusted redirect URI schemes/hosts** (e.g. `cursor://`, `claude.ai`) or **exact normalized aliases** for known clients; unknown or spoofed DCR names fall back to **“your MCP client”** instead of echoing arbitrary metadata.
> 
> **Frontend:** `MCPCallback` reads `mcp_client.label` only when it is a string, then shows “return to {label}” before the existing redirect handoff.
> 
> Unit tests cover the resolver; Vitest covers the callback UI for a known client and malformed label metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5f7757a7041a64a39faa4777ae866ce2106553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->