### PR TITLE
Fix provider execution config and Azure Blob listing

### DIFF
--- a/api/src/repositories/integrations.py
+++ b/api/src/repositories/integrations.py
@@ -633,8 +633,9 @@ class IntegrationsRepository(BaseRepository[Integration]):
             integration_id: Integration UUID
             org_id: Organization UUID
             include_default_secrets: Whether integration-level secret defaults
-                may be included. Direct mapping enumeration disables this so
-                global secrets do not leak through org mapping reads.
+                may be included. SDK execution reads need these for mapped
+                integrations; mapping-list/admin responses should not leak
+                global secrets through org mappings.
 
         Returns:
             dict: Merged configuration (integration defaults + org overrides)

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -690,7 +690,11 @@ async def sdk_integrations_get(
 
         if mapping:
             # Org-specific mapping found
-            config = await repo.get_config_for_mapping(mapping.integration_id, org_uuid)
+            config = await repo.get_config_for_mapping(
+                mapping.integration_id,
+                org_uuid,
+                include_default_secrets=True,
+            )
             integration = mapping.integration
             entity_id = mapping.entity_id or (integration.default_entity_id if integration else None)
 

--- a/api/src/services/file_storage/azure_blob_client.py
+++ b/api/src/services/file_storage/azure_blob_client.py
@@ -132,9 +132,11 @@ class AzureBlobStorageClient:
         del Bucket
         await self._ensure_client()
 
-        pager = self._container_client.list_blobs(name_starts_with=Prefix).by_page(
+        list_kwargs: dict[str, Any] = {"name_starts_with": Prefix}
+        if MaxKeys is not None:
+            list_kwargs["results_per_page"] = MaxKeys
+        pager = self._container_client.list_blobs(**list_kwargs).by_page(
             continuation_token=ContinuationToken,
-            results_per_page=MaxKeys,
         )
         try:
             page = await anext(pager)

--- a/api/tests/unit/repositories/test_integrations_repository.py
+++ b/api/tests/unit/repositories/test_integrations_repository.py
@@ -16,6 +16,7 @@ from src.models.contracts.integrations import (
     IntegrationMappingUpdate,
 )
 from src.repositories.integrations import IntegrationsRepository
+from src.models.enums import ConfigType
 
 
 class TestIntegrationsRepository:
@@ -335,6 +336,53 @@ class TestIntegrationsRepository:
 
         assert len(result) == 2
         assert any(i.is_deleted for i in result)
+
+    @pytest.mark.parametrize(
+        ("include_default_secrets", "expected_secret"),
+        [(False, None), (True, "decrypted-placeholder")],
+    )
+    async def test_get_config_for_mapping_default_secret_policy(
+        self,
+        repository,
+        mock_session,
+        include_default_secrets,
+        expected_secret,
+    ):
+        """Default secret fallback is opt-in for SDK execution reads."""
+        integration_id = uuid4()
+        org_id = uuid4()
+        secret_key = "api" + "_key"
+
+        default_secret = MagicMock()
+        default_secret.organization_id = None
+        default_secret.config_type = ConfigType.SECRET
+        default_secret.key = secret_key
+        default_secret.value = "encrypted-placeholder"
+
+        org_override = MagicMock()
+        org_override.organization_id = org_id
+        org_override.config_type = ConfigType.STRING
+        org_override.key = "base_url"
+        org_override.value = "https://example.test"
+
+        mock_result = MagicMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [default_secret, org_override]
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        with patch(
+            "src.repositories.integrations.decrypt_secret",
+            return_value="decrypted-placeholder",
+        ):
+            config = await repository.get_config_for_mapping(
+                integration_id,
+                org_id,
+                include_default_secrets=include_default_secrets,
+            )
+
+        assert config["base_url"] == "https://example.test"
+        assert config.get(secret_key) == expected_secret
 
     async def test_update_integration(self, repository, mock_session, mock_integration):
         """Test updating an integration with partial data."""

--- a/api/tests/unit/routers/test_cli_auto_refresh.py
+++ b/api/tests/unit/routers/test_cli_auto_refresh.py
@@ -494,3 +494,59 @@ class TestBuildOAuthDataAutoRefresh:
             assert result.access_token == "fresh-access-token"
             mock_persist.assert_awaited_once()
             db.commit.assert_awaited_once()
+
+
+class TestSDKIntegrationsGetConfig:
+    """Tests for integration config resolution through the SDK endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_org_mapping_includes_default_secrets_for_execution_reads(self):
+        """Mapped SDK reads must include default secrets needed by workflow clients."""
+        from src.models.contracts.cli import SDKIntegrationsGetRequest
+        from src.routers import cli
+
+        org_id = "00000000-0000-0000-0000-000000000002"
+        integration_id = "11111111-1111-1111-1111-111111111111"
+
+        mapping = MagicMock()
+        mapping.integration_id = integration_id
+        mapping.entity_id = "0"
+        mapping.entity_name = "Provider"
+        mapping.oauth_token = None
+
+        integration = MagicMock()
+        integration.id = integration_id
+        integration.default_entity_id = None
+        integration.config_schema = []
+        integration.oauth_provider = None
+        mapping.integration = integration
+
+        repo = MagicMock()
+        repo.get_integration_for_org = AsyncMock(return_value=mapping)
+        repo.get_config_for_mapping = AsyncMock(
+            return_value={
+                "base_url": "https://example.test",
+                "api_integration_code": "decrypted-code",
+                "secret": "decrypted-secret",
+            }
+        )
+
+        user = MagicMock()
+        user.email = "engine@example.test"
+
+        with (
+            patch.object(cli, "_resolve_sdk_org_id", AsyncMock(return_value=org_id)),
+            patch("src.repositories.integrations.IntegrationsRepository", return_value=repo),
+        ):
+            response = await cli.sdk_integrations_get(
+                SDKIntegrationsGetRequest(name="Autotask", scope=org_id),
+                user,
+                MagicMock(),
+            )
+
+        repo.get_config_for_mapping.assert_awaited_once()
+        assert repo.get_config_for_mapping.await_args.kwargs == {
+            "include_default_secrets": True
+        }
+        assert response is not None
+        assert response.config["secret"] == "decrypted-secret"

--- a/api/tests/unit/services/test_azure_blob_storage_client.py
+++ b/api/tests/unit/services/test_azure_blob_storage_client.py
@@ -1,0 +1,69 @@
+"""Unit tests for the Azure Blob S3-shaped storage adapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.services.file_storage.azure_blob_client import AzureBlobStorageClient
+
+
+class _AsyncPageIterator:
+    def __init__(self, pages):
+        self._pages = list(pages)
+        self.continuation_token = "next-token"
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._pages:
+            raise StopAsyncIteration
+        return self._pages.pop(0)
+
+
+class _BlobPager:
+    def __init__(self, container):
+        self._container = container
+
+    def by_page(self, **kwargs):
+        self._container.by_page_kwargs = kwargs
+        return _AsyncPageIterator(
+            [[SimpleNamespace(name="workspace/report.txt", size=12, etag='"etag"')]]
+        )
+
+
+class _ContainerClient:
+    def __init__(self):
+        self.list_blobs_kwargs = None
+        self.by_page_kwargs = None
+
+    def list_blobs(self, **kwargs):
+        self.list_blobs_kwargs = kwargs
+        return _BlobPager(self)
+
+
+@pytest.mark.asyncio
+async def test_list_objects_v2_passes_page_size_to_list_blobs_not_by_page():
+    """Azure async paging accepts results_per_page on list_blobs, not by_page."""
+    client = object.__new__(AzureBlobStorageClient)
+    container = _ContainerClient()
+    client._container_client = container
+    client._ensure_client = AsyncMock()
+
+    response = await client.list_objects_v2(
+        Bucket="ignored",
+        Prefix="workspace/",
+        ContinuationToken="cursor",
+        MaxKeys=25,
+    )
+
+    assert container.list_blobs_kwargs == {
+        "name_starts_with": "workspace/",
+        "results_per_page": 25,
+    }
+    assert container.by_page_kwargs == {"continuation_token": "cursor"}
+    assert response["Contents"][0]["Key"] == "workspace/report.txt"
+    assert response["NextContinuationToken"] == "next-token"

--- a/api/tests/unit/services/test_file_storage_backend_selection.py
+++ b/api/tests/unit/services/test_file_storage_backend_selection.py
@@ -72,12 +72,11 @@ def _client_with_blob_names(names, *, next_token=None):
             self._blobs = blobs
 
         def by_page(self, **kwargs):
-            page_size = kwargs["results_per_page"]
-            blobs = self._blobs[:page_size] if page_size else self._blobs
-            return FakePager(blobs)
+            assert set(kwargs) <= {"continuation_token"}
+            return FakePager(self._blobs)
 
     class FakeContainer:
-        def list_blobs(self, name_starts_with=""):
+        def list_blobs(self, name_starts_with="", results_per_page=None):
             blobs = [
                 SimpleNamespace(
                     name=name,
@@ -88,6 +87,8 @@ def _client_with_blob_names(names, *, next_token=None):
                 for name in names
                 if name.startswith(name_starts_with)
             ]
+            if results_per_page:
+                blobs = blobs[:results_per_page]
             return FakePaged(blobs)
 
     client._container_client = FakeContainer()


### PR DESCRIPTION
## Summary
- allow SDK execution integration reads to include integration-level secret defaults when an org mapping exists
- keep mapping/admin config reads from leaking default secrets by default
- fix Azure Blob S3-shaped listing to pass page size to list_blobs instead of by_page

## Verification
- python -m pytest api\\tests\\unit\\services\\test_azure_blob_storage_client.py api\\tests\\unit\\repositories\\test_integrations_repository.py api\\tests\\unit\\routers\\test_cli_auto_refresh.py -q
- python -m ruff check api\\src\\services\\file_storage\\azure_blob_client.py api\\src\\repositories\\integrations.py api\\src\\routers\\cli.py api\\tests\\unit\\repositories\\test_integrations_repository.py api\\tests\\unit\\routers\\test_cli_auto_refresh.py api\\tests\\unit\\services\\test_azure_blob_storage_client.py

## Live symptoms addressed
- Provider-scoped Autotask/NinjaOne executions could not see global secret defaults from managed Postgres
- /api/files/list failed on Azure Blob with AsyncItemPaged.by_page() unexpected keyword argument results_per_page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which SDK paths receive decrypted integration-level secrets (execution vs enumeration) and fixes production file listing on Azure; scope is narrow but touches credentials and storage.
> 
> **Overview**
> Fixes **provider workflow execution** failing when org mappings rely on **integration-level secret defaults** stored in Postgres: `sdk_integrations_get` now loads merged mapping config with **`include_default_secrets=True`**, while **mapping list/get/admin-style SDK paths** still omit global secrets by default so they are not leaked through org mapping responses.
> 
> Corrects **Azure Blob S3-shaped listing** by passing **`results_per_page` to `list_blobs`** (only **`continuation_token` on `by_page`**), which restores **`/api/files/list`** when object storage uses Azure instead of S3.
> 
> Adds **unit tests** for the secret opt-in behavior, the SDK integrations get path, and Azure list paging kwargs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0e34ab71199b6f0e8dd2a52af66efd5f78b115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->