### PR TITLE
Expose configured worker capacity in diagnostics

### DIFF
--- a/api/src/models/contracts/platform.py
+++ b/api/src/models/contracts/platform.py
@@ -65,7 +65,22 @@ class PoolSummary(BaseModel):
         description="Pool status: online or offline"
     )
     started_at: str | None = None
-    pool_size: int = Field(default=0, description="Total number of processes in pool")
+    pool_size: int = Field(
+        default=0,
+        description="Backward-compatible alias for active_process_count",
+    )
+    active_process_count: int = Field(
+        default=0,
+        description="Currently forked one-shot child processes",
+    )
+    configured_capacity: int | None = Field(
+        default=None,
+        description="Maximum concurrent child processes this pool may admit",
+    )
+    max_workers: int | None = Field(
+        default=None,
+        description="Configured ProcessPoolManager max_workers value",
+    )
     idle_count: int = Field(default=0, description="Number of idle processes")
     busy_count: int = Field(default=0, description="Number of busy processes")
     last_heartbeat: str | None = None
@@ -110,6 +125,10 @@ class PoolStatsResponse(BaseModel):
 
     total_pools: int = Field(..., description="Number of registered pools")
     total_processes: int = Field(..., description="Total processes across all pools")
+    total_configured_capacity: int | None = Field(
+        default=None,
+        description="Total configured concurrent execution capacity across pools",
+    )
     total_idle: int = Field(..., description="Total idle processes across all pools")
     total_busy: int = Field(..., description="Total busy processes across all pools")
 
@@ -214,4 +233,3 @@ class WorkerMetricsResponse(BaseModel):
 
     range: str = Field(..., description="Requested time range: 1h, 6h, 24h, 7d")
     points: list[WorkerMetricPoint] = Field(default_factory=list)
-

--- a/api/src/models/contracts/platform.py
+++ b/api/src/models/contracts/platform.py
@@ -110,6 +110,14 @@ class PoolDetail(BaseModel):
     status: str | None = None
     started_at: str | None = None
     last_heartbeat: str | None = None
+    configured_capacity: int | None = Field(
+        default=None,
+        description="Maximum concurrent child processes this pool may admit",
+    )
+    max_workers: int | None = Field(
+        default=None,
+        description="Configured ProcessPoolManager max_workers value",
+    )
     processes: list[ProcessInfo] = Field(default_factory=list)
 
 

