### PR TITLE
[codex] default debug CLI auth to unattended sessions

### DIFF
--- a/.claude/skills/bifrost-debug/SKILL.md
+++ b/.claude/skills/bifrost-debug/SKILL.md
@@ -72,7 +72,7 @@ On `./debug.sh down`, run:
 bifrost logout --url <URL> --yes
 ```
 
-That removes any matching persistent entry and the matching `BIFROST_API_URL` line from `.env`. If password-grant login wrote token lines, remove `BIFROST_ACCESS_TOKEN` and `BIFROST_REFRESH_TOKEN` from `.env` as well, or delete `.env` if it only contains Bifrost debug credentials.
+That removes any matching persistent entry and the matching `BIFROST_API_URL` line from `.env`. If password-grant login wrote token lines, it also removes `BIFROST_ACCESS_TOKEN` and `BIFROST_REFRESH_TOKEN`; if `.env` only contained Bifrost debug credentials, it is deleted.
 
 ### When to use browser login instead
 

--- a/.claude/skills/bifrost-debug/SKILL.md
+++ b/.claude/skills/bifrost-debug/SKILL.md
@@ -54,35 +54,35 @@ The user picks the mode by setting (or not setting) `NETBIRD_SETUP_KEY` in `~/.c
 
 ## Auto-connect the CLI in this folder
 
-After `./debug.sh up`, wire the per-folder CLI to target this stack. Tokens for multiple instances coexist in the OS keychain, keyed by URL — the user's prod token (if any) is not affected.
+After `./debug.sh up`, wire the per-folder CLI to target this stack without user involvement. Debug stacks have MFA off and print the seed email/password in `./debug.sh status`, so use password-grant login by default. This writes only the current worktree's `.env`; the user's prod keychain token (if any) is not affected.
 
-1. Run the standard browser login against the debug URL:
+1. Run password-grant login against the debug URL:
 
    ```bash
-   bifrost login --url <URL_FROM_DEBUG_STATUS>
+   bifrost login --url <URL_FROM_DEBUG_STATUS> --email <EMAIL_FROM_DEBUG_STATUS> --password <PASSWORD_FROM_DEBUG_STATUS>
    ```
 
-   This opens the device-code page, the user accepts, and the token lands in the keychain (or the JSON fallback on headless Linux). On success, `bifrost login` also writes `BIFROST_API_URL=<URL>` to `.env` in the current directory and adds `.env` to `.gitignore` if it isn't already.
+   This calls `/auth/login`, refuses if MFA is enabled, and writes `BIFROST_API_URL`, `BIFROST_ACCESS_TOKEN`, and `BIFROST_REFRESH_TOKEN` to `.env` in the current directory. It also adds `.env` to `.gitignore` if it isn't already.
 
-2. Tell the user: *"Stack up at <URL>. CLI in this folder is now connected — token is in your keychain alongside any other instances you've logged into."*
+2. Tell the user: *"Stack up at <URL>. CLI in this folder is now connected with an ephemeral dev-stack session; no browser login needed."*
 
 On `./debug.sh down`, run:
 
 ```bash
-bifrost logout --url <URL>
+bifrost logout --url <URL> --yes
 ```
 
-That removes the keychain entry and prompts to remove the matching `BIFROST_API_URL` line from `.env`.
+That removes any matching persistent entry and the matching `BIFROST_API_URL` line from `.env`. If password-grant login wrote token lines, remove `BIFROST_ACCESS_TOKEN` and `BIFROST_REFRESH_TOKEN` from `.env` as well, or delete `.env` if it only contains Bifrost debug credentials.
 
-### When to use password-grant instead
+### When to use browser login instead
 
-If the user wants tokens that *don't* persist anywhere — POC folders, throwaway sessions — use the password-grant path:
+For a long-lived prod or staging instance with MFA enabled, use the browser device-code path:
 
 ```bash
-bifrost login --url <URL> --email <EMAIL_FROM_DEBUG_STATUS> --password <PASSWORD_FROM_DEBUG_STATUS>
+bifrost login --url <URL>
 ```
 
-This prints three `BIFROST_*` lines to stdout and writes nothing to disk. The caller can `eval` them or pipe them into `.env`. Only works on instances with `BIFROST_MFA_ENABLED=false`. Do not suggest this as the default — it exists for the "leave no trace" use case.
+That opens the device-code page, the user accepts, and the token lands in the keychain (or JSON fallback on headless Linux). Do not use this as the default for local debug stacks; it needlessly blocks unattended agents.
 
 ## Lifecycle: who tears down what
 

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -391,12 +391,7 @@ def logout_flow(api_url: str | None = None) -> tuple[bool, str | None]:
     creds = credentials.get_credentials(api_url)
     if creds:
         target_url = (creds.get("api_url") or api_url or "").rstrip("/")
