### PR TITLE
ci: fence DigitalOcean deploy to upstream repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,15 +328,17 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # =============================================================================
-  # Deploy Dev - Push-to-main only. Rolls the DigitalOcean deployment once
-  # the :dev images are published. Targets anything labeled
+  # Deploy Dev - upstream-only. MTG-Thomas deploys from bifrost-infra to Azure,
+  # so fork image promotion must not be blocked by upstream DigitalOcean wiring.
+  # In jackmusick/bifrost this rolls the DigitalOcean deployment once the :dev
+  # images are published. Targets anything labeled
   # `app.kubernetes.io/part-of=bifrost` in the `bifrost` namespace so new
   # services are picked up automatically. Failures page the maintainer via
   # GitHub's built-in workflow-failure email (no extra wiring).
   # =============================================================================
   deploy-dev:
     # Fires only after build-dev lands a new image on push: main.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository == 'jackmusick/bifrost' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build-dev]
     runs-on: ubuntu-latest
     name: Deploy Dev to DigitalOcean


### PR DESCRIPTION
## Summary
- keep the DigitalOcean deploy job available for upstream jackmusick/bifrost only
- prevent MTG-Thomas main image promotion from failing on an upstream deploy target we do not use
- document that MTG-Thomas deploys from bifrost-infra to Azure

## Verification
- python YAML parse of .github/workflows/ci.yml

## Context
The MTG-Thomas fork publishes platform images for Azure-backed promotion through bifrost-infra. The previous push-to-main CI path built API/client dev images successfully, then failed in the DigitalOcean deploy job at doctl setup, which blocked infra image promotion automation even though our infra is Azure-owned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow condition and comments only; no application runtime or deployment logic changes on Azure.
> 
> **Overview**
> The **`deploy-dev`** job now runs only when **`github.repository == 'jackmusick/bifrost'`**, in addition to push-on-`main`. Forks (e.g. MTG-Thomas) still get **`build-dev`** on `main` but **skip** the DigitalOcean rollout that depended on upstream **`doctl`** secrets and was failing on forks.
> 
> Comments clarify that **MTG-Thomas** promotes images via **bifrost-infra → Azure**, while upstream **jackmusick/bifrost** keeps the post-`:dev` image **DigitalOcean** deploy behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f92c9118e6b0b0bd488fbd5f911221134e9f66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->