### PR TITLE
ci: restore worker image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,24 +436,19 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # =============================================================================
-  # Build API Image - Only on version tags, after tests pass
+  # Release Manifest Check - Fail before any tag image is published
   # =============================================================================
-  build-api:
+  verify-release-manifest:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [test-unit, test-e2e, lint]
     runs-on: ubuntu-latest
-    name: Build API Image
+    name: Verify Release Manifest
     permissions:
       contents: read
-      packages: write
-      id-token: write # OIDC for keyless cosign signing
-      attestations: write # for actions/attest-build-provenance
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
 
       - name: Compute version from tag
         id: version
@@ -489,6 +484,36 @@ jobs:
             echo "::error::Run 'scripts/update-plugin-version.sh $TAG_VERSION' on main, commit, then re-tag."
             exit 1
           fi
+
+  # =============================================================================
+  # Build API Image - Only on version tags, after tests pass
+  # =============================================================================
+  build-api:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [verify-release-manifest]
+    runs-on: ubuntu-latest
+    name: Build API Image
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # OIDC for keyless cosign signing
+      attestations: write # for actions/attest-build-provenance
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Compute version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Release tag '${GITHUB_REF#refs/tags/}' must be strict semver like v1.2.3 or v1.2.3-beta.1."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -551,7 +576,7 @@ jobs:
   # =============================================================================
   build-client:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test-unit, test-e2e, lint]
+    needs: [verify-release-manifest]
     runs-on: ubuntu-latest
     name: Build Client Image
     permissions:
@@ -638,7 +663,7 @@ jobs:
   # =============================================================================
   build-worker:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test-unit, test-e2e, lint]
+    needs: [verify-release-manifest]
     runs-on: ubuntu-latest
     name: Build Worker Image
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   REGISTRY: ghcr.io
   API_IMAGE: mtg-thomas/bifrost-api
   CLIENT_IMAGE: mtg-thomas/bifrost-client
+  WORKER_IMAGE: mtg-thomas/bifrost-worker
 
 jobs:
   # =============================================================================
@@ -238,6 +239,37 @@ jobs:
         with:
           subject-name: ghcr.io/${{ env.API_IMAGE }}
           subject-digest: ${{ steps.build-api.outputs.digest }}
+          push-to-registry: true
+
+      - name: Build and push worker dev image
+        id: build-worker
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./api/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ env.WORKER_IMAGE }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ env.WORKER_IMAGE }}:dev
+            ghcr.io/${{ env.WORKER_IMAGE }}:sha-${{ steps.version.outputs.short_sha }}
+          build-args: |
+            BIFROST_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign worker dev image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ env.WORKER_IMAGE }}@${{ steps.build-worker.outputs.digest }}
+
+      - name: Attest worker dev image provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ env.WORKER_IMAGE }}
+          subject-digest: ${{ steps.build-worker.outputs.digest }}
           push-to-registry: true
 
       - name: Build and push client dev image
@@ -602,6 +634,92 @@ jobs:
           push-to-registry: true
 
   # =============================================================================
+  # Build Worker Image - Only on version tags, after tests pass
+  # =============================================================================
+  build-worker:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [test-unit, test-e2e, lint]
+    runs-on: ubuntu-latest
+    name: Build Worker Image
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # OIDC for keyless cosign signing
+      attestations: write # for actions/attest-build-provenance
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Compute version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Release tag '${GITHUB_REF#refs/tags/}' must be strict semver like v1.2.3 or v1.2.3-beta.1."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}
+          tags: |
+            # Semantic version tags
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # SHA for traceability
+            type=sha
+            # Latest tag only on stable releases (not pre-releases like v1.0.0-beta)
+            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+
+      - name: Build and push worker image
+        id: build-worker
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./api/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: BIFROST_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign worker image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ env.WORKER_IMAGE }}@${{ steps.build-worker.outputs.digest }}
+
+      - name: Attest worker image provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ env.WORKER_IMAGE }}
+          subject-digest: ${{ steps.build-worker.outputs.digest }}
+          push-to-registry: true
+
+  # =============================================================================
   # Create GitHub Release - Only on version tags, after images are built.
   # Release assets are signed with Sigstore/cosign (keyless OIDC) and a SLSA
   # build provenance attestation is generated via GitHub's native attestation
@@ -609,7 +727,7 @@ jobs:
   # =============================================================================
   create-release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-api, build-client]
+    needs: [build-api, build-client, build-worker]
     runs-on: ubuntu-latest
     name: Create Release
     permissions:
@@ -711,6 +829,11 @@ jobs:
             **Client:**
             ```bash
             docker pull ${{ env.REGISTRY }}/${{ env.CLIENT_IMAGE }}:${{ steps.get_version.outputs.image_tag }}
+            ```
+
+            **Worker:**
+            ```bash
+            docker pull ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE }}:${{ steps.get_version.outputs.image_tag }}
             ```
 
             ### Type Stubs for IDEs


### PR DESCRIPTION
Summary: restores publishing for ghcr.io/mtg-thomas/bifrost-worker on dev builds and tag releases, while keeping the MTG fork DigitalOcean deploy boundary intact. Root cause: infra promotion expects API, client, and worker SHA tags, but current CI only published API and client, so bifrost-infra failed resolving bifrost-worker:sha-4eea219. Verification: check_mtg_ci_boundaries, check_github_action_pins, workflow YAML parse, git diff --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow wiring and container publishing; no application runtime or auth logic is modified.
> 
> **Overview**
> Restores **GHCR publishing for `bifrost-worker`** so promotion can resolve worker images alongside API and client (e.g. `sha-*` tags).
> 
> On **main dev builds**, CI now builds, pushes, signs, and attests `ghcr.io/mtg-thomas/bifrost-worker` using `./api/Dockerfile`, with the same version/`dev`/`sha-*` tagging pattern as the API image. **Tag releases** add a dedicated `build-worker` job (semver metadata, cosign, provenance) and wire **`create-release`** to wait on it and document the worker `docker pull` command.
> 
> Release flow is tightened by splitting **`verify-release-manifest`** into its own gate job; **`build-api`** and **`build-client`** (and the new worker job) depend on that check instead of duplicating manifest validation inside the API build job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee5392ca7ffc320e689a0e9044ac39a27bb83f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to include worker image building, signing, and provenance attestation for improved release security and artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->