-        had_persistent = credentials.get_persistent_backend().get(target_url) is not None
-        had_dotenv_tokens = credentials._get_cwd_dotenv_credentials(target_url) is not None
         credentials.clear_credentials(target_url)
-        if had_dotenv_tokens and not had_persistent:
-            _remove_env_url_line(target_url)
-            _remove_env_keys({"BIFROST_ACCESS_TOKEN", "BIFROST_REFRESH_TOKEN"})
         print(f"Logged out from {target_url}.")
         return True, target_url
     print("No active session found.")

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -498,6 +498,29 @@ def _remove_env_url_line(api_url: str) -> bool:
     return True
 
 
+def _remove_env_keys(keys: set[str]) -> bool:
+    """Remove KEY= or export KEY= lines from CWD's .env."""
+    env_path = pathlib.Path.cwd() / ".env"
+    lines = _read_env_file(env_path)
+    if not lines:
+        return False
+    kept: list[str] = []
+    removed = False
+    for line in lines:
+        stripped = line.lstrip()
+        if any(stripped.startswith(f"{key}=") or stripped.startswith(f"export {key}=") for key in keys):
+            removed = True
+            continue
+        kept.append(line)
+    if not removed:
+        return False
+    if all(not line.strip() for line in kept):
+        env_path.unlink()
+    else:
+        env_path.write_text("".join(kept))
+    return True
+
+
 def main(args: list[str] | None = None) -> int:
     """
     Main CLI entry point.
@@ -754,26 +777,26 @@ Examples:
         assert password is not None
         rc, data = asyncio.run(password_login_flow(api_url, email, password))
         if rc == 0 and data is not None:
-            expires_at = datetime.now(timezone.utc) + timedelta(
-                seconds=data.get("expires_in", 1800)
-            )
-            credentials.save_credentials(
-                api_url=api_url,
-                access_token=data["access_token"],
-                refresh_token=data["refresh_token"],
-                expires_at=expires_at.isoformat(),
-            )
-            # Persist only the target URL to CWD's .env. Tokens belong in the
-            # credential backend, never in a project directory.
+            # Persist URL + tokens to CWD's .env so subsequent `bifrost`
+            # commands from this directory just work — no shell-eval needed.
+            # Isolation is by directory: each sandbox dir has its own .env.
             try:
                 _write_env_url(api_url)
+                _upsert_env_vars(
+                    {
+                        "BIFROST_ACCESS_TOKEN": data["access_token"],
+                        "BIFROST_REFRESH_TOKEN": data["refresh_token"],
+                    }
+                )
             except OSError as e:
                 print(
                     f"Warning: could not update .env in current directory: {e}",
                     file=sys.stderr,
                 )
-                # Fall back to printing the non-secret URL only.
+                # Fall back to printing so the caller can eval them.
                 print(f"BIFROST_API_URL={api_url}")
+                print(f"BIFROST_ACCESS_TOKEN={data['access_token']}")
+                print(f"BIFROST_REFRESH_TOKEN={data['refresh_token']}")
         return rc
 
     # Browser device-code flow (persistent → keychain or JSON fallback).
@@ -871,6 +894,8 @@ Examples:
     if confirm in ("y", "yes"):
         if _remove_env_url_line(target_url):
             print(f"Removed BIFROST_API_URL line from {env_path}")
+        if _remove_env_keys({"BIFROST_ACCESS_TOKEN", "BIFROST_REFRESH_TOKEN"}):
+            print(f"Removed BIFROST token lines from {env_path}")
     return 0
 
 

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -814,6 +814,7 @@ Examples:
         resolved_url = "http://localhost:8000"
     try:
         _write_env_url(resolved_url)
+        _remove_env_keys({"BIFROST_ACCESS_TOKEN", "BIFROST_REFRESH_TOKEN"})
     except OSError as e:
         print(f"Warning: could not update .env in current directory: {e}", file=sys.stderr)
     return 0

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -26,6 +26,7 @@ import time
 import webbrowser
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -389,8 +390,13 @@ def logout_flow(api_url: str | None = None) -> tuple[bool, str | None]:
     """
     creds = credentials.get_credentials(api_url)
     if creds:
-        target_url = creds.get("api_url") or api_url
+        target_url = (creds.get("api_url") or api_url or "").rstrip("/")
+        had_persistent = credentials.get_persistent_backend().get(target_url) is not None
+        had_dotenv_tokens = credentials._get_cwd_dotenv_credentials(target_url) is not None
         credentials.clear_credentials(target_url)
+        if had_dotenv_tokens and not had_persistent:
+            _remove_env_url_line(target_url)
+            _remove_env_keys({"BIFROST_ACCESS_TOKEN", "BIFROST_REFRESH_TOKEN"})
         print(f"Logged out from {target_url}.")
         return True, target_url
     print("No active session found.")
@@ -468,38 +474,8 @@ def _write_env_url(api_url: str) -> None:
             pass
 
 
