### PR TITLE
chore(release): bump plugin manifests to 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins).",
-  "version": "0.9.2-dev.5",
+  "version": "1.1.0",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/jackmusick/bifrost"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "0.9.2-dev.5",
+  "version": "1.1.0",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
   "author": {
     "name": "Jack Musick",

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "0.9.2-dev.5",
+  "version": "1.1.0",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
   "author": {
     "name": "Jack Musick",


### PR DESCRIPTION
## Summary
- bump Claude/Codex plugin manifests to 1.1.0 before tagging v1.1.0
- keep installed marketplace content aligned with the release tag

## Verification
- manifest-only release prep change
- tag release-check will run after this lands

Docs drift is intentionally deferred to a follow-up per release decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version bumps with no runtime, auth, or application logic changes.
> 
> **Overview**
> Bumps the **`version`** field from **`0.9.2-dev.5`** to **`1.1.0`** in the Claude and Codex plugin manifests (root **`.claude-plugin/plugin.json`**, **`.codex-plugin/plugin.json`**, and **`plugins/bifrost/.codex-plugin/plugin.json`**) so marketplace/plugin installs match the upcoming **v1.1.0** release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8876acbe8c1dc40396c34a0076120b6e6813a241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->