### PR TITLE
Add Talos runtime to diagnostics

### DIFF
--- a/api/src/models/contracts/platform.py
+++ b/api/src/models/contracts/platform.py
@@ -116,8 +116,14 @@ class PoolDetail(BaseModel):
 
     worker_id: str
     hostname: str | None = None
-    runtime: str | None = None
-    runtime_label: str | None = None
+    runtime: str | None = Field(
+        default=None,
+        description="Operator/runtime hint for the pool, such as compose, aks, aca, or talos",
+    )
+    runtime_label: str | None = Field(
+        default=None,
+        description="Display label for the pool runtime, when provided by the worker",
+    )
     status: str | None = None
     started_at: str | None = None
     last_heartbeat: str | None = None

--- a/api/src/models/contracts/platform.py
+++ b/api/src/models/contracts/platform.py
@@ -60,6 +60,14 @@ class PoolSummary(BaseModel):
 
     worker_id: str = Field(..., description="Pool identifier (container hostname)")
     hostname: str | None = None
+    runtime: str | None = Field(
+        default=None,
+        description="Operator/runtime hint for the pool, such as compose, aks, aca, or talos",
+    )
+    runtime_label: str | None = Field(
+        default=None,
+        description="Display label for the pool runtime, when provided by the worker",
+    )
     status: str | None = Field(
         default=None,
         description="Pool status: online or offline"
@@ -108,6 +116,8 @@ class PoolDetail(BaseModel):
 
     worker_id: str
     hostname: str | None = None
+    runtime: str | None = None
+    runtime_label: str | None = None
     status: str | None = None
     started_at: str | None = None
     last_heartbeat: str | None = None

--- a/api/src/routers/platform/workers.py
+++ b/api/src/routers/platform/workers.py
@@ -292,8 +292,10 @@ async def list_pools(
                 pool_info.max_workers = hb.get("max_workers", pool_info.configured_capacity)
                 pool_info.idle_count = hb.get("idle_count", 0)
                 pool_info.busy_count = hb.get("busy_count", 0)
-                pool_info.runtime = hb.get("runtime", pool_info.runtime)
-                pool_info.runtime_label = hb.get("runtime_label", pool_info.runtime_label)
+                if (rt := hb.get("runtime")) is not None:
+                    pool_info.runtime = rt
+                if (rtl := hb.get("runtime_label")) is not None:
+                    pool_info.runtime_label = rtl
                 pool_info.last_heartbeat = hb.get("timestamp")
                 pool_info.requirements_installed = hb.get("requirements_installed")
                 pool_info.requirements_total = hb.get("requirements_total")
@@ -356,8 +358,10 @@ async def get_pool(
             result.last_heartbeat = hb.get("timestamp")
             result.configured_capacity = hb.get("configured_capacity", hb.get("max_workers"))
             result.max_workers = hb.get("max_workers", result.configured_capacity)
-            result.runtime = hb.get("runtime", result.runtime)
-            result.runtime_label = hb.get("runtime_label", result.runtime_label)
+            if (rt := hb.get("runtime")) is not None:
+                result.runtime = rt
+            if (rtl := hb.get("runtime_label")) is not None:
+                result.runtime_label = rtl
 
             # Parse process info from heartbeat
             for p in hb.get("processes", []):

--- a/api/src/routers/platform/workers.py
+++ b/api/src/routers/platform/workers.py
@@ -293,7 +293,10 @@ async def list_pools(
                 pool_info.idle_count = hb.get("idle_count", 0)
                 pool_info.busy_count = hb.get("busy_count", 0)
                 if (rt := hb.get("runtime")) is not None:
+                    runtime_changed = rt != pool_info.runtime
                     pool_info.runtime = rt
+                    if runtime_changed and hb.get("runtime_label") is None:
+                        pool_info.runtime_label = None
                 if (rtl := hb.get("runtime_label")) is not None:
                     pool_info.runtime_label = rtl
                 pool_info.last_heartbeat = hb.get("timestamp")
@@ -359,7 +362,10 @@ async def get_pool(
             result.configured_capacity = hb.get("configured_capacity", hb.get("max_workers"))
             result.max_workers = hb.get("max_workers", result.configured_capacity)
             if (rt := hb.get("runtime")) is not None:
+                runtime_changed = rt != result.runtime
                 result.runtime = rt
+                if runtime_changed and hb.get("runtime_label") is None:
+                    result.runtime_label = None
             if (rtl := hb.get("runtime_label")) is not None:
                 result.runtime_label = rtl
 

--- a/api/src/routers/platform/workers.py
+++ b/api/src/routers/platform/workers.py
@@ -274,6 +274,8 @@ async def list_pools(
         pool_info = PoolSummary(
             worker_id=worker_id,
             hostname=data.get("hostname"),
+            runtime=data.get("runtime"),
+            runtime_label=data.get("runtime_label"),
             status=data.get("status"),
             started_at=data.get("started_at"),
         )
@@ -290,6 +292,8 @@ async def list_pools(
                 pool_info.max_workers = hb.get("max_workers", pool_info.configured_capacity)
                 pool_info.idle_count = hb.get("idle_count", 0)
                 pool_info.busy_count = hb.get("busy_count", 0)
+                pool_info.runtime = hb.get("runtime", pool_info.runtime)
+                pool_info.runtime_label = hb.get("runtime_label", pool_info.runtime_label)
                 pool_info.last_heartbeat = hb.get("timestamp")
                 pool_info.requirements_installed = hb.get("requirements_installed")
                 pool_info.requirements_total = hb.get("requirements_total")
@@ -340,6 +344,8 @@ async def get_pool(
     result = PoolDetail(
         worker_id=worker_id,
         hostname=data.get("hostname"),
+        runtime=data.get("runtime"),
+        runtime_label=data.get("runtime_label"),
         status=data.get("status"),
         started_at=data.get("started_at"),
     )
@@ -350,6 +356,8 @@ async def get_pool(
             result.last_heartbeat = hb.get("timestamp")
             result.configured_capacity = hb.get("configured_capacity", hb.get("max_workers"))
             result.max_workers = hb.get("max_workers", result.configured_capacity)
+            result.runtime = hb.get("runtime", result.runtime)
+            result.runtime_label = hb.get("runtime_label", result.runtime_label)
 
             # Parse process info from heartbeat
             for p in hb.get("processes", []):

--- a/client/src/pages/diagnostics/components/ContainerTable.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.tsx
@@ -1,6 +1,6 @@
 // client/src/pages/diagnostics/components/ContainerTable.tsx
 import { Fragment, useState } from "react";
-import { ChevronDown, ChevronRight, Cloud, Server, Boxes } from "lucide-react";
+import { Boxes, ChevronDown, ChevronRight, Cloud, Server } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -24,7 +24,7 @@ import {
 } from "@/components/ui/tooltip";
 
 type PoolData = PoolSummary | PoolDetail;
-type RuntimeKind = "AKS" | "VM" | "ACA" | "Unknown";
+type RuntimeKind = "AKS" | "VM" | "ACA" | "Talos" | "Unknown";
 
 function formatUptime(seconds: number): string {
     if (seconds < 60) return `${Math.floor(seconds)}s`;
@@ -81,10 +81,18 @@ function getUptimeSeconds(pool: PoolData): number {
 }
 
 function getRuntimeKind(pool: PoolData): RuntimeKind {
+    const explicitRuntime = pool.runtime?.trim().toLowerCase();
+    if (explicitRuntime === "talos") {
+        return "Talos";
+    }
+
     const workerId = pool.worker_id.toLowerCase();
     const hostname = (pool.hostname ?? "").toLowerCase();
     const source = `${workerId} ${hostname}`;
 
+    if (source.includes("talos")) {
+        return "Talos";
+    }
     if (source.includes("aks") || source.includes("k8s")) {
         return "AKS";
     }
@@ -99,15 +107,23 @@ function getRuntimeKind(pool: PoolData): RuntimeKind {
 
 function RuntimeBadge({ pool }: Readonly<{ pool: PoolData }>) {
     const runtime = getRuntimeKind(pool);
-    const Icon = runtime === "AKS" ? Boxes : runtime === "ACA" ? Cloud : Server;
+    const Icon =
+        runtime === "AKS" || runtime === "Talos"
+            ? Boxes
+            : runtime === "ACA"
+                ? Cloud
+                : Server;
     const label =
-        runtime === "AKS"
+        pool.runtime_label ??
+        (runtime === "AKS"
             ? "AKS pod"
+            : runtime === "Talos"
+                ? "Talos pod"
             : runtime === "ACA"
                 ? "ACA app"
                 : runtime === "VM"
                     ? "VM"
-                    : "Unknown";
+                    : "Unknown");
 
     return (
         <Badge variant="outline" className="gap-1 text-[10px]">

--- a/client/src/pages/diagnostics/components/ContainerTable.tsx
+++ b/client/src/pages/diagnostics/components/ContainerTable.tsx
@@ -90,7 +90,7 @@ function getRuntimeKind(pool: PoolData): RuntimeKind {
     const hostname = (pool.hostname ?? "").toLowerCase();
     const source = `${workerId} ${hostname}`;
 
-    if (source.includes("talos")) {
+    if (/\btalos\b/.test(source)) {
         return "Talos";
     }
     if (source.includes("aks") || source.includes("k8s")) {

--- a/client/src/pages/diagnostics/components/WorkersTab.tsx
+++ b/client/src/pages/diagnostics/components/WorkersTab.tsx
@@ -45,7 +45,20 @@ export function WorkersTab() {
     const pools = useMemo(() => {
         const byId = new Map<string, PoolSummary | typeof wsPools[number]>();
         for (const p of poolsData?.pools ?? []) byId.set(p.worker_id, p);
-        for (const p of wsPools) byId.set(p.worker_id, p);
+        for (const p of wsPools) {
+            const existing = byId.get(p.worker_id);
+            byId.set(
+                p.worker_id,
+                existing
+                    ? {
+                          ...existing,
+                          ...p,
+                          runtime: p.runtime ?? existing.runtime,
+                          runtime_label: p.runtime_label ?? existing.runtime_label,
+                      }
+                    : p,
+            );
+        }
         return [...byId.values()];
     }, [poolsData, wsPools]);
     const queueItems = queueData?.items || [];

--- a/client/src/pages/diagnostics/components/WorkersTab.tsx
+++ b/client/src/pages/diagnostics/components/WorkersTab.tsx
@@ -47,17 +47,21 @@ export function WorkersTab() {
         for (const p of poolsData?.pools ?? []) byId.set(p.worker_id, p);
         for (const p of wsPools) {
             const existing = byId.get(p.worker_id);
-            byId.set(
-                p.worker_id,
-                existing
-                    ? {
-                          ...existing,
-                          ...p,
-                          runtime: p.runtime ?? existing.runtime,
-                          runtime_label: p.runtime_label ?? existing.runtime_label,
-                      }
-                    : p,
-            );
+            if (!existing) {
+                byId.set(p.worker_id, p);
+                continue;
+            }
+            const runtime = p.runtime ?? existing.runtime;
+            const runtimeChanged =
+                p.runtime != null && p.runtime !== existing.runtime;
+            byId.set(p.worker_id, {
+                ...existing,
+                ...p,
+                runtime,
+                runtime_label:
+                    p.runtime_label ??
+                    (runtimeChanged ? null : existing.runtime_label),
+            });
         }
         return [...byId.values()];
     }, [poolsData, wsPools]);

--- a/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
+++ b/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
@@ -79,6 +79,8 @@ export function useWorkerWebSocket(): UseWorkerWebSocketReturn {
 					const updatedPool: PoolDetail = {
 						worker_id: message.worker_id,
 						hostname: message.hostname || null,
+						runtime: message.runtime || null,
+						runtime_label: message.runtime_label || null,
 						status: message.status || null,
 						started_at: message.started_at || null,
 						last_heartbeat: message.timestamp || null,
@@ -113,6 +115,8 @@ export function useWorkerWebSocket(): UseWorkerWebSocketReturn {
 						{
 							worker_id: message.worker_id,
 							hostname: message.hostname || null,
+							runtime: message.runtime || null,
+							runtime_label: message.runtime_label || null,
 							status: "online",
 							started_at: message.started_at || null,
 							last_heartbeat: null,

--- a/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
+++ b/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
@@ -117,8 +117,8 @@ export function useWorkerWebSocket(): UseWorkerWebSocketReturn {
 						{
 							worker_id: message.worker_id,
 							hostname: message.hostname || null,
-							runtime: message.runtime || null,
-							runtime_label: message.runtime_label || null,
+							runtime: message.runtime ?? null,
+							runtime_label: message.runtime_label ?? null,
 							status: "online",
 							started_at: message.started_at || null,
 							last_heartbeat: null,

--- a/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
+++ b/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
@@ -78,11 +78,16 @@ export function useWorkerWebSocket(): UseWorkerWebSocketReturn {
 
 					const existing = idx >= 0 ? prev[idx] : undefined;
 
+					const runtime = message.runtime ?? existing?.runtime ?? null;
+					const runtimeChanged =
+						message.runtime != null && message.runtime !== existing?.runtime;
 					const updatedPool: PoolDetail = {
 						worker_id: message.worker_id,
 						hostname: message.hostname || null,
-						runtime: message.runtime ?? existing?.runtime ?? null,
-						runtime_label: message.runtime_label ?? existing?.runtime_label ?? null,
+						runtime,
+						runtime_label:
+							message.runtime_label ??
+							(runtimeChanged ? null : existing?.runtime_label ?? null),
 						status: message.status || null,
 						started_at: message.started_at || null,
 						last_heartbeat: message.timestamp || null,

--- a/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
+++ b/client/src/pages/diagnostics/hooks/useWorkerWebSocket.ts
@@ -76,11 +76,13 @@ export function useWorkerWebSocket(): UseWorkerWebSocketReturn {
 						pending_recycle: p.pending_recycle,
 					}));
 
+					const existing = idx >= 0 ? prev[idx] : undefined;
+
 					const updatedPool: PoolDetail = {
 						worker_id: message.worker_id,
 						hostname: message.hostname || null,
-						runtime: message.runtime || null,
-						runtime_label: message.runtime_label || null,
+						runtime: message.runtime ?? existing?.runtime ?? null,
+						runtime_label: message.runtime_label ?? existing?.runtime_label ?? null,
 						status: message.status || null,
 						started_at: message.started_at || null,
 						last_heartbeat: message.timestamp || null,

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -358,8 +358,8 @@ export interface PoolHeartbeatMessage {
 	type: "worker_heartbeat";
 	worker_id: string;
 	hostname?: string;
-	runtime?: string;
-	runtime_label?: string;
+	runtime?: string | null;
+	runtime_label?: string | null;
 	status?: string;
 	started_at?: string;
 	timestamp?: string;
@@ -393,8 +393,8 @@ export interface PoolOnlineMessage {
 	type: "worker_online";
 	worker_id: string;
 	hostname?: string;
-	runtime?: string;
-	runtime_label?: string;
+	runtime?: string | null;
+	runtime_label?: string | null;
 	started_at?: string;
 }
 

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -358,6 +358,8 @@ export interface PoolHeartbeatMessage {
 	type: "worker_heartbeat";
 	worker_id: string;
 	hostname?: string;
+	runtime?: string;
+	runtime_label?: string;
 	status?: string;
 	started_at?: string;
 	timestamp?: string;
@@ -391,6 +393,8 @@ export interface PoolOnlineMessage {
 	type: "worker_online";
 	worker_id: string;
 	hostname?: string;
+	runtime?: string;
+	runtime_label?: string;
 	started_at?: string;
 }
 

--- a/client/src/services/workers.ts
+++ b/client/src/services/workers.ts
@@ -38,6 +38,8 @@ export interface ProcessInfo {
 export interface PoolSummary {
 	worker_id: string;
 	hostname: string | null;
+	runtime?: string | null;
+	runtime_label?: string | null;
 	status: string | null;
 	started_at: string | null;
 	pool_size: number;
@@ -54,6 +56,8 @@ export interface PoolSummary {
 export interface PoolDetail {
 	worker_id: string;
 	hostname: string | null;
+	runtime?: string | null;
+	runtime_label?: string | null;
 	status: string | null;
 	started_at: string | null;
 	last_heartbeat: string | null;


### PR DESCRIPTION
## Summary
- add optional runtime/runtime_label metadata to worker pool REST and WebSocket payloads
- recognize Talos pools in the diagnostics runtime badge as "Talos pod"
- preserve the existing diagnostics runtime badge behavior for AKS, ACA, VM, and Unknown

## Verification
- git diff --cached --check
- python -m py_compile api/src/models/contracts/platform.py api/src/routers/platform/workers.py

Note: local client Vitest/tsc could not be run because npm ci hung in the fresh worktree before installing local binaries; CI should run the full client checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API fields and diagnostics UI only; no auth, execution, or data-path changes.
> 
> **Overview**
> Adds optional **`runtime`** and **`runtime_label`** on worker pool **REST** contracts and list/detail handlers, populated from Redis registration and heartbeats (heartbeats can override runtime and clear a stale label when runtime changes without a new label).
> 
> The **diagnostics** client threads the same fields through WebSocket types, **`useWorkerWebSocket`**, and REST/WS merge in **`WorkersTab`** so live updates do not drop runtime metadata. **`ContainerTable`** prefers **`runtime_label`** for the badge, classifies **Talos** (explicit `runtime` or id/hostname heuristics) as **"Talos pod"**, and keeps existing AKS/ACA/VM/Unknown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d604346d3bc59cc211686dc369b3163a9d4aa0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pools now include optional runtime and runtime label metadata that surfaces in diagnostics.
  * Diagnostics UI shows runtime badges (including Talos) and uses runtime_label for display.
  * Real-time updates: heartbeat/online events can provide runtime info via WebSocket and are merged with REST snapshots so runtime fields prefer recent live values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->