-def _remove_env_url_line(api_url: str) -> bool:
-    """
-    Remove a `BIFROST_API_URL=<api_url>` line from CWD's .env, if present.
-
-    Returns True if a line was removed.
-    """
-    env_path = pathlib.Path.cwd() / ".env"
-    lines = _read_env_file(env_path)
-    if not lines:
-        return False
-    target = api_url.rstrip("/")
-    kept: list[str] = []
-    removed = False
-    for line in lines:
-        stripped = line.lstrip()
-        if stripped.startswith("BIFROST_API_URL=") or stripped.startswith("export BIFROST_API_URL="):
-            value = line.split("=", 1)[1].strip().strip('"').strip("'").rstrip("/")
-            if value == target:
-                removed = True
-                continue
-        kept.append(line)
-    if not removed:
-        return False
-    if all(not line.strip() for line in kept):
-        env_path.unlink()
-    else:
-        env_path.write_text("".join(kept))
-    return True
-
-
-def _remove_env_keys(keys: set[str]) -> bool:
-    """Remove KEY= or export KEY= lines from CWD's .env."""
+def _rewrite_env_file(should_remove_line: Callable[[str], bool]) -> bool:
+    """Remove matching lines from CWD's .env. Returns True if any line was removed."""
     env_path = pathlib.Path.cwd() / ".env"
     lines = _read_env_file(env_path)
     if not lines:
@@ -507,8 +483,7 @@ def _remove_env_keys(keys: set[str]) -> bool:
     kept: list[str] = []
     removed = False
     for line in lines:
-        stripped = line.lstrip()
-        if any(stripped.startswith(f"{key}=") or stripped.startswith(f"export {key}=") for key in keys):
+        if should_remove_line(line):
             removed = True
             continue
         kept.append(line)
@@ -519,6 +494,37 @@ def _remove_env_keys(keys: set[str]) -> bool:
     else:
         env_path.write_text("".join(kept))
     return True
+
+
+def _remove_env_url_line(api_url: str) -> bool:
+    """
+    Remove a `BIFROST_API_URL=<api_url>` line from CWD's .env, if present.
+
+    Returns True if a line was removed.
+    """
+    target = api_url.rstrip("/")
+
+    def should_remove(line: str) -> bool:
+        stripped = line.lstrip()
+        if stripped.startswith("BIFROST_API_URL=") or stripped.startswith("export BIFROST_API_URL="):
+            value = line.split("=", 1)[1].strip().strip('"').strip("'").rstrip("/")
+            return value == target
+        return False
+
+    return _rewrite_env_file(should_remove)
+
+
+def _remove_env_keys(keys: set[str]) -> bool:
+    """Remove KEY= or export KEY= lines from CWD's .env."""
+
+    def should_remove(line: str) -> bool:
+        stripped = line.lstrip()
+        return any(
+            stripped.startswith(f"{key}=") or stripped.startswith(f"export {key}=")
+            for key in keys
+        )
+
+    return _rewrite_env_file(should_remove)
 
 
 def main(args: list[str] | None = None) -> int:

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 # Global client injection for platform mode
 _injected_client: Optional["BifrostClient"] = None
+_last_refreshed_env_credentials: dict[str, str] | None = None
 
 # Retry config for transient 5xx — see workstream E of issue #171.
 # SDK is machine-to-machine, so the retry budget is more generous than
@@ -139,12 +140,19 @@ async def refresh_tokens() -> bool:
     Returns:
         True if refresh successful, False otherwise
     """
+    global _last_refreshed_env_credentials
+
     creds = get_credentials()
     if not creds:
         return False
 
     api_url = creds["api_url"]
     refresh_token = creds["refresh_token"]
+    is_env_sourced = (
+        os.environ.get("BIFROST_API_URL", "").rstrip("/") == api_url.rstrip("/")
+        and os.environ.get("BIFROST_ACCESS_TOKEN") == creds.get("access_token")
+        and os.environ.get("BIFROST_REFRESH_TOKEN") == refresh_token
+    )
 
     try:
         async with httpx.AsyncClient(
@@ -163,13 +171,18 @@ async def refresh_tokens() -> bool:
             # Calculate expiry time (30 minutes from now)
             expires_at = datetime.now(timezone.utc) + timedelta(seconds=data.get("expires_in", 1800))
 
-            # Save new credentials
-            save_credentials(
-                api_url=api_url,
-                access_token=data["access_token"],
-                refresh_token=data["refresh_token"],
-                expires_at=expires_at.isoformat(),
-            )
+            refreshed = {
+                "api_url": api_url,
+                "access_token": data["access_token"],
+                "refresh_token": data["refresh_token"],
+                "expires_at": expires_at.isoformat(),
+            }
+
+            if is_env_sourced:
+                _last_refreshed_env_credentials = refreshed
+            else:
+                _last_refreshed_env_credentials = None
+                save_credentials(**refreshed)
 
             return True
     except Exception:
@@ -494,7 +507,12 @@ class BifrostClient:
     async def _refresh_and_update(self) -> bool:
         """Refresh tokens and update this client's auth headers."""
         if await refresh_tokens():
