### PR TITLE
ci: publish release images to fork registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  API_IMAGE: jackmusick/bifrost-api
-  CLIENT_IMAGE: jackmusick/bifrost-client
+  API_IMAGE: mtg-thomas/bifrost-api
+  CLIENT_IMAGE: mtg-thomas/bifrost-client
 
 jobs:
   # =============================================================================
@@ -724,7 +724,7 @@ jobs:
             ```bash
             cosign verify-blob \
               --bundle bifrost-${{ steps.get_version.outputs.version }}-source.tar.gz.sigstore \
-              --certificate-identity-regexp 'https://github\.com/jackmusick/bifrost/.*' \
+              --certificate-identity-regexp 'https://github\.com/${{ github.repository }}/.*' \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               bifrost-${{ steps.get_version.outputs.version }}-source.tar.gz
             ```
@@ -733,7 +733,7 @@ jobs:
 
             ```bash
             gh attestation verify bifrost-${{ steps.get_version.outputs.version }}-source.tar.gz \
-              --owner jackmusick
+              --owner ${{ github.repository_owner }}
             ```
 
           draft: false


### PR DESCRIPTION
## Summary
- publish release API/client images to the fork-owned GHCR namespace
- update generated release verification instructions to use the current repository owner

## Verification
- parsed .github/workflows/ci.yml with Python/YAML

## Release note
This unblocks the failed v1.1.0 tag image jobs, which were attempting to push to ghcr.io/jackmusick/* from the MTG fork.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only registry and release-note template changes; no application runtime or auth logic is modified.
> 
> **Overview**
> Points **release and dev image pushes** at the fork-owned GHCR namespace by changing workflow `env` values `API_IMAGE` and `CLIENT_IMAGE` from `jackmusick/*` to `mtg-thomas/*`, so tag builds from the MTG fork can publish images the workflow actor is allowed to push.
> 
> Updates the **generated GitHub release body** so cosign and `gh attestation verify` examples use `${{ github.repository }}` and `${{ github.repository_owner }}` instead of a hardcoded upstream owner, keeping verification instructions aligned with wherever the release was built.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8285dd582ffd57968dc2ffce7add3a140966eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to use dynamic repository information for container images and verification processes, replacing previously hardcoded values. This improves flexibility and consistency across different deployment contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->