--- a/api/src/routers/platform/workers.py
+++ b/api/src/routers/platform/workers.py
@@ -184,6 +184,8 @@ async def get_pool_stats(
 
     total_pools = len(pool_keys)
     total_processes = 0
+    total_configured_capacity = 0
+    saw_configured_capacity = False
     total_idle = 0
     total_busy = 0
 
@@ -200,7 +202,11 @@ async def get_pool_stats(
         if heartbeat_data:
             try:
                 hb = json.loads(heartbeat_data)
-                total_processes += hb.get("pool_size", 0)
+                total_processes += hb.get("active_process_count", hb.get("pool_size", 0))
+                configured_capacity = hb.get("configured_capacity", hb.get("max_workers"))
+                if configured_capacity is not None:
+                    total_configured_capacity += int(configured_capacity)
+                    saw_configured_capacity = True
                 total_idle += hb.get("idle_count", 0)
                 total_busy += hb.get("busy_count", 0)
             except json.JSONDecodeError as e:
@@ -210,6 +216,7 @@ async def get_pool_stats(
     return PoolStatsResponse(
         total_pools=total_pools,
         total_processes=total_processes,
+        total_configured_capacity=total_configured_capacity if saw_configured_capacity else None,
         total_idle=total_idle,
         total_busy=total_busy,
     )
@@ -275,6 +282,12 @@ async def list_pools(
             try:
                 hb = json.loads(heartbeat_data)
                 pool_info.pool_size = hb.get("pool_size", 0)
+                pool_info.active_process_count = hb.get(
+                    "active_process_count",
+                    pool_info.pool_size,
+                )
+                pool_info.configured_capacity = hb.get("configured_capacity", hb.get("max_workers"))
+                pool_info.max_workers = hb.get("max_workers", pool_info.configured_capacity)
                 pool_info.idle_count = hb.get("idle_count", 0)
                 pool_info.busy_count = hb.get("busy_count", 0)
                 pool_info.last_heartbeat = hb.get("timestamp")

--- a/api/src/routers/platform/workers.py
+++ b/api/src/routers/platform/workers.py
@@ -348,6 +348,8 @@ async def get_pool(
         try:
             hb = json.loads(heartbeat_data)
             result.last_heartbeat = hb.get("timestamp")
+            result.configured_capacity = hb.get("configured_capacity", hb.get("max_workers"))
+            result.max_workers = hb.get("max_workers", result.configured_capacity)
 
             # Parse process info from heartbeat
             for p in hb.get("processes", []):

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -1596,7 +1596,7 @@ class ProcessPoolManager:
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "processes": processes,
             "active_process_count": len(self.processes),
-            "configured_capacity": self.max_workers,
+            "configured_capacity": max_workers,
             "max_workers": max_workers,
             "pool_size": len(self.processes),
             "available_slots": available_slots,

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -1595,8 +1595,10 @@ class ProcessPoolManager:
             "started_at": self._started_at.isoformat() if self._started_at else None,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "processes": processes,
+            "active_process_count": len(self.processes),
+            "configured_capacity": self.max_workers,
+            "max_workers": self.max_workers,
             "pool_size": len(self.processes),
-            "max_workers": max_workers,
             "available_slots": available_slots,
             "idle_count": idle_count,
             "busy_count": busy_count,
@@ -1657,6 +1659,9 @@ class ProcessPoolManager:
             "shutdown": self._shutdown,
             "worker_id": self.worker_id,
             "pool_size": len(self.processes),
+            "active_process_count": len(self.processes),
+            "configured_capacity": self.max_workers,
+            "max_workers": self.max_workers,
             "processes": [
                 {
                     "process_id": p.id,

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -1597,6 +1597,7 @@ class ProcessPoolManager:
             "processes": processes,
             "active_process_count": len(self.processes),
             "configured_capacity": self.max_workers,
+            "max_workers": max_workers,
             "pool_size": len(self.processes),
             "available_slots": available_slots,
             "idle_count": idle_count,

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -1597,7 +1597,6 @@ class ProcessPoolManager:
             "processes": processes,
             "active_process_count": len(self.processes),
             "configured_capacity": self.max_workers,
-            "max_workers": self.max_workers,
             "pool_size": len(self.processes),
             "available_slots": available_slots,
             "idle_count": idle_count,

--- a/api/tests/e2e/platform/test_workers_api.py
+++ b/api/tests/e2e/platform/test_workers_api.py
@@ -184,6 +184,9 @@ class TestWorkersListEndpoint:
                 {"pid": 12346, "process_id": "process-2", "state": "busy"},
             ],
             "pool_size": 2,
+            "active_process_count": 2,
+            "configured_capacity": 4,
+            "max_workers": 4,
             "idle_count": 1,
             "busy_count": 1,
         }
@@ -207,6 +210,9 @@ class TestWorkersListEndpoint:
         assert pool.hostname == "test-host"
         assert pool.status == "online"
         assert pool.pool_size == 2
+        assert pool.active_process_count == 2
+        assert pool.configured_capacity == 4
+        assert pool.max_workers == 4
         assert pool.busy_count == 1
 
 

--- a/api/tests/e2e/platform/test_workers_api.py
+++ b/api/tests/e2e/platform/test_workers_api.py
@@ -215,6 +215,77 @@ class TestWorkersListEndpoint:
         assert pool.max_workers == 4
         assert pool.busy_count == 1
 
+    async def test_get_worker_stats_includes_configured_capacity(
+        self,
+        redis_client,
+        db_session: AsyncSession,
+        clean_redis_workers,
+    ):
+        """Worker stats aggregate active processes and configured capacity."""
+        from src.routers.platform.workers import get_pool_stats
+        from src.core.auth import UserPrincipal
+
+        now = datetime.now(timezone.utc).isoformat()
+        workers = [
+            (
+                "stats-worker-001",
+                {
+                    "pool_size": 2,
+                    "active_process_count": 2,
+                    "configured_capacity": 4,
+                    "max_workers": 4,
+                    "idle_count": 1,
+                    "busy_count": 1,
+                },
+            ),
+            (
+                "stats-worker-002",
+                {
+                    "pool_size": 1,
+                    "active_process_count": 1,
+                    "max_workers": 3,
+                    "idle_count": 0,
+                    "busy_count": 1,
+                },
+            ),
+        ]
+
+        for worker_id, counts in workers:
+            await redis_client.hset(
+                f"bifrost:pool:{worker_id}",
+                mapping={
+                    "hostname": f"{worker_id}-host",
+                    "status": "online",
+                    "started_at": now,
+                },
+            )
+            await redis_client.set(
+                f"bifrost:pool:{worker_id}:heartbeat",
+                json.dumps(
+                    {
+                        "type": "worker_heartbeat",
+                        "worker_id": worker_id,
+                        "timestamp": now,
+                        **counts,
+                    }
+                ),
+            )
+
+        admin = UserPrincipal(
+            user_id=uuid4(),
+            email="admin@test.com",
+            organization_id=None,
+            is_superuser=True,
+        )
+
+        result = await get_pool_stats(admin)
+
+        assert result.total_pools == 2
+        assert result.total_processes == 3
+        assert result.total_configured_capacity == 7
+        assert result.total_idle == 1
+        assert result.total_busy == 2
+
 
 @pytest.mark.e2e
 @pytest.mark.asyncio

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -513,6 +513,9 @@ class TestProcessPoolManagerHeartbeat:
         assert heartbeat["type"] == "worker_heartbeat"
         assert heartbeat["worker_id"] == "test-worker-123"
         assert heartbeat["pool_size"] == 2
+        assert heartbeat["active_process_count"] == 2
+        assert heartbeat["configured_capacity"] == pool.max_workers
+        assert heartbeat["max_workers"] == pool.max_workers
         # In on-demand mode every running handle is BUSY (the IDLE-marked
         # handle above is for test-shape parity with persistent-pool
         # heartbeats; idle_count is reported as 0 in this mode).

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -671,6 +671,9 @@ class TestProcessPoolManagerStatus:
         assert status["shutdown"] is False
         assert status["worker_id"] == "test-worker"
         assert status["pool_size"] == 1
+        assert status["active_process_count"] == 1
+        assert status["configured_capacity"] == pool.max_workers
+        assert status["max_workers"] == pool.max_workers
         assert len(status["processes"]) == 1
         assert status["processes"][0]["process_id"] == "process-1"
         assert status["processes"][0]["state"] == "idle"

--- a/client/src/pages/diagnostics/components/ContainerTable.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.tsx
@@ -52,14 +52,18 @@ function getPoolCounts(pool: PoolData) {
         const processes = pool.processes as ProcessInfo[];
         return {
             total: processes.length,
+            capacity: processes.length,
             idle: processes.filter((p) => p.state === "idle").length,
             busy: processes.filter((p) => p.state === "busy").length,
             processes,
         };
     }
     const summary = pool as PoolSummary;
+    const active = summary.active_process_count ?? summary.pool_size ?? 0;
+    const capacity = summary.configured_capacity ?? summary.max_workers ?? active;
     return {
-        total: summary.pool_size ?? 0,
+        total: active,
+        capacity,
         idle: summary.idle_count ?? 0,
         busy: summary.busy_count ?? 0,
         processes: [] as ProcessInfo[],
@@ -144,7 +148,7 @@ export function ContainerTable({ pools, workerIds }: ContainerTableProps) {
                         <TableHead>Container</TableHead>
                         <TableHead className="w-[100px]">Runtime</TableHead>
                         <TableHead className="w-[80px]">Status</TableHead>
-                        <TableHead className="w-[100px]">Forks</TableHead>
+                        <TableHead className="w-[120px]">Forks</TableHead>
                         <TableHead className="w-[200px]">Memory</TableHead>
                         <TableHead className="w-[90px]">Uptime</TableHead>
                     </TableRow>
@@ -233,7 +237,7 @@ export function ContainerTable({ pools, workerIds }: ContainerTableProps) {
                                         </Badge>
                                     </TableCell>
                                     <TableCell className="text-sm">
-                                        {counts.total}{" "}
+                                        {counts.total}/{counts.capacity}{" "}
                                         {counts.busy > 0 && (
                                             <span className="text-xs text-muted-foreground">
                                                 ({counts.busy} busy)

--- a/client/src/pages/diagnostics/components/ContainerTable.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.tsx
@@ -50,9 +50,13 @@ function formatBytes(bytes: number): string {
 function getPoolCounts(pool: PoolData) {
     if ("processes" in pool && Array.isArray(pool.processes)) {
         const processes = pool.processes as ProcessInfo[];
+        const active = processes.length;
+        const detail = pool as PoolDetail;
+        const capacity =
+            detail.configured_capacity ?? detail.max_workers ?? active;
         return {
-            total: processes.length,
-            capacity: processes.length,
+            total: active,
+            capacity,
             idle: processes.filter((p) => p.state === "idle").length,
             busy: processes.filter((p) => p.state === "busy").length,
             processes,

--- a/client/src/pages/diagnostics/components/ContainerTable.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.tsx
@@ -47,7 +47,7 @@ function formatBytes(bytes: number): string {
     return `${mb.toFixed(0)} MB`;
 }
 
-function getPoolCounts(pool: PoolData) {
+export function getPoolCounts(pool: PoolData) {
     if ("processes" in pool && Array.isArray(pool.processes)) {
         const processes = pool.processes as ProcessInfo[];
         const detail = pool as PoolDetail;

--- a/client/src/pages/diagnostics/components/ContainerTable.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.tsx
@@ -50,8 +50,8 @@ function formatBytes(bytes: number): string {
 function getPoolCounts(pool: PoolData) {
     if ("processes" in pool && Array.isArray(pool.processes)) {
         const processes = pool.processes as ProcessInfo[];
-        const active = processes.length;
         const detail = pool as PoolDetail;
+        const active = detail.active_process_count ?? detail.pool_size ?? processes.length;
         const capacity =
             detail.configured_capacity ?? detail.max_workers ?? active;
         return {

--- a/client/src/pages/diagnostics/components/WorkersTab.tsx
+++ b/client/src/pages/diagnostics/components/WorkersTab.tsx
@@ -59,20 +59,25 @@ export function WorkersTab() {
     // Compute summary stats
     const stats = useMemo(() => {
         let totalForks = 0;
+        let totalCapacity = 0;
         let totalBusy = 0;
         for (const pool of pools) {
             if ("processes" in pool && Array.isArray(pool.processes)) {
                 totalForks += pool.processes.length;
+                totalCapacity += pool.processes.length;
                 totalBusy += pool.processes.filter(
                     (p: ProcessInfo) => p.state === "busy"
                 ).length;
             } else {
                 const summary = pool as PoolSummary;
-                totalForks += summary.pool_size ?? 0;
+                const active = summary.active_process_count ?? summary.pool_size ?? 0;
+                const capacity = summary.configured_capacity ?? summary.max_workers ?? active;
+                totalForks += active;
+                totalCapacity += capacity;
                 totalBusy += summary.busy_count ?? 0;
             }
         }
-        return { containers: pools.length, forks: totalForks, busy: totalBusy };
+        return { containers: pools.length, forks: totalForks, capacity: totalCapacity, busy: totalBusy };
     }, [pools]);
 
     return (
@@ -113,7 +118,7 @@ export function WorkersTab() {
                 <div className="flex items-center gap-3">
                     <span className="text-sm text-muted-foreground">
                         {stats.containers} container{stats.containers !== 1 ? "s" : ""}{" "}
-                        &middot; {stats.forks} fork{stats.forks !== 1 ? "s" : ""}
+                        &middot; {stats.forks}/{stats.capacity} active forks
                     </span>
                     <Button
                         variant="outline"

--- a/client/src/pages/diagnostics/components/WorkersTab.tsx
+++ b/client/src/pages/diagnostics/components/WorkersTab.tsx
@@ -3,11 +3,11 @@ import { RefreshCw, Loader2, WifiOff, Server } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { usePools, useQueueStatus, type ProcessInfo, type PoolDetail, type PoolSummary } from "@/services/workers";
+import { usePools, useQueueStatus, type PoolSummary } from "@/services/workers";
 import { getErrorMessage } from "@/lib/api-error";
 import { QueueBadge } from "./QueueBadge";
 import { MemoryChart } from "./MemoryChart";
-import { ContainerTable } from "./ContainerTable";
+import { ContainerTable, getPoolCounts } from "./ContainerTable";
 import { useWorkerWebSocket } from "../hooks/useWorkerWebSocket";
 
 export function WorkersTab() {
@@ -62,24 +62,10 @@ export function WorkersTab() {
         let totalCapacity = 0;
         let totalBusy = 0;
         for (const pool of pools) {
-            if ("processes" in pool && Array.isArray(pool.processes)) {
-                const detail = pool as PoolDetail;
-                const active = detail.active_process_count ?? detail.pool_size ?? pool.processes.length;
-                const capacity =
-                    detail.configured_capacity ?? detail.max_workers ?? active;
-                totalForks += active;
-                totalCapacity += capacity;
-                totalBusy += pool.processes.filter(
-                    (p: ProcessInfo) => p.state === "busy"
-                ).length;
-            } else {
-                const summary = pool as PoolSummary;
-                const active = summary.active_process_count ?? summary.pool_size ?? 0;
-                const capacity = summary.configured_capacity ?? summary.max_workers ?? active;
-                totalForks += active;
-                totalCapacity += capacity;
-                totalBusy += summary.busy_count ?? 0;
-            }
+            const counts = getPoolCounts(pool);
+            totalForks += counts.total;
+            totalCapacity += counts.capacity;
+            totalBusy += counts.busy;
         }
         return { containers: pools.length, forks: totalForks, capacity: totalCapacity, busy: totalBusy };
     }, [pools]);

--- a/client/src/pages/diagnostics/components/WorkersTab.tsx
+++ b/client/src/pages/diagnostics/components/WorkersTab.tsx
@@ -64,7 +64,7 @@ export function WorkersTab() {
         for (const pool of pools) {
             if ("processes" in pool && Array.isArray(pool.processes)) {
                 const detail = pool as PoolDetail;
-                const active = pool.processes.length;
+                const active = detail.active_process_count ?? detail.pool_size ?? pool.processes.length;
                 const capacity =
                     detail.configured_capacity ?? detail.max_workers ?? active;
                 totalForks += active;

--- a/client/src/pages/diagnostics/components/WorkersTab.tsx
+++ b/client/src/pages/diagnostics/components/WorkersTab.tsx
@@ -3,7 +3,7 @@ import { RefreshCw, Loader2, WifiOff, Server } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { usePools, useQueueStatus, type ProcessInfo, type PoolSummary } from "@/services/workers";
+import { usePools, useQueueStatus, type ProcessInfo, type PoolDetail, type PoolSummary } from "@/services/workers";
 import { getErrorMessage } from "@/lib/api-error";
 import { QueueBadge } from "./QueueBadge";
 import { MemoryChart } from "./MemoryChart";
@@ -63,8 +63,12 @@ export function WorkersTab() {
         let totalBusy = 0;
         for (const pool of pools) {
             if ("processes" in pool && Array.isArray(pool.processes)) {
-                totalForks += pool.processes.length;
-                totalCapacity += pool.processes.length;
+                const detail = pool as PoolDetail;
+                const active = pool.processes.length;
+                const capacity =
+                    detail.configured_capacity ?? detail.max_workers ?? active;
+                totalForks += active;
+                totalCapacity += capacity;
                 totalBusy += pool.processes.filter(
                     (p: ProcessInfo) => p.state === "busy"
                 ).length;

--- a/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
+++ b/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
@@ -82,6 +82,8 @@ export function useWorkerWebSocket(): UseWorkerWebSocketReturn {
 						status: message.status || null,
 						started_at: message.started_at || null,
 						last_heartbeat: message.timestamp || null,
+						configured_capacity: message.configured_capacity ?? null,
+						max_workers: message.max_workers ?? null,
 						processes,
 						requirements_installed: message.requirements_installed ?? null,
 						requirements_total: message.requirements_total ?? null,

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -347,6 +347,9 @@ export interface PoolHeartbeatMessage {
 	started_at?: string;
 	timestamp?: string;
 	pool_size?: number;
+	active_process_count?: number;
+	configured_capacity?: number;
+	max_workers?: number;
 	idle_count?: number;
 	busy_count?: number;
 	requirements_installed?: number;

--- a/client/src/services/workers.ts
+++ b/client/src/services/workers.ts
@@ -41,6 +41,9 @@ export interface PoolSummary {
 	status: string | null;
 	started_at: string | null;
 	pool_size: number;
+	active_process_count?: number;
+	configured_capacity?: number | null;
+	max_workers?: number | null;
 	idle_count: number;
 	busy_count: number;
 	last_heartbeat: string | null;
@@ -69,6 +72,7 @@ export interface PoolsListResponse {
 export interface PoolStatsResponse {
 	total_pools: number;
 	total_processes: number;
+	total_configured_capacity?: number | null;
 	total_idle: number;
 	total_busy: number;
 }
@@ -288,4 +292,3 @@ export function useWorkerMetrics(range: string = "1h") {
         refetchInterval: 60_000, // Refresh every 60s to get new data points
     });
 }
-

--- a/client/src/services/workers.ts
+++ b/client/src/services/workers.ts
@@ -57,6 +57,8 @@ export interface PoolDetail {
 	status: string | null;
 	started_at: string | null;
 	last_heartbeat: string | null;
+	pool_size?: number;
+	active_process_count?: number;
 	configured_capacity?: number | null;
 	max_workers?: number | null;
 	processes: ProcessInfo[];

--- a/client/src/services/workers.ts
+++ b/client/src/services/workers.ts
@@ -57,6 +57,8 @@ export interface PoolDetail {
 	status: string | null;
 	started_at: string | null;
 	last_heartbeat: string | null;
+	configured_capacity?: number | null;
+	max_workers?: number | null;
 	processes: ProcessInfo[];
 	requirements_installed: number | null;
 	requirements_total: number | null;


### PR DESCRIPTION
## Summary
- expose configured worker capacity alongside active process counts in platform worker APIs and heartbeats
- update diagnostics UI to show active/configured worker counts
- cover the new capacity fields in process-pool and platform worker tests

## Linux VM verification
Ran on `codex-vm` / `codex-dev-01` from a clean `origin/main` clone with this patch applied:
- `client`: `npm ci && npm run tsc` passed
- `api`: `python -m pytest api/tests/unit/execution/test_process_pool.py api/tests/e2e/platform/test_workers_api.py -q -ra -o addopts="-v --tb=short --strict-markers"` passed with `35 passed, 9 skipped`; skipped tests require a live API at `http://api:8000`

Notes:
- VM only has Python 3.13, so backend venv installed pinned lock entries with `pip install --no-deps -r requirements.lock`; normal lock install hits an unrelated Python 3.13 hash-resolution issue on `pyyaml-ft`.
- A disposable local Redis container was used for the process-pool Redis cleanup path and removed after verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and UI fields with fallbacks to legacy `pool_size`/`max_workers`; no auth or execution-path behavior changes beyond observability.
> 
> **Overview**
> Worker diagnostics now distinguish **active forked processes** from **configured concurrency capacity** (`max_workers`), while keeping `pool_size` as a backward-compatible alias.
> 
> **Backend:** `ProcessPoolManager` heartbeats and status include `active_process_count`, `configured_capacity`, and `max_workers`. Platform worker list/detail/stats APIs read these from Redis heartbeats (with fallbacks to older payloads) and expose `total_configured_capacity` in pool stats.
> 
> **Frontend:** Diagnostics shows forks as **active/capacity** (per container and in the header summary). WebSocket heartbeats and client types carry the new fields; shared `getPoolCounts` centralizes the fallback logic.
> 
> **Tests:** Unit and e2e coverage for heartbeat shape, list pools, and aggregated stats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0def415f8c2facc3ed1bd2f138b199f86c7e2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed worker pool capacity metrics (configured capacity, max workers) and active process counts to monitoring and diagnostics views; dashboard now shows active forks relative to capacity.
  * Worker metrics auto-refreshes every 60 seconds for up-to-date data.

* **Tests**
  * End-to-end and unit tests updated to cover the new heartbeat/metrics fields.

* **Chore**
  * Minor cleanup of trailing file content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->