-            creds = get_credentials()
+            creds = (
+                _last_refreshed_env_credentials
+                if _last_refreshed_env_credentials
+                and _last_refreshed_env_credentials["api_url"].rstrip("/") == self.api_url
+                else get_credentials()
+            )
             if creds:
                 self._access_token = creds["access_token"]
                 # Force new async client on next request (with new token)

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -22,6 +22,7 @@ import httpx
 
 from .credentials import (
     clear_credentials,
+    credentials_are_ephemeral,
     get_credentials,
     is_token_expired,
     load_allowed_dotenv,
@@ -147,12 +148,15 @@ async def refresh_tokens() -> bool:
         return False
 
     api_url = creds["api_url"]
-    refresh_token = creds["refresh_token"]
-    is_env_sourced = (
-        os.environ.get("BIFROST_API_URL", "").rstrip("/") == api_url.rstrip("/")
-        and os.environ.get("BIFROST_ACCESS_TOKEN") == creds.get("access_token")
-        and os.environ.get("BIFROST_REFRESH_TOKEN") == refresh_token
-    )
+    if (
+        _last_refreshed_env_credentials
+        and _last_refreshed_env_credentials["api_url"].rstrip("/") == api_url.rstrip("/")
+    ):
+        refresh_token = _last_refreshed_env_credentials["refresh_token"]
+        is_env_sourced = True
+    else:
+        refresh_token = creds["refresh_token"]
+        is_env_sourced = credentials_are_ephemeral(api_url)
 
     try:
         async with httpx.AsyncClient(

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -325,6 +325,47 @@ def _reset_persistent_backend_for_tests() -> None:
 # Public functions
 # --------------------------------------------------------------------------- #
 
+def _read_cwd_dotenv_values() -> dict[str, str | None]:
+    try:
+        from dotenv import dotenv_values
+    except ImportError:
+        return {}
+    path = Path.cwd() / ".env"
+    if not path.exists():
+        return {}
+    return dotenv_values(path) or {}
+
+
+def _resolve_url_from_cwd_dotenv() -> str | None:
+    url = (_read_cwd_dotenv_values().get("BIFROST_API_URL") or "").rstrip("/")
+    return url or None
+
+
+def _get_cwd_dotenv_credentials(api_url: str) -> Credentials | None:
+    values = _read_cwd_dotenv_values()
+    env_url = (values.get("BIFROST_API_URL") or "").rstrip("/")
+    if not env_url or env_url != api_url.rstrip("/"):
+        return None
+    access = values.get("BIFROST_ACCESS_TOKEN") or ""
+    refresh = values.get("BIFROST_REFRESH_TOKEN") or ""
+    if not access or not refresh:
+        return None
+    return Credentials(
+        api_url=env_url,
+        access_token=access,
+        refresh_token=refresh,
+        expires_at="2099-01-01T00:00:00+00:00",
+    )
+
+
+def credentials_are_ephemeral(api_url: str) -> bool:
+    """Return True when credentials for api_url come from env vars or CWD .env only."""
+    url = api_url.rstrip("/")
+    if get_persistent_backend().get(url) is not None:
+        return False
+    return EnvBackend().get(url) is not None or _get_cwd_dotenv_credentials(url) is not None
+
+
 def _resolve_url(api_url: str | None) -> str | None:
     """
     Resolve which URL the no-arg credentials calls should target.
@@ -332,7 +373,8 @@ def _resolve_url(api_url: str | None) -> str | None:
     Order:
       1. The argument (if given).
       2. BIFROST_API_URL env var.
-      3. The first URL in the persistent backend (back-compat for users
+      3. BIFROST_API_URL in CWD .env (password-grant ephemeral sessions).
+      4. The first URL in the persistent backend (back-compat for users
          who only have one set; ordering is stable per backend but not
          guaranteed across backends).
     """
@@ -341,6 +383,9 @@ def _resolve_url(api_url: str | None) -> str | None:
     env_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
     if env_url:
         return env_url
+    cwd_url = _resolve_url_from_cwd_dotenv()
+    if cwd_url:
+        return cwd_url
     urls = get_persistent_backend().list_urls()
     if urls:
         return urls[0]
@@ -405,8 +450,9 @@ def get_credentials(api_url: str | None = None) -> dict | None:
 
     Resolution order:
       1. Env vars (EnvBackend) — for ephemeral sessions.
-      2. Persistent backend (keychain or JSON) — for long-lived sessions.
-      3. Legacy single-record JSON — lazily migrated.
+      2. CWD .env file — for password-grant ephemeral sessions.
+      3. Persistent backend (keychain or JSON) — for long-lived sessions.
+      4. Legacy single-record JSON — lazily migrated.
 
     If api_url is None, the URL is resolved via _resolve_url(). When even
     that fails, we fall through to the legacy file as a last resort to
@@ -430,12 +476,17 @@ def get_credentials(api_url: str | None = None) -> dict | None:
     if env_creds is not None:
         return env_creds.to_dict()
 
-    # 2. Persistent backend
+    # 2. CWD .env (password-grant ephemeral sessions)
+    dotenv_creds = _get_cwd_dotenv_credentials(resolved)
+    if dotenv_creds is not None:
+        return dotenv_creds.to_dict()
+
+    # 3. Persistent backend
     creds = get_persistent_backend().get(resolved)
     if creds is not None:
         return creds.to_dict()
 
-    # 3. Legacy fallback (and migrate if found)
+    # 4. Legacy fallback (and migrate if found)
     legacy = _try_migrate_legacy()
     if legacy is not None and legacy.api_url.rstrip("/") == resolved:
         return legacy.to_dict()

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -368,14 +368,15 @@ def credentials_are_ephemeral(api_url: str) -> bool:
     return False
 
 
-def _resolve_url(api_url: str | None) -> str | None:
+def _resolve_url(api_url: str | None, *, include_cwd_dotenv: bool = False) -> str | None:
     """
     Resolve which URL the no-arg credentials calls should target.
 
     Order:
       1. The argument (if given).
       2. BIFROST_API_URL env var.
-      3. BIFROST_API_URL in CWD .env (password-grant ephemeral sessions).
+      3. BIFROST_API_URL in CWD .env when explicitly requested
+         (password-grant ephemeral sessions).
       4. The first URL in the persistent backend (back-compat for users
          who only have one set; ordering is stable per backend but not
          guaranteed across backends).
@@ -385,9 +386,10 @@ def _resolve_url(api_url: str | None) -> str | None:
     env_url = os.environ.get("BIFROST_API_URL", "").rstrip("/")
     if env_url:
         return env_url
-    cwd_url = _resolve_url_from_cwd_dotenv()
-    if cwd_url:
-        return cwd_url
+    if include_cwd_dotenv:
+        cwd_url = _resolve_url_from_cwd_dotenv()
+        if cwd_url:
+            return cwd_url
     urls = get_persistent_backend().list_urls()
     if urls:
         return urls[0]
@@ -464,7 +466,7 @@ def get_credentials(api_url: str | None = None) -> dict | None:
     or None. Returns dict (not Credentials) for back-compat with existing
     callers in client.py / cli.py.
     """
-    resolved = _resolve_url(api_url)
+    resolved = _resolve_url(api_url, include_cwd_dotenv=True)
 
     if resolved is None:
         # No URL anywhere; try legacy file as last resort to learn one.
@@ -520,7 +522,7 @@ def clear_credentials(api_url: str | None = None) -> None:
     targets the same record `get_credentials()` would have returned, even
     when multiple URLs are present.
     """
-    target = _resolve_url(api_url)
+    target = _resolve_url(api_url, include_cwd_dotenv=True)
     if target is None:
         return
     get_persistent_backend().clear(target)

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -5,10 +5,12 @@ Multi-record credential storage for the CLI. Supports per-URL credentials
 across multiple Bifrost instances simultaneously, with three backends:
 
 - EnvBackend (read-only): BIFROST_API_URL + BIFROST_ACCESS_TOKEN + BIFROST_REFRESH_TOKEN
+- CWD .env (read-only): password-grant ephemeral sessions for this directory
 - KeyringBackend: OS-native credential storage via the `keyring` library
 - JsonBackend: ~/.bifrost/credentials.json as a dict-of-URLs
 
-Resolution order: env vars → persistent (keychain or JSON) → legacy single-record JSON.
+Resolution order for credentials: env vars → CWD .env → persistent
+(keychain or JSON) → legacy single-record JSON.
 """
 
 import json

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -361,9 +361,11 @@ def _get_cwd_dotenv_credentials(api_url: str) -> Credentials | None:
 def credentials_are_ephemeral(api_url: str) -> bool:
     """Return True when credentials for api_url come from env vars or CWD .env only."""
     url = api_url.rstrip("/")
-    if get_persistent_backend().get(url) is not None:
-        return False
-    return EnvBackend().get(url) is not None or _get_cwd_dotenv_credentials(url) is not None
+    if EnvBackend().get(url) is not None:
+        return True
+    if _get_cwd_dotenv_credentials(url) is not None:
+        return True
+    return False
 
 
 def _resolve_url(api_url: str | None) -> str | None:

--- a/api/tests/e2e/platform/test_cli_ephemeral_login.py
+++ b/api/tests/e2e/platform/test_cli_ephemeral_login.py
@@ -94,6 +94,7 @@ def test_ephemeral_login_round_trip(e2e_api_url, tmp_path):
     child_env.update(env_lines)
     result2 = subprocess.run(
         _bifrost_cli() + ["api", "GET", "/api/integrations"],
+        cwd=tmp_path,
         env=child_env,
         capture_output=True,
         text=True,

--- a/api/tests/e2e/platform/test_cli_ephemeral_login.py
+++ b/api/tests/e2e/platform/test_cli_ephemeral_login.py
@@ -34,8 +34,8 @@ def _bifrost_cli() -> list[str]:
     return [sys.executable, "-m", "bifrost"]
 
 
-def test_ephemeral_login_round_trip(e2e_api_url):
-    """Full path: password-grant login, parse env-style output, use tokens via env vars in a child `bifrost api` call.
+def test_ephemeral_login_round_trip(e2e_api_url, tmp_path):
+    """Full path: password-grant login writes .env, then those tokens authenticate `bifrost api`.
 
     Skips if the test stack has global MFA enabled (the default), since
     the password path by design refuses on instances with MFA on. Run with
@@ -62,6 +62,7 @@ def test_ephemeral_login_round_trip(e2e_api_url):
             "--password", password,
             "--url", e2e_api_url,
         ],
+        cwd=tmp_path,
         capture_output=True,
         text=True,
         timeout=30,
@@ -70,9 +71,14 @@ def test_ephemeral_login_round_trip(e2e_api_url):
         f"login failed: stdout={result.stdout!r} stderr={result.stderr!r}"
     )
 
-    # Step 2: parse the three BIFROST_* lines.
+    assert "BIFROST_ACCESS_TOKEN=" not in result.stdout
+    assert "BIFROST_REFRESH_TOKEN=" not in result.stdout
+
+    # Step 2: parse the three BIFROST_* lines from CWD .env.
+    env_path = tmp_path / ".env"
+    assert env_path.exists(), f"login did not write {env_path}"
     env_lines = {}
-    for line in result.stdout.splitlines():
+    for line in env_path.read_text().splitlines():
         if "=" in line and line.startswith("BIFROST_"):
             k, _, v = line.partition("=")
             env_lines[k] = v

--- a/api/tests/unit/sdk/test_client_injection.py
+++ b/api/tests/unit/sdk/test_client_injection.py
@@ -163,3 +163,51 @@ class TestClientInjection:
             assert callable(client.close)
         finally:
             await client.close()
+
+
+
+class TestEnvCredentialRefresh:
+    @pytest.mark.asyncio
+    async def test_401_refresh_updates_env_sourced_client_without_persisting(self, monkeypatch):
+        """Env-backed sessions refresh the active client without writing keychain/JSON."""
+        from bifrost import client as client_mod
+
+        monkeypatch.setenv("BIFROST_API_URL", "http://localhost:38421")
+        monkeypatch.setenv("BIFROST_ACCESS_TOKEN", "old_access")
+        monkeypatch.setenv("BIFROST_REFRESH_TOKEN", "old_refresh")
+
+        saved = []
+
+        class StubResponse:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "access_token": "new_access",
+                    "refresh_token": "new_refresh",
+                    "expires_in": 1800,
+                }
+
+        class StubAsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def post(self, path, json=None):
+                assert path == "/auth/refresh"
+                assert json == {"refresh_token": "old_refresh"}
+                return StubResponse()
+
+        monkeypatch.setattr(client_mod.httpx, "AsyncClient", StubAsyncClient)
+        monkeypatch.setattr(client_mod, "save_credentials", lambda **kwargs: saved.append(kwargs))
+
+        client = client_mod.BifrostClient("http://localhost:38421", "old_access")
+        assert await client._refresh_and_update()
+        assert saved == []
+        assert client._access_token == "new_access"
+        assert client._sync_http.headers["Authorization"] == "Bearer new_access"

