### PR TITLE
docs: add right-sized delivery lanes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,19 @@ Match verification to the change (see `CLAUDE.md` for detail):
 Before calling significant platform work complete, run the relevant checks from `CLAUDE.md` and report anything skipped with the reason.
 
 Use [docs/dev/delivery-lanes.md](docs/dev/delivery-lanes.md) to choose the
-lightest verification and review path that protects the actual risk, including
-[reviewer budget](docs/dev/delivery-lanes.md#reviewer-budget) and
-[Codex-authored PR stewardship](docs/dev/delivery-lanes.md#codex-authored-prs).
-Do not run the full pre-completion matrix for tiny docs, narrow tests, or
-throwaway spikes unless the task specifically depends on stack behavior.
+lightest verification and review path that protects the actual risk. Do not run
+the full pre-completion matrix for tiny docs, narrow tests, or throwaway spikes
+unless the task specifically depends on stack behavior.
+
+Default PR review to one accountable reviewer. Add extra human or AI reviewers
+only for sensitive paths, broad ownership boundaries, unfamiliar code, or
+explicit user request; stacked generic reviewers are delivery drag, not maturity.
+
+For Codex-authored PRs, treat automated review as a velocity-preserving safety
+net. Address concrete correctness, security, auth, execution, deployment, and
+coverage findings; summarize or dismiss duplicated, stale, style-only, or
+scope-expanding bot feedback. Do one focused stewardship pass by default, then a
+second pass only if real defects remain or the user asks.
 
 ## Security And Sensitive Paths
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,21 @@ Match verification to the change (see `CLAUDE.md` for detail):
 
 Before calling significant platform work complete, run the relevant checks from `CLAUDE.md` and report anything skipped with the reason.
 
+Use [docs/dev/delivery-lanes.md](docs/dev/delivery-lanes.md) to choose the
+lightest verification and review path that protects the actual risk. Do not run
+the full pre-completion matrix for tiny docs, narrow tests, or throwaway spikes
+unless the task specifically depends on stack behavior.
+
+Default PR review to one accountable reviewer. Add extra human or AI reviewers
+only for sensitive paths, broad ownership boundaries, unfamiliar code, or
+explicit user request; stacked generic reviewers are delivery drag, not maturity.
+
+For Codex-authored PRs, treat automated review as a velocity-preserving safety
+net. Address concrete correctness, security, auth, execution, deployment, and
+coverage findings; summarize or dismiss duplicated, stale, style-only, or
+scope-expanding bot feedback. Do one focused stewardship pass by default, then a
+second pass only if real defects remain or the user asks.
+
 ## Security And Sensitive Paths
 
 Use extra care around auth, execution, multi-tenancy filters, migrations, secrets, manifest round-trips, and audit logging. Call out sensitive-path changes in summaries and PR descriptions.
@@ -95,6 +110,7 @@ Do not expose secret values in chat, logs, test fixtures, screenshots, or commit
 
 - `CLAUDE.md` — upstream-style platform commands, manifest rules, verification checklist
 - `CONTRIBUTING.md` — human-facing PR expectations, DCO, and governance links
+- [docs/dev/delivery-lanes.md](docs/dev/delivery-lanes.md) — right-sized verification and reviewer budget
 - [GOVERNANCE.md](./GOVERNANCE.md) — maintainer roles, culture, continuity
 - [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) — community standards
 - [docs/security/openssf-best-practices-badge.md](docs/security/openssf-best-practices-badge.md) — BadgeApp tiers and submit flow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,19 +86,11 @@ Match verification to the change (see `CLAUDE.md` for detail):
 Before calling significant platform work complete, run the relevant checks from `CLAUDE.md` and report anything skipped with the reason.
 
 Use [docs/dev/delivery-lanes.md](docs/dev/delivery-lanes.md) to choose the
-lightest verification and review path that protects the actual risk. Do not run
-the full pre-completion matrix for tiny docs, narrow tests, or throwaway spikes
-unless the task specifically depends on stack behavior.
-
-Default PR review to one accountable reviewer. Add extra human or AI reviewers
-only for sensitive paths, broad ownership boundaries, unfamiliar code, or
-explicit user request; stacked generic reviewers are delivery drag, not maturity.
-
-For Codex-authored PRs, treat automated review as a velocity-preserving safety
-net. Address concrete correctness, security, auth, execution, deployment, and
-coverage findings; summarize or dismiss duplicated, stale, style-only, or
-scope-expanding bot feedback. Do one focused stewardship pass by default, then a
-second pass only if real defects remain or the user asks.
+lightest verification and review path that protects the actual risk, including
+[reviewer budget](docs/dev/delivery-lanes.md#reviewer-budget) and
+[Codex-authored PR stewardship](docs/dev/delivery-lanes.md#codex-authored-prs).
+Do not run the full pre-completion matrix for tiny docs, narrow tests, or
+throwaway spikes unless the task specifically depends on stack behavior.
 
 ## Security And Sensitive Paths
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,22 @@ Call it out in the PR description so the reviewer doesn't have to rediscover it.
 
 ## Reviewer budget
 
-See [Reviewer Budget](./docs/dev/delivery-lanes.md#reviewer-budget) and
-[Codex-Authored PRs](./docs/dev/delivery-lanes.md#codex-authored-prs) in the
-delivery lanes doc.
+Use code review to reduce risk, not to collect redundant opinions. Most PRs get
+one accountable reviewer. Add a second reviewer when the change crosses an
+ownership boundary or touches a sensitive path. Use AI/code-review bots when the
+diff is broad, subtle, security-sensitive, or when the author wants another pass.
+
+Skip extra reviewers for small docs, narrow tests, obvious bug fixes, and
+low-risk chores already covered by focused checks. If reviewers disagree, the
+author or maintainer should resolve the decision explicitly instead of waiting
+for every reviewer to converge.
+
+For Codex-authored PRs, automated review is part of the normal authoring loop:
+human prompt, Codex implementation, automated review, Codex stewardship. Keep
+that loop moving. One primary automated reviewer is the default; add another
+only for sensitive paths, broad diffs, unfamiliar subsystems, or targeted second
+opinions. Codex should fix concrete defects and record why stale, duplicate,
+style-only, or scope-expanding suggestions were not followed.
 
 ## How to pick up work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,22 +97,9 @@ Call it out in the PR description so the reviewer doesn't have to rediscover it.
 
 ## Reviewer budget
 
-Use code review to reduce risk, not to collect redundant opinions. Most PRs get
-one accountable reviewer. Add a second reviewer when the change crosses an
-ownership boundary or touches a sensitive path. Use AI/code-review bots when the
-diff is broad, subtle, security-sensitive, or when the author wants another pass.
-
-Skip extra reviewers for small docs, narrow tests, obvious bug fixes, and
-low-risk chores already covered by focused checks. If reviewers disagree, the
-author or maintainer should resolve the decision explicitly instead of waiting
-for every reviewer to converge.
-
-For Codex-authored PRs, automated review is part of the normal authoring loop:
-human prompt, Codex implementation, automated review, Codex stewardship. Keep
-that loop moving. One primary automated reviewer is the default; add another
-only for sensitive paths, broad diffs, unfamiliar subsystems, or targeted second
-opinions. Codex should fix concrete defects and record why stale, duplicate,
-style-only, or scope-expanding suggestions were not followed.
+See [Reviewer Budget](./docs/dev/delivery-lanes.md#reviewer-budget) and
+[Codex-Authored PRs](./docs/dev/delivery-lanes.md#codex-authored-prs) in the
+delivery lanes doc.
 
 ## How to pick up work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,16 @@ enabled.
 
 ## Before you open a PR
 
-- [ ] Dev stack is running (`./debug.sh`) and your change works end-to-end in the browser at `http://localhost:3000`.
-- [ ] Tests exist for the code you changed (see **Testing expectations** below).
-- [ ] `pyright` + `ruff check` pass in `api/`; `npm run tsc` + `npm run lint` pass in `client/`.
+Pick the delivery lane first: [docs/dev/delivery-lanes.md](./docs/dev/delivery-lanes.md).
+Small docs and chores should not pay the same process cost as auth, execution,
+migrations, or live-ops changes.
+
+- [ ] The PR description names the lane or otherwise explains the verification scope.
+- [ ] Tests exist for changed runtime behavior (see **Testing expectations** below).
+- [ ] Relevant targeted checks pass for the touched area.
 - [ ] If you changed `api/shared/models.py` or API contracts, you re-ran `npm run generate:types` in `client/`.
 - [ ] If you touched a sensitive path, you've called it out in the PR description.
+- [ ] For product/API or platform/live-ops lanes, the dev stack or CI has exercised the behavior that matters.
 
 ## Testing expectations
 
@@ -89,6 +94,25 @@ If your change touches any of those, expect:
 - Higher scrutiny on any code path that could cross tenant boundaries, leak secrets, or skip an audit.
 
 Call it out in the PR description so the reviewer doesn't have to rediscover it.
+
+## Reviewer budget
+
+Use code review to reduce risk, not to collect redundant opinions. Most PRs get
+one accountable reviewer. Add a second reviewer when the change crosses an
+ownership boundary or touches a sensitive path. Use AI/code-review bots when the
+diff is broad, subtle, security-sensitive, or when the author wants another pass.
+
+Skip extra reviewers for small docs, narrow tests, obvious bug fixes, and
+low-risk chores already covered by focused checks. If reviewers disagree, the
+author or maintainer should resolve the decision explicitly instead of waiting
+for every reviewer to converge.
+
+For Codex-authored PRs, automated review is part of the normal authoring loop:
+human prompt, Codex implementation, automated review, Codex stewardship. Keep
+that loop moving. One primary automated reviewer is the default; add another
+only for sensitive paths, broad diffs, unfamiliar subsystems, or targeted second
+opinions. Codex should fix concrete defects and record why stale, duplicate,
+style-only, or scope-expanding suggestions were not followed.
 
 ## How to pick up work
 

--- a/docs/dev/delivery-lanes.md
+++ b/docs/dev/delivery-lanes.md
@@ -1,0 +1,125 @@
+# Delivery Lanes
+
+Bifrost needs mature engineering practices, but not every change needs the same
+ceremony. Choose the lightest lane that protects the actual risk, then say what
+you chose in the PR description.
+
+## Lane 1: Tiny And Internal
+
+Use for docs, copy, README/runbook updates, small style-only UI polish, isolated
+test expectation fixes, and low-risk chores with no runtime behavior change.
+
+Expected flow:
+
+- Work in a branch or worktree.
+- Run a format, lint, or targeted check only when it is relevant.
+- Open a PR with a short rationale.
+- Do not boot the dev stack or full test stack unless the change needs it.
+
+Review expectation: one maintainer pass is enough. Extra AI/code reviewers are
+optional and should be skipped when they would only restate obvious style nits.
+
+## Lane 2: Product Or API
+
+Use for endpoints, DTOs, user-visible frontend, generated types, workflow-facing
+code, manifest serialization, CLI/MCP surfaces, and meaningful behavior changes.
+
+Expected flow:
+
+- Work in a branch or worktree.
+- Add or update the narrow tests that cover the changed behavior.
+- Run the targeted backend/client checks for the touched area.
+- Regenerate OpenAPI TypeScript types when API contracts change.
+- Before merge, make sure CI or the equivalent relevant local checks are green.
+
+Review expectation: one human/maintainer review by default. Add a specialist or
+AI review only when the diff is broad, subtle, or crosses an unfamiliar boundary.
+
+## Lane 3: Platform Or Live Operations
+
+Use for auth, execution, tenant isolation, migrations, queues, schedules,
+deployment behavior, secrets, audit logging, infrastructure, and anything that
+can affect live workflow execution or customer data.
+
+Expected flow:
+
+- Work in an isolated worktree.
+- Run the relevant tests and type/lint checks from `CLAUDE.md`.
+- Capture live or VM-backed evidence when the task depends on deployed behavior.
+- Keep read-only inspection separate from live mutation.
+- Call out sensitive paths and rollback/verification notes in the PR.
+
+Review expectation: human review is required. Add extra reviewers only for
+specific risk ownership, such as security, data model, deployment, or execution
+engine behavior. Avoid piling on generic reviewers.
+
+## Lane 4: Spike Or Proof
+
+Use when the goal is to test an idea quickly before deciding whether it should
+be productized.
+
+Expected flow:
+
+- Make the experiment explicitly temporary.
+- Prefer a disposable branch, worktree, script, or draft PR.
+- Prove or disprove the idea with the smallest useful evidence.
+- Convert only the proven, useful part into a separate mergeable PR.
+
+Review expectation: do not treat spike code as production-ready just because it
+exists in git. Review the follow-up production PR, not the throwaway experiment.
+
+## Reviewer Budget
+
+Code review is for risk reduction, not for creating a queue of overlapping
+opinions.
+
+- Default to one accountable reviewer.
+- Add a second reviewer only when the change spans ownership boundaries or a
+  sensitive path.
+- Use AI/code-review bots for broad diffs, unfamiliar code, security-sensitive
+  changes, or when the author explicitly wants another pass.
+- Skip extra reviewers for small docs, narrow tests, obvious bug fixes, and
+  changes already covered by focused tests plus CI.
+- If reviews disagree, the author or maintainer should resolve the decision
+  explicitly instead of waiting for every reviewer to converge.
+
+## Codex-Authored PRs
+
+Many Bifrost PRs are created by a human prompting Codex, Codex writing the code,
+automated code-review agents reviewing it, and Codex stewarding the PR through
+feedback. That loop is useful when it finds real defects and still lets changes
+move. It fails when every PR becomes a long-running bot arbitration exercise.
+
+Use this default:
+
+- Codex opens the PR with the chosen delivery lane, changed-risk summary, and
+  verification already run or intentionally skipped.
+- One primary automated reviewer is enough by default. Prefer the reviewer that
+  tends to catch the risk in the diff: Bugbot-style review for runtime defects,
+  CodeRabbit-style review for broader logic/design review, and static-analysis
+  tools for security/compliance gates.
+- Codex should address concrete correctness, security, data-loss, auth,
+  execution, deployment, and test-coverage findings.
+- Codex should summarize or dismiss duplicated, stale, style-only, or
+  already-covered findings instead of repeatedly rewriting the PR to satisfy
+  every bot suggestion.
+- A second automated reviewer is appropriate for Lane 3 changes, broad Lane 2
+  changes, unfamiliar subsystems, or when the first review finds a serious bug
+  class that deserves a different lens.
+- For large sync or merge PRs, scope automated review by path or concern. A bot
+  saying "too many files" is a signal to narrow the review, not to keep
+  rerunning the same broad pass.
+- For Dependabot and base-image PRs, prefer dependency/security evidence and a
+  build/runtime smoke over generic code-review commentary.
+
+Stewardship budget:
+
+- Do one focused response pass for the primary automated review.
+- Do one follow-up pass after pushed fixes if the reviewer found real defects.
+- Stop and ask the maintainer when feedback becomes repetitive, contradicts
+  project intent, demands unrelated refactors, or would turn a small PR into a
+  larger one.
+
+The goal is to keep enough automated review that the maintainer can trust
+Codex-authored platform changes, while preserving enough velocity that people
+keep making those changes.


### PR DESCRIPTION
## Summary
- Adds delivery lanes so docs, product/API, platform/live-ops, and spike work do not all pay the same process cost.
- Codifies reviewer budget for Codex-authored PRs: one primary automated reviewer by default, targeted second pass only when risk warrants it.
- Updates AGENTS.md and CONTRIBUTING.md so future agents and humans see the policy.

## Delivery lane
Lane 1: Tiny/Internal docs and process policy.

## Verification
- git diff --check
- No Docker/test stack run; this is docs/process-only guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Introduces **delivery lanes** in `docs/dev/delivery-lanes.md` so work is classified by risk (tiny/internal, product/API, platform/live-ops, spike) with matching verification and review expectations instead of one-size-fits-all process.
> 
> **`AGENTS.md`** and **`CONTRIBUTING.md`** now point contributors and agents at that doc: pick the lightest lane, name it in the PR, and avoid full stack/test matrices for docs-only or spike work unless needed. The pre-PR checklist is reframed around lane-scoped verification rather than always requiring a running dev stack and blanket checks.
> 
> Adds **reviewer budget** guidance—default one accountable reviewer, extra humans or bots only when risk warrants—and a **Codex-authored PR** loop (one primary automated review, fix real defects, dismiss duplicate or scope-creeping bot feedback, limited stewardship passes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b049f71ea8dd173d3b50a41eb9948cef93ac752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced formal "delivery lanes" to classify PR scope and required workflow.
  * Revised contribution checklist to require lane selection and align verification steps to lane scope.
  * Added reviewer budget guidance and clarified reviewer expectations, including handling of automated/AI-assisted PRs.
  * Clarified when lightweight verification is appropriate for small docs, narrow tests, or spikes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->