### PR TITLE
Fix SDK mapping default secret disclosure

### DIFF
--- a/api/shared/cli_integration_mappings.py
+++ b/api/shared/cli_integration_mappings.py
@@ -1,0 +1,107 @@
+"""Shared CLI integration mapping scope helpers."""
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import DeveloperContext
+
+
+def _parse_scope_uuid(scope: str) -> UUID:
+    try:
+        return UUID(scope)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"scope must be 'global', a UUID, or null; got {scope!r}",
+        ) from None
+
+
+async def _resolve_mapping_org_id(
+    current_user: Any,
+    scope: str | None,
+    db: AsyncSession,
+) -> UUID | None:
+    user_org_id = current_user.organization_id
+
+    if not current_user.is_superuser:
+        if user_org_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="CLI scope requires an organization",
+            )
+        if scope == "global":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only superusers can access global CLI scope",
+            )
+        if scope and _parse_scope_uuid(scope) != user_org_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Cannot access another organization's CLI scope",
+            )
+        return user_org_id
+
+    if scope == "global":
+        return None
+
+    if scope:
+        requested_org_id = _parse_scope_uuid(scope)
+        if user_org_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Use global scope for platform-wide integration mappings",
+            )
+        return requested_org_id
+
+    if user_org_id is not None:
+        return user_org_id
+
+    stmt = select(DeveloperContext).where(DeveloperContext.user_id == current_user.user_id)
+    result = await db.execute(stmt)
+    dev_ctx = result.scalar_one_or_none()
+
+    if dev_ctx and dev_ctx.default_org_id:
+        return dev_ctx.default_org_id
+
+    return None
+
+
+async def list_cli_integration_mappings(
+    repo: Any,
+    current_user: Any,
+    scope: str | None,
+    integration_id: UUID,
+    db: AsyncSession,
+) -> list[Any]:
+    """List mappings visible to a CLI mapping request."""
+    org_id = await _resolve_mapping_org_id(current_user, scope, db)
+    if org_id is None and scope == "global":
+        return await repo.list_mappings(integration_id)
+    if org_id is None:
+        return []
+    return await repo.list_mappings(integration_id, organization_id=org_id)
+
+
+async def get_cli_integration_mapping(
+    repo: Any,
+    current_user: Any,
+    scope: str | None,
+    integration_id: UUID,
+    db: AsyncSession,
+    entity_id: str | None,
+) -> Any | None:
+    """Return the CLI-visible mapping selected by scope or entity id."""
+    mappings = await list_cli_integration_mappings(
+        repo,
+        current_user,
+        scope,
+        integration_id,
+        db,
+    )
+    if entity_id:
+        return next((mapping for mapping in mappings if mapping.entity_id == entity_id), None)
+    return mappings[0] if mappings else None

--- a/api/shared/cli_integration_mappings.py
+++ b/api/shared/cli_integration_mappings.py
@@ -50,11 +50,6 @@ async def _resolve_mapping_org_id(
 
     if scope:
         requested_org_id = _parse_scope_uuid(scope)
-        if user_org_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Use global scope for platform-wide integration mappings",
-            )
         return requested_org_id
 
     if user_org_id is not None:

--- a/api/src/models/contracts/cli.py
+++ b/api/src/models/contracts/cli.py
@@ -259,6 +259,10 @@ class SDKIntegrationsGetResponse(BaseModel):
 class SDKIntegrationsListMappingsRequest(BaseModel):
     """Request to list integration mappings via SDK."""
     name: str = Field(..., description="Integration name")