--- a/api/tests/unit/test_cli_login_ephemeral.py
+++ b/api/tests/unit/test_cli_login_ephemeral.py
@@ -359,6 +359,37 @@ class TestLogoutClearsKeychainAndPromptsEnv:
         assert rc == 0
         assert (tmp_path / ".env").read_text() == "BIFROST_API_URL=https://prod.example.com\n"
 
+    def test_logout_no_prompt_leaves_dotenv_only_session_alone(self, monkeypatch, tmp_path):
+        """Password-grant sessions live only in CWD .env — logout must honor --no-prompt."""
+        from bifrost import credentials as creds_mod
+
+        monkeypatch.setattr(
+            creds_mod,
+            "get_credentials_path",
+            lambda: tmp_path / "credentials.json",
+        )
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.delenv("BIFROST_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("BIFROST_REFRESH_TOKEN", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        env_before = (
+            "BIFROST_API_URL=https://prod.example.com\n"
+            "BIFROST_ACCESS_TOKEN=secret-at\n"
+            "BIFROST_REFRESH_TOKEN=secret-rt\n"
+        )
+        (tmp_path / ".env").write_text(env_before)
+
+        rc = cli.handle_logout([
+            "--url", "https://prod.example.com",
+            "--no-prompt",
+        ])
+        assert rc == 0
+        assert (tmp_path / ".env").read_text() == env_before
+
 
 class TestAuthList:
     def test_auth_list_with_no_credentials(self, monkeypatch, tmp_path, capsys):

