### PR TITLE
[codex] Document pve-t340 test VM guidance

### DIFF
--- a/.claude/skills/bifrost-testing/SKILL.md
+++ b/.claude/skills/bifrost-testing/SKILL.md
@@ -17,6 +17,10 @@ Workflow for running and writing tests in Bifrost. Covers: stack lifecycle, whic
 
 4. **No silencing.** If a test is noisy, fix the source or delete the test. Don't filter output, don't swallow the failure.
 
+5. **Use the dedicated pve-t340 test VMs for VM-backed validation.** If a task calls for remote VM testing, hardware-backed validation, long-running suites away from the workstation, or says "test it on the VM", the target is the dedicated Bifrost test VM pool on the Dell T340 Proxmox host `pve-t340.netbird.cloud`. Do not use the legacy laptop Proxmox host named `pve` or its VM unless the user explicitly names that legacy target.
+
+6. **Keeper is the source for pve-t340 access.** SSH key material and Proxmox credentials for `pve-t340` live in Keeper. Retrieve them at runtime, keep them out of the repo and logs, and treat Keeper or `pve-t340.netbird.cloud` being unavailable as a blocker. Never silently substitute another VM.
+
 ## Test Authoring Rules (Definition of Done for New Work)
 
 ### React components → sibling `*.test.tsx`
@@ -74,6 +78,8 @@ Run the broader suite to catch regressions outside your targeted area:
 - UI change → `./test.sh client unit && ./test.sh client e2e`
 
 Verify the authoring rules above are satisfied for any new code.
+
+If VM-backed validation was requested or is warranted by the change, run it on the dedicated Bifrost test VMs hosted by `pve-t340.netbird.cloud`. In the final report, name the host, VM name/id if known, repo path, and exact commands run. If you cannot reach Keeper or `pve-t340`, say so and stop; do not fall back to the laptop `pve` host.
 
 ### 4. UX review (conditional, conversation-driven)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,11 @@ Release claims after meaningful work. Skip entirely if the operator does not use
 ## Testing And Verification (Persona B)
 
 - Primary bar: `./test.sh` on the **shared Linux dev environment** or **GitHub Actions** on `MTG-Thomas/bifrost`.
+- Dedicated VM target: when a task needs a remote test VM, hardware-backed validation, long-running suites off the workstation, or says "test it on the VM", use the dedicated Bifrost test VMs hosted on the Dell T340 Proxmox host `pve-t340.netbird.cloud`.
+- Do **not** fall back to the legacy laptop Proxmox host named `pve` or its VM unless the user explicitly asks for that legacy target.
+- SSH key material and Proxmox access details for `pve-t340` live in Keeper. Retrieve them at the time of use; never copy secrets into this repo, docs, shell history snippets, or coordination notes.
+- If Keeper or `pve-t340.netbird.cloud` is unavailable, report that blocker instead of silently testing somewhere else.
+- When reporting VM-backed test results, include the actual target (`pve-t340.netbird.cloud`, VM name/id if known, and repo/worktree path) so accidental legacy-VM testing is visible.
 - Do not treat a Windows laptop without the stack as the platform verification environment.
 
 Match verification to the change (see `CLAUDE.md` for detail):


### PR DESCRIPTION
## Summary
- Add explicit guidance that VM-backed Bifrost validation must use the dedicated test VMs on `pve-t340.netbird.cloud`.
- Document Keeper as the source for SSH/Proxmox access and require agents to report blockers instead of silently falling back.
- Require final test reports to name the VM target used, making accidental legacy laptop `pve` testing visible.

## Validation
- Docs-only change; reviewed the diff and confirmed only `AGENTS.md` and `.claude/skills/bifrost-testing/SKILL.md` changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent/testing guides; no application, auth, or infrastructure code changes.
> 
> **Overview**
> This PR **documents** where VM-backed Bifrost validation must run and how agents should behave when access fails.
> 
> **`AGENTS.md`** (Persona B testing) now states that remote/hardware/long-running “test on the VM” work must use the dedicated test VMs on **`pve-t340.netbird.cloud`**, not the legacy laptop host **`pve`** unless the user explicitly asks. It adds **Keeper** as the runtime source for SSH/Proxmox credentials (no secrets in repo/docs), requires reporting blockers instead of silently using another host, and requires VM test reports to name host, VM id/name, and worktree path.
> 
> **`.claude/skills/bifrost-testing/SKILL.md`** mirrors that policy as new hard rules (#5–#6) and extends the “before declaring done” step with the same VM target, reporting fields, and stop-on-Keeper/`pve-t340` unavailability (no fallback to laptop `pve`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c4e006da66e00ab54876a16d2a43940412510d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing procedures for dedicated VM-backed validation, including access workflows, test result reporting requirements, and guidance for infrastructure unavailability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->