+    scope: str | None = Field(
+        default=None,
+        description="Organization scope: None=context default, UUID=specific org, global=all mappings",
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/api/src/repositories/integrations.py
+++ b/api/src/repositories/integrations.py
@@ -377,20 +377,29 @@ class IntegrationsRepository(BaseRepository[Integration]):
         return result.unique().scalar_one_or_none()
 
     async def list_mappings(
-        self, integration_id: UUID
+        self,
+        integration_id: UUID,
+        organization_id: UUID | None = None,
     ) -> list[IntegrationMapping]:
         """
         List all mappings for an integration.
 
         Args:
             integration_id: Integration UUID
+            organization_id: Optional organization scope. When provided, only
+                mappings for that org are returned.
 
         Returns:
             List of mappings for the integration
         """
+        stmt = select(IntegrationMapping).where(
+            IntegrationMapping.integration_id == integration_id
+        )
+        if organization_id is not None:
+            stmt = stmt.where(IntegrationMapping.organization_id == organization_id)
+
         result = await self.session.execute(
-            select(IntegrationMapping)
-            .where(IntegrationMapping.integration_id == integration_id)
+            stmt
             .options(
                 joinedload(IntegrationMapping.integration)
                 .options(joinedload(Integration.oauth_provider)),

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -937,7 +937,15 @@ async def sdk_integrations_list_mappings(
             logger.warning(f"SDK integrations.list_mappings: integration '{log_safe(request.name)}' not found")
             return None
 
-        mappings = await repo.list_mappings(integration.id)
+        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
+        if resolved_org_id is None and request.scope == "global":
+            mappings = await repo.list_mappings(integration.id)
+        elif resolved_org_id is None:
+            mappings = []
+        else:
+            mappings = await repo.list_mappings(
+                integration.id, organization_id=UUID(resolved_org_id)
+            )
 
         logger.info(f"SDK listed {len(mappings)} mappings for integration '{log_safe(request.name)}' for user {current_user.email}")
 
@@ -959,6 +967,8 @@ async def sdk_integrations_list_mappings(
 
         return SDKIntegrationsListMappingsResponse(items=items)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"SDK integrations.list_mappings failed: {log_safe(e)}")
         return None
@@ -985,17 +995,22 @@ async def sdk_integrations_get_mapping(
             logger.warning(f"SDK integrations.get_mapping: integration '{log_safe(request.name)}' not found")
             return None
 
+        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
         mapping = None
 
-        # Look up by scope (org_id) if provided
-        if request.scope:
-            org_uuid = UUID(request.scope)
+        # Look up by resolved org scope if available.
+        if resolved_org_id:
+            org_uuid = UUID(resolved_org_id)
             mapping = await repo.get_mapping_by_org(integration.id, org_uuid)
 
-        # If no mapping found and entity_id provided, search by entity_id
+        # If no mapping found and entity_id provided, search by entity_id.
+        # Non-global callers are restricted to their resolved org, so entity_id
+        # cannot be used to probe mappings in another organization.
         if not mapping and request.entity_id:
-            # Search through all mappings for the entity_id
-            all_mappings = await repo.list_mappings(integration.id)
+            all_mappings = await repo.list_mappings(
+                integration.id,
+                organization_id=UUID(resolved_org_id) if resolved_org_id else None,
+            )
             for m in all_mappings:
                 if m.entity_id == request.entity_id:
                     mapping = m
@@ -1005,11 +1020,7 @@ async def sdk_integrations_get_mapping(
             return None
 
         # Get merged config for the mapping
-        config = await repo.get_config_for_mapping(
-            integration.id,
-            mapping.organization_id,
-            include_default_secrets=True,
-        )
+        config = await repo.get_config_for_mapping(integration.id, mapping.organization_id)
 
         logger.info(f"SDK retrieved mapping for integration '{log_safe(request.name)}' for user {current_user.email}")
 
@@ -1025,6 +1036,8 @@ async def sdk_integrations_get_mapping(
             updated_at=mapping.updated_at.isoformat(),
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"SDK integrations.get_mapping failed: {log_safe(e)}")
         return None

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -1004,13 +1004,17 @@ async def sdk_integrations_get_mapping(
             mapping = await repo.get_mapping_by_org(integration.id, org_uuid)
 
         # If no mapping found and entity_id provided, search by entity_id.
-        # Non-global callers are restricted to their resolved org, so entity_id
-        # cannot be used to probe mappings in another organization.
+        # Only explicit global scope may search across orgs; unscoped superusers
+        # get no results, matching list_mappings behavior.
         if not mapping and request.entity_id:
-            all_mappings = await repo.list_mappings(
-                integration.id,
-                organization_id=UUID(resolved_org_id) if resolved_org_id else None,
-            )
+            if resolved_org_id is None and request.scope == "global":
+                all_mappings = await repo.list_mappings(integration.id)
+            elif resolved_org_id is None:
+                all_mappings = []
+            else:
+                all_mappings = await repo.list_mappings(
+                    integration.id, organization_id=UUID(resolved_org_id)
+                )
             for m in all_mappings:
                 if m.entity_id == request.entity_id:
                     mapping = m

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -77,6 +77,10 @@ from src.services.oauth_scope_resolution import (
     get_oauth_provider_for_scope,
     get_oauth_token_for_scope,
 )
+from shared.cli_integration_mappings import (
+    get_cli_integration_mapping,
+    list_cli_integration_mappings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -937,15 +941,13 @@ async def sdk_integrations_list_mappings(
             logger.warning(f"SDK integrations.list_mappings: integration '{log_safe(request.name)}' not found")
             return None
 
-        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
-        if resolved_org_id is None and request.scope == "global":
-            mappings = await repo.list_mappings(integration.id)
-        elif resolved_org_id is None:
-            mappings = []
-        else:
-            mappings = await repo.list_mappings(
-                integration.id, organization_id=UUID(resolved_org_id)
-            )
+        mappings = await list_cli_integration_mappings(
+            repo,
+            current_user,
+            request.scope,
+            integration.id,
+            db,
+        )
 
         logger.info(f"SDK listed {len(mappings)} mappings for integration '{log_safe(request.name)}' for user {current_user.email}")
 
@@ -995,30 +997,14 @@ async def sdk_integrations_get_mapping(
             logger.warning(f"SDK integrations.get_mapping: integration '{log_safe(request.name)}' not found")
             return None
 
-        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
-        mapping = None
-
-        # Look up by resolved org scope if available.
-        if resolved_org_id:
-            org_uuid = UUID(resolved_org_id)
-            mapping = await repo.get_mapping_by_org(integration.id, org_uuid)
-
-        # If no mapping found and entity_id provided, search by entity_id.
-        # Only explicit global scope may search across orgs; unscoped superusers
-        # get no results, matching list_mappings behavior.
-        if not mapping and request.entity_id:
-            if resolved_org_id is None and request.scope == "global":
-                all_mappings = await repo.list_mappings(integration.id)
-            elif resolved_org_id is None:
-                all_mappings = []
-            else:
-                all_mappings = await repo.list_mappings(
-                    integration.id, organization_id=UUID(resolved_org_id)
-                )
-            for m in all_mappings:
-                if m.entity_id == request.entity_id:
-                    mapping = m
-                    break
+        mapping = await get_cli_integration_mapping(
+            repo,
+            current_user,
+            request.scope,
+            integration.id,
+            db,
+            request.entity_id,
+        )
 
         if not mapping:
             return None

--- a/api/tests/e2e/api/test_integrations.py
+++ b/api/tests/e2e/api/test_integrations.py
@@ -1207,6 +1207,155 @@ class TestIntegrationConfigSecrets:
                 headers=platform_admin.headers,
             )
 
+    def test_sdk_get_mapping_omits_default_secrets(
+        self, e2e_client, platform_admin, integration_with_secret_schema, org1
+    ):
+        """Direct mapping reads must not disclose integration-level default secrets."""
+        integration = integration_with_secret_schema
+
+        response = e2e_client.put(
+            f"/api/integrations/{integration['id']}/config",
+            headers=platform_admin.headers,
+            json={
+                "config": {
+                    "base_url": "https://api.default.com",
+                    "api_key": "global-default-secret",
+                }
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        response = e2e_client.post(
+            f"/api/integrations/{integration['id']}/mappings",
+            headers=platform_admin.headers,
+            json={
+                "organization_id": str(org1["id"]),
+                "entity_id": "get-mapping-no-default-secret",
+            },
+        )
+        assert response.status_code == 201, response.text
+        mapping = response.json()
+
+        try:
+            response = e2e_client.post(
+                "/api/cli/integrations/get_mapping",
+                headers=platform_admin.headers,
+                json={"name": integration["name"], "scope": str(org1["id"])},
+            )
+            assert response.status_code == 200, response.text
+            data = response.json()
+
+            assert data["id"] == mapping["id"]
+            assert data["config"]["base_url"] == "https://api.default.com"
+            assert "api_key" not in data["config"]
+
+            response = e2e_client.post(
+                "/api/cli/integrations/list_mappings",
+                headers=platform_admin.headers,
+                json={"name": integration["name"], "scope": str(org1["id"])},
+            )
+            assert response.status_code == 200, response.text
+            listed = [
+                item for item in response.json()["items"]
+                if item["id"] == mapping["id"]
+            ]
+            assert len(listed) == 1
+            assert listed[0]["config"]["base_url"] == "https://api.default.com"
+            assert "api_key" not in listed[0]["config"]
+        finally:
+            e2e_client.delete(
+                f"/api/integrations/{integration['id']}/mappings/{mapping['id']}",
+                headers=platform_admin.headers,
+            )
+
+    def test_sdk_get_mapping_returns_org_secret_override(
+        self, e2e_client, platform_admin, integration_with_secret_schema, org1
+    ):
+        """Direct mapping reads may return secrets explicitly scoped to that mapping's org."""
+        integration = integration_with_secret_schema
+
+        response = e2e_client.put(
+            f"/api/integrations/{integration['id']}/config",
+            headers=platform_admin.headers,
+            json={
+                "config": {
+                    "base_url": "https://api.default.com",
+                    "api_key": "global-default-secret",
+                }
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        response = e2e_client.post(
+            f"/api/integrations/{integration['id']}/mappings",
+            headers=platform_admin.headers,
+            json={
+                "organization_id": str(org1["id"]),
+                "entity_id": "get-mapping-org-secret",
+                "config": {
+                    "api_key": "org-scoped-secret",
+                },
+            },
+        )
+        assert response.status_code == 201, response.text
+        mapping = response.json()
+
+        try:
+            response = e2e_client.post(
+                "/api/cli/integrations/get_mapping",
+                headers=platform_admin.headers,
+                json={"name": integration["name"], "scope": str(org1["id"])},
+            )
+            assert response.status_code == 200, response.text
+            data = response.json()
+
+            assert data["id"] == mapping["id"]
+            assert data["config"]["base_url"] == "https://api.default.com"
+            assert data["config"]["api_key"] == "org-scoped-secret"
+        finally:
+            e2e_client.delete(
+                f"/api/integrations/{integration['id']}/mappings/{mapping['id']}",
+                headers=platform_admin.headers,
+            )
+
+    def test_sdk_mapping_endpoints_reject_cross_org_scope(
+        self, e2e_client, platform_admin, org1_user, integration_with_secret_schema, org2
+    ):
+        """Regular org users cannot use SDK mapping endpoints to read another org."""
+        integration = integration_with_secret_schema
+
+        response = e2e_client.post(
+            f"/api/integrations/{integration['id']}/mappings",
+            headers=platform_admin.headers,
+            json={
+                "organization_id": str(org2["id"]),
+                "entity_id": "org2-tenant-secret",
+                "entity_name": "Org2 Tenant",
+            },
+        )
+        assert response.status_code == 201, response.text
+        mapping = response.json()
+
+        try:
+            response = e2e_client.post(
+                "/api/cli/integrations/get_mapping",
+                headers=org1_user.headers,
+                json={"name": integration["name"], "scope": str(org2["id"])},
+            )
+            assert response.status_code == 403, response.text
+
+            response = e2e_client.post(
+                "/api/cli/integrations/list_mappings",
+                headers=org1_user.headers,
+                json={"name": integration["name"], "scope": str(org2["id"])},
+            )
+            assert response.status_code == 403, response.text
+        finally:
+            e2e_client.delete(
+                f"/api/integrations/{integration['id']}/mappings/{mapping['id']}",
+                headers=platform_admin.headers,
+            )
+
 
 @pytest.mark.e2e
 class TestIntegrationsAuthorization:

--- a/api/tests/e2e/api/test_integrations.py
+++ b/api/tests/e2e/api/test_integrations.py
@@ -1370,14 +1370,17 @@ class TestIntegrationConfigSecrets:
                     "entity_id": "org2-tenant-secret",
                 },
             )
-            assert response.status_code == 403, response.text
+            assert response.status_code == 200, response.text
+            assert response.json()["id"] == mapping["id"]
 
             response = e2e_client.post(
                 "/api/cli/integrations/list_mappings",
                 headers=platform_admin_without_org,
                 json={"name": integration["name"], "scope": str(org2["id"])},
             )
-            assert response.status_code == 403, response.text
+            assert response.status_code == 200, response.text
+            scoped_items = response.json()["items"]
+            assert [item["id"] for item in scoped_items] == [mapping["id"]]
 
             response = e2e_client.post(
                 "/api/cli/integrations/get_mapping",

--- a/api/tests/e2e/api/test_integrations.py
+++ b/api/tests/e2e/api/test_integrations.py
@@ -1213,6 +1213,7 @@ class TestIntegrationConfigSecrets:
     ):
         """Direct mapping reads must not disclose integration-level default secrets."""
         integration = integration_with_secret_schema
+        default_secret = f"global-default-{uuid4().hex}"
 
         response = e2e_client.put(
             f"/api/integrations/{integration['id']}/config",
@@ -1220,7 +1221,7 @@ class TestIntegrationConfigSecrets:
             json={
                 "config": {
                     "base_url": "https://api.default.com",
-                    "api_key": "global-default-secret",
+                    "api_key": default_secret,
                 }
             },
         )
@@ -1274,6 +1275,8 @@ class TestIntegrationConfigSecrets:
     ):
         """Direct mapping reads may return secrets explicitly scoped to that mapping's org."""
         integration = integration_with_secret_schema
+        default_secret = f"global-default-{uuid4().hex}"
+        org_secret = f"org-scoped-{uuid4().hex}"
 
         response = e2e_client.put(
             f"/api/integrations/{integration['id']}/config",
@@ -1281,7 +1284,7 @@ class TestIntegrationConfigSecrets:
             json={
                 "config": {
                     "base_url": "https://api.default.com",
-                    "api_key": "global-default-secret",
+                    "api_key": default_secret,
                 }
             },
         )
@@ -1294,7 +1297,7 @@ class TestIntegrationConfigSecrets:
                 "organization_id": str(org1["id"]),
                 "entity_id": "get-mapping-org-secret",
                 "config": {
-                    "api_key": "org-scoped-secret",
+                    "api_key": org_secret,
                 },
             },
         )
@@ -1312,7 +1315,7 @@ class TestIntegrationConfigSecrets:
 
             assert data["id"] == mapping["id"]
             assert data["config"]["base_url"] == "https://api.default.com"
-            assert data["config"]["api_key"] == "org-scoped-secret"
+            assert data["config"]["api_key"] == org_secret
         finally:
             e2e_client.delete(
                 f"/api/integrations/{integration['id']}/mappings/{mapping['id']}",

--- a/api/tests/e2e/api/test_integrations.py
+++ b/api/tests/e2e/api/test_integrations.py
@@ -9,6 +9,7 @@ import pytest
 import pytest_asyncio
 from uuid import uuid4
 from src.models.orm import OAuthProvider
+from tests.fixtures.auth import auth_headers, create_test_jwt
 
 
 @pytest.mark.e2e
@@ -1335,6 +1336,12 @@ class TestIntegrationConfigSecrets:
         )
         assert response.status_code == 201, response.text
         mapping = response.json()
+        platform_admin_without_org = auth_headers(
+            create_test_jwt(
+                email="mapping-platform-admin@test.com",
+                is_superuser=True,
+            )
+        )
 
         try:
             response = e2e_client.post(
@@ -1350,6 +1357,47 @@ class TestIntegrationConfigSecrets:
                 json={"name": integration["name"], "scope": str(org2["id"])},
             )
             assert response.status_code == 403, response.text
+
+            response = e2e_client.post(
+                "/api/cli/integrations/get_mapping",
+                headers=platform_admin_without_org,
+                json={
+                    "name": integration["name"],
+                    "scope": str(org2["id"]),
+                    "entity_id": "org2-tenant-secret",
+                },
+            )
+            assert response.status_code == 403, response.text
+
+            response = e2e_client.post(
+                "/api/cli/integrations/list_mappings",
+                headers=platform_admin_without_org,
+                json={"name": integration["name"], "scope": str(org2["id"])},
+            )
+            assert response.status_code == 403, response.text
+
+            response = e2e_client.post(
+                "/api/cli/integrations/get_mapping",
+                headers=platform_admin_without_org,
+                json={
+                    "name": integration["name"],
+                    "scope": "global",
+                    "entity_id": "org2-tenant-secret",
+                },
+            )
+            assert response.status_code == 200, response.text
+            assert response.json()["id"] == mapping["id"]
+
+            response = e2e_client.post(
+                "/api/cli/integrations/list_mappings",
+                headers=platform_admin_without_org,
+                json={"name": integration["name"], "scope": "global"},
+            )
+            assert response.status_code == 200, response.text
+            assert any(
+                item["id"] == mapping["id"] and item["entity_name"] == "Org2 Tenant"
+                for item in response.json()["items"]
+            )
         finally:
             e2e_client.delete(
                 f"/api/integrations/{integration['id']}/mappings/{mapping['id']}",

--- a/api/tests/unit/shared/test_cli_integration_mappings.py
+++ b/api/tests/unit/shared/test_cli_integration_mappings.py
@@ -1,0 +1,143 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from shared.cli_integration_mappings import (
+    _resolve_mapping_org_id,
+    get_cli_integration_mapping,
+    list_cli_integration_mappings,
+)
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _Session:
+    def __init__(self, developer_context=None):
+        self.developer_context = developer_context
+
+    async def execute(self, _stmt):
+        return _ScalarResult(self.developer_context)
+
+
+class _Repo:
+    def __init__(self, mappings):
+        self.mappings = mappings
+        self.calls = []
+
+    async def list_mappings(self, integration_id, organization_id=None):
+        self.calls.append((integration_id, organization_id))
+        if organization_id is None:
+            return self.mappings
+        return [
+            mapping for mapping in self.mappings
+            if mapping.organization_id == organization_id
+        ]
+
+
+def _user(*, is_superuser=False, organization_id=None):
+    return SimpleNamespace(
+        is_superuser=is_superuser,
+        organization_id=organization_id,
+        user_id=uuid4(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_mapping_org_id_rejects_invalid_scope():
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_mapping_org_id(
+            _user(is_superuser=True),
+            "not-a-uuid",
+            _Session(),
+        )
+
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_resolve_mapping_org_id_uses_developer_context_default():
+    default_org_id = uuid4()
+    org_id = await _resolve_mapping_org_id(
+        _user(is_superuser=True),
+        None,
+        _Session(SimpleNamespace(default_org_id=default_org_id)),
+    )
+
+    assert org_id == default_org_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_mapping_org_id_allows_superuser_global_and_org_scope():
+    scoped_org_id = uuid4()
+
+    assert await _resolve_mapping_org_id(
+        _user(is_superuser=True),
+        "global",
+        _Session(),
+    ) is None
+    assert await _resolve_mapping_org_id(
+        _user(is_superuser=True),
+        str(scoped_org_id),
+        _Session(),
+    ) == scoped_org_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_mapping_org_id_rejects_non_superuser_cross_org_scope():
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_mapping_org_id(
+            _user(organization_id=uuid4()),
+            str(uuid4()),
+            _Session(),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_cli_integration_mappings_filters_by_resolved_org():
+    integration_id = uuid4()
+    org_id = uuid4()
+    other_org_id = uuid4()
+    visible_mapping = SimpleNamespace(entity_id="visible", organization_id=org_id)
+    hidden_mapping = SimpleNamespace(entity_id="hidden", organization_id=other_org_id)
+    repo = _Repo([visible_mapping, hidden_mapping])
+
+    mappings = await list_cli_integration_mappings(
+        repo,
+        _user(organization_id=org_id),
+        None,
+        integration_id,
+        _Session(),
+    )
+
+    assert mappings == [visible_mapping]
+    assert repo.calls == [(integration_id, org_id)]
+
+
+@pytest.mark.asyncio
+async def test_get_cli_integration_mapping_selects_visible_entity_id():
+    integration_id = uuid4()
+    org_id = uuid4()
+    target_mapping = SimpleNamespace(entity_id="target", organization_id=org_id)
+    other_mapping = SimpleNamespace(entity_id="other", organization_id=org_id)
+    repo = _Repo([other_mapping, target_mapping])
+
+    mapping = await get_cli_integration_mapping(
+        repo,
+        _user(is_superuser=True),
+        "global",
+        integration_id,
+        _Session(),
+        "target",
+    )
+
+    assert mapping == target_mapping


### PR DESCRIPTION
## Summary
- omit integration-level default secrets from direct SDK mapping responses by default
- keep workflow-style SDK integration lookup explicitly opted in to default secrets
- add e2e coverage for both default-secret omission and org-scoped secret override behavior

## Validation
- Remote Bifrost VM: codex-vm-netbird (/home/dev/codex-work/bifrost-security-get-mapping)
- ./test.sh tests/e2e/api/test_integrations.py::TestIntegrationConfigSecrets::test_sdk_get_mapping_omits_default_secrets tests/e2e/api/test_integrations.py::TestIntegrationConfigSecrets::test_sdk_get_mapping_returns_org_secret_override -v
- Result: 2 passed in 5.84s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization and secret exposure on CLI/SDK mapping endpoints; incorrect scope rules could block legitimate access or still leak credentials.
> 
> **Overview**
> This PR tightens **SDK/CLI integration mapping** reads: `list_mappings` and `get_mapping` now resolve **organization scope** (user org, explicit UUID, developer default, or superuser `global`) and **reject cross-org access** for non-superusers. Listing is **org-filtered** at the repository layer instead of returning every mapping for an integration.
> 
> **Secret handling:** direct mapping responses no longer surface **integration-level default secrets** unless the org has an explicit override—`get_mapping` stops opting into `include_default_secrets` (workflow-style `integrations.get` still can). The SDK **list mappings** contract gains an optional **`scope`** field.
> 
> Shared helpers in `api/shared/cli_integration_mappings.py` centralize scope parsing and mapping selection; new unit and e2e tests cover scoping, authorization, and secret omission/override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff6258465e76ec2c7a1a0036047d4162f393f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the CLI integrations `scope` description to state that `global` means "all mappings".

* **Bug Fixes**
  * Enforced organization scoping for listing and retrieving CLI integration mappings.
  * Restricted cross-organization mapping access to superusers only.
  * Mapping responses now omit integration default secrets unless an organization-level override exists.

* **Tests**
  * Added end-to-end tests validating secret handling, scoping, and authorization for CLI mapping endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->