--- a/api/tests/unit/test_cli_login_ephemeral.py
+++ b/api/tests/unit/test_cli_login_ephemeral.py
@@ -239,6 +239,28 @@ class TestBrowserLoginWritesEnv:
         gi = (tmp_path / ".gitignore").read_text()
         assert gi.count(".env") == 1
 
+    def test_browser_login_removes_stale_password_grant_tokens(self, monkeypatch, tmp_path):
+        async def fake_login(api_url=None, auto_open=True):
+            return True
+
+        monkeypatch.setattr(cli, "login_flow", fake_login)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            "OTHER_VAR=keep-me\n"
+            "BIFROST_API_URL=https://old.example.com\n"
+            "BIFROST_ACCESS_TOKEN=stale-at\n"
+            "BIFROST_REFRESH_TOKEN=stale-rt\n"
+        )
+
+        rc = cli.handle_login(["--url", "https://prod.example.com"])
+
+        assert rc == 0
+        env_text = (tmp_path / ".env").read_text()
+        assert "OTHER_VAR=keep-me" in env_text
+        assert "BIFROST_API_URL=https://prod.example.com" in env_text
+        assert "BIFROST_ACCESS_TOKEN=" not in env_text
+        assert "BIFROST_REFRESH_TOKEN=" not in env_text
+
     def test_does_not_write_env_when_browser_login_fails(self, monkeypatch, tmp_path):
         async def fake_login(api_url=None, auto_open=True):
             return False
@@ -362,7 +384,6 @@ class TestLogoutClearsKeychainAndPromptsEnv:
     def test_logout_no_prompt_leaves_dotenv_only_session_alone(self, monkeypatch, tmp_path):
         """Password-grant sessions live only in CWD .env — logout must honor --no-prompt."""
         from bifrost import credentials as creds_mod
-
         monkeypatch.setattr(
             creds_mod,
             "get_credentials_path",

--- a/api/tests/unit/test_cli_login_ephemeral.py
+++ b/api/tests/unit/test_cli_login_ephemeral.py
@@ -64,25 +64,15 @@ class TestPasswordLoginFlagParsing:
 
 
 class TestPasswordLoginSuccess:
-    def test_writes_url_only_to_env_and_credentials_to_backend(
+    def test_writes_three_vars_to_env_and_warning_to_stderr(
         self, capsys, monkeypatch, tmp_path,
     ):
-        from bifrost import credentials as creds_mod
-
         stub = _stub_post({
             "access_token": "at_value",
             "refresh_token": "rt_value",
             "expires_in": 1800,
         })
         monkeypatch.setattr("httpx.AsyncClient", stub)
-        monkeypatch.setattr(
-            creds_mod,
-            "get_credentials_path",
-            lambda: tmp_path / "credentials.json",
-        )
-        creds_mod._reset_persistent_backend_for_tests()
-        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
-        creds_mod._reset_persistent_backend_for_tests()
         monkeypatch.chdir(tmp_path)
 
         rc = cli.handle_login([
@@ -94,21 +84,17 @@ class TestPasswordLoginSuccess:
 
         env_text = (tmp_path / ".env").read_text()
         assert "BIFROST_API_URL=http://localhost:38421" in env_text
-        assert "BIFROST_ACCESS_TOKEN" not in env_text
-        assert "BIFROST_REFRESH_TOKEN" not in env_text
+        assert "BIFROST_ACCESS_TOKEN=at_value" in env_text
+        assert "BIFROST_REFRESH_TOKEN=rt_value" in env_text
 
-        saved = creds_mod.get_credentials("http://localhost:38421")
-        assert saved is not None
-        assert saved["access_token"] == "at_value"
-        assert saved["refresh_token"] == "rt_value"
-
-        # Warning to stderr
         captured = capsys.readouterr()
+        assert "BIFROST_ACCESS_TOKEN=" not in captured.out
+        assert "BIFROST_REFRESH_TOKEN=" not in captured.out
         assert "MFA" in captured.err
         assert "ephemeral" in captured.err.lower()
 
-    def test_does_not_write_tokens_to_cwd_env(self, capsys, monkeypatch, tmp_path):
-        """Password-grant tokens must not be stored in a project directory."""
+    def test_does_not_write_to_keychain(self, capsys, monkeypatch, tmp_path):
+        """Password-grant must not touch the persistent (keychain/JSON) store."""
         from bifrost import credentials as creds_mod
 
         stub = _stub_post({
@@ -132,10 +118,8 @@ class TestPasswordLoginSuccess:
             "--url", "http://localhost:38421",
         ])
 
-        env_text = (tmp_path / ".env").read_text()
-        assert "BIFROST_API_URL=http://localhost:38421" in env_text
-        assert "BIFROST_ACCESS_TOKEN" not in env_text
-        assert "BIFROST_REFRESH_TOKEN" not in env_text
+        assert not (tmp_path / "credentials.json").exists()
+        assert (tmp_path / ".env").exists()
 
 
 class TestPasswordLoginMfaRefusal:
@@ -319,6 +303,38 @@ class TestLogoutClearsKeychainAndPromptsEnv:
         env_text = (tmp_path / ".env").read_text()
         assert "OTHER_VAR=keep-me" in env_text
         assert "BIFROST_API_URL=" not in env_text
+
+    def test_logout_yes_removes_password_grant_token_lines(self, monkeypatch, tmp_path):
+        from bifrost import credentials as creds_mod
+        monkeypatch.setattr(
+            creds_mod,
+            "get_credentials_path",
+            lambda: tmp_path / "credentials.json",
+        )
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.setattr(creds_mod, "_select_persistent_backend", creds_mod.JsonBackend)
+        creds_mod._reset_persistent_backend_for_tests()
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        creds_mod.save_credentials("https://prod.example.com", "at", "rt", "2099-01-01T00:00:00+00:00")
+        (tmp_path / ".env").write_text(
+            "OTHER_VAR=keep-me\n"
+            "BIFROST_API_URL=https://prod.example.com\n"
+            "BIFROST_ACCESS_TOKEN=secret-at\n"
+            "BIFROST_REFRESH_TOKEN=secret-rt\n"
+        )
+
+        rc = cli.handle_logout([
+            "--url", "https://prod.example.com",
+            "--yes",
+        ])
+        assert rc == 0
+        env_text = (tmp_path / ".env").read_text()
+        assert "OTHER_VAR=keep-me" in env_text
+        assert "BIFROST_API_URL=" not in env_text
+        assert "BIFROST_ACCESS_TOKEN=" not in env_text
+        assert "BIFROST_REFRESH_TOKEN=" not in env_text
 
     def test_logout_no_prompt_leaves_env_alone(self, monkeypatch, tmp_path):
         from bifrost import credentials as creds_mod


### PR DESCRIPTION
## Summary
- default debug-stack CLI auth to password-grant sessions that write per-directory `.env` credentials
- keep password-grant refreshes in-process instead of persisting rotated tokens to keychain/JSON stores
- make logout `--yes` remove password-grant token lines, and update tests/debug guidance for unattended agents

## Validation
- `py -3 -m ruff check api/bifrost/client.py api/bifrost/cli.py api/tests/unit/sdk/test_client_injection.py api/tests/unit/test_cli_login_ephemeral.py api/tests/e2e/platform/test_cli_ephemeral_login.py`
- `PYTHONPATH=api py -3 -m pytest api/tests/unit/test_cli_login_ephemeral.py api/tests/unit/sdk/test_client_injection.py -v` (`26 passed, 2 warnings`)
- pve-t340/codex-vm-netbird stock MFA-on E2E: `tests/e2e/platform/test_cli_ephemeral_login.py -v` (`2 passed, 1 skipped`)
- pve-t340/codex-vm-netbird MFA-off positive password-grant E2E: `test_ephemeral_login_round_trip` (`1 passed`)

## Notes
- VM test stack was restored to MFA-on and torn down after validation; teardown completed with log-export permission warnings only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication storage and refresh behavior (tokens in project `.env`, refresh not written back to disk); scoped to dev/ephemeral paths but affects how the CLI resolves and rotates credentials.
> 
> **Overview**
> **Debug and agent workflows** now treat **password-grant** `bifrost login` as the default for local debug stacks: credentials land in the **current directory’s `.env`** (`BIFROST_API_URL`, access, and refresh tokens) so later CLI commands work without browser or keychain setup. The **bifrost-debug** skill documents that flow and recommends `bifrost logout --url … --yes` to strip URL and token lines from `.env`.
> 
> **Credential resolution** adds **CWD `.env`** (after process env, before keychain/JSON). Password-grant login **no longer** writes to the persistent store; browser login still uses the keychain but **removes stale** `BIFROST_ACCESS_TOKEN` / `BIFROST_REFRESH_TOKEN` lines from `.env`. **Token refresh** for env- or `.env`-sourced sessions updates tokens **in memory only** (not keychain or `.env` on disk). **Logout** can remove those token lines when the user confirms (or with `--yes`).
> 
> Tests and e2e coverage were updated for `.env` persistence, logout cleanup, and non-persisting refresh for ephemeral auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43703af3789f71f568703dfc7f78748c6abfb6af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ephemeral credential sessions now store authentication tokens directly in the local environment file instead of persistent keychain storage, enabling cleaner development workflows.

* **Bug Fixes**
  * Logout functionality now properly removes all credential-related tokens from the local environment file while preserving other settings.

* **Documentation**
  * Updated development workflow documentation to reflect the new authentication flow and local environment-based token persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->