### PR TITLE
Merge upstream invite registration updates

### DIFF
--- a/api/src/core/csrf.py
+++ b/api/src/core/csrf.py
@@ -40,6 +40,8 @@ CSRF_EXEMPT_PATHS = {
     "/auth/setup/passkey/options",  # First-time passkey setup (no auth)
     "/auth/setup/passkey/verify",  # First-time passkey setup (no auth)
     "/auth/register-from-invite",  # Invite-based registration (token-gated, no cookies yet)
+    "/auth/register-from-invite/passkey/options",  # Invite passkey setup (token-gated)
+    "/auth/register-from-invite/passkey/verify",  # Invite passkey setup (token-gated)
     "/auth/device/code",  # Device flow: request code (no auth)
     "/auth/device/token",  # Device flow: exchange code for token (no auth)
     "/auth/cli/start",  # Native CLI OAuth: start localhost callback flow (no auth)

--- a/api/src/models/contracts/passkeys.py
+++ b/api/src/models/contracts/passkeys.py
@@ -184,3 +184,23 @@ class SetupPasskeyVerifyResponse(BaseModel):
     access_token: str = Field(description="JWT access token")
     refresh_token: str = Field(description="JWT refresh token")
     token_type: str = "bearer"
+
+
+class InvitePasskeyOptionsRequest(BaseModel):
+    """Request to start passkey registration from an invite token."""
+
+    token: str = Field(description="Invite token from the registration URL")
+
+
+class InvitePasskeyVerifyRequest(BaseModel):
+    """Request to complete invite registration with a passkey."""
+
+    token: str = Field(description="Invite token from the registration URL")
+    credential: dict[str, Any] = Field(
+        description="WebAuthn credential from navigator.credentials.create()"
+    )
+    device_name: str | None = Field(
+        default=None,
+        description="Friendly name for the passkey",
+        max_length=255,
+    )

--- a/api/src/models/contracts/user_invites.py
+++ b/api/src/models/contracts/user_invites.py
@@ -36,6 +36,12 @@ class CreateInviteResponse(BaseModel):
     event_id: UUID | None = None
 
 
+class SendInviteRequest(BaseModel):
+    """Request to emit invite automation for an existing raw registration link."""
+
+    registration_url: str
+
+
 class RegisterFromInviteRequest(BaseModel):
     """Invitee submits this to consume the token and set up auth."""
 

--- a/api/src/models/contracts/users.py
+++ b/api/src/models/contracts/users.py
@@ -114,6 +114,7 @@ class UserPublic(UserBase):
     created_at: datetime
     updated_at: datetime
     invite_status: str = "active"  # one of InviteStatus values; populated by router
+    registration_url: str | None = None  # only populated immediately after invite creation
 
     @field_serializer("created_at", "updated_at", "last_login")
     def serialize_dt(self, dt: datetime | None) -> str | None:

--- a/api/src/models/contracts/users.py
+++ b/api/src/models/contracts/users.py
@@ -88,7 +88,7 @@ class UserCreate(BaseModel):
     is_active: bool = True
     is_superuser: bool = False
     organization_id: UUID | None = None
-    invite: bool = False  # If True, generate invite record; link returned and event optionally fired
+    invite: bool = True  # If True, generate invite record; link returned and event optionally fired
     trigger_automation: bool | None = None  # None treated as True for contract compat during transition
 
 

--- a/api/src/routers/auth.py
+++ b/api/src/routers/auth.py
@@ -41,6 +41,8 @@ from src.models import (
     OAuthProviderInfo,
 )
 from src.models.contracts.passkeys import (
+    InvitePasskeyOptionsRequest,
+    InvitePasskeyVerifyRequest,
     SetupPasskeyOptionsRequest,
     SetupPasskeyOptionsResponse,
     SetupPasskeyVerifyRequest,
@@ -1832,3 +1834,59 @@ async def register_from_invite(
     public = UserPublic.model_validate(registered)
     public.invite_status = "active"
     return public
+
+
+@router.post("/register-from-invite/passkey/options", response_model=SetupPasskeyOptionsResponse)
+async def register_from_invite_passkey_options(
+    request: InvitePasskeyOptionsRequest,
+    db: DbSession,
+) -> SetupPasskeyOptionsResponse:
+    """Start passkey registration for a user holding a valid invite token."""
+    from src.services.passkey_service import PasskeyService
+
+    invite_svc = UserInviteService(db)
+    try:
+        _, invited_user = await invite_svc.get_valid_invite_user(token=request.token)
+        options = await PasskeyService(db).generate_registration_options(invited_user.id)
+    except (InviteConsumeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return SetupPasskeyOptionsResponse(
+        registration_token=request.token,
+        options=options,
+        expires_in=300,
+    )
+
+
+@router.post("/register-from-invite/passkey/verify", response_model=SetupPasskeyVerifyResponse)
+async def register_from_invite_passkey_verify(
+    request: InvitePasskeyVerifyRequest,
+    response: Response,
+    db: DbSession,
+) -> SetupPasskeyVerifyResponse:
+    """Complete invite registration by verifying a passkey and logging the user in."""
+    import json
+
+    from src.services.passkey_service import PasskeyService
+
+    invite_svc = UserInviteService(db)
+    try:
+        _, invited_user = await invite_svc.get_valid_invite_user(token=request.token)
+        passkey_service = PasskeyService(db)
+        await passkey_service.verify_registration(
+            user_id=invited_user.id,
+            credential_json=json.dumps(request.credential),
+            device_name=request.device_name,
+        )
+        registered = await invite_svc.consume(token=request.token)
+        await db.commit()
+    except (InviteConsumeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    login = await _generate_login_tokens(registered, db, response)
+    return SetupPasskeyVerifyResponse(
+        user_id=str(registered.id),
+        email=registered.email,
+        access_token=login.access_token or "",
+        refresh_token=login.refresh_token or "",
+    )

--- a/api/src/routers/auth.py
+++ b/api/src/routers/auth.py
@@ -2122,7 +2122,6 @@ async def register_from_invite_passkey_verify(
             device_name=request.device_name,
         )
         registered = await invite_svc.consume(token=request.token)
-        await db.commit()
     except (InviteConsumeError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/api/src/routers/auth.py
+++ b/api/src/routers/auth.py
@@ -2108,8 +2108,6 @@ async def register_from_invite_passkey_verify(
     db: DbSession,
 ) -> SetupPasskeyVerifyResponse:
     """Complete invite registration by verifying a passkey and logging the user in."""
-    import json
-
     from src.services.passkey_service import PasskeyService
 
     invite_svc = UserInviteService(db)

--- a/api/src/routers/oauth_sso.py
+++ b/api/src/routers/oauth_sso.py
@@ -356,6 +356,8 @@ async def oauth_callback(
         # Existing OAuth user - update last login
         user = existing_user
         user.last_login = datetime.now(timezone.utc)
+        user.is_registered = True
+        user.is_verified = True
 
         # Update OAuth account
         await oauth_service.link_oauth_account(user, user_info, tokens)
@@ -375,6 +377,8 @@ async def oauth_callback(
             await oauth_service.link_oauth_account(user, user_info, tokens)
 
             user.last_login = datetime.now(timezone.utc)
+            user.is_registered = True
+            user.is_verified = True
             await db.commit()
 
         except ValueError as e:

--- a/api/src/routers/users.py
+++ b/api/src/routers/users.py
@@ -6,6 +6,7 @@ List and manage users, view user roles and forms.
 
 import logging
 from datetime import datetime, timezone
+from urllib.parse import parse_qs, urlparse
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -30,7 +31,11 @@ from src.models import (
     UserRolesResponse,
     UserFormsResponse,
 )
-from src.models.contracts.user_invites import CreateInviteResponse, InviteStatus
+from src.models.contracts.user_invites import (
+    CreateInviteResponse,
+    InviteStatus,
+    SendInviteRequest,
+)
 from src.core.constants import PROVIDER_ORG_ID
 
 logger = logging.getLogger(__name__)
@@ -156,39 +161,18 @@ async def create_user(
         },
     )
 
-    invite_status = InviteStatus.NEVER_INVITED
-    if request.invite:
-        svc = UserInviteService(db)
-        raw_token, invite = await svc.create_or_replace(
-            user_id=new_user.id, created_by=user.user_id
-        )
-        invite_status = InviteStatus.PENDING
-        should_emit = request.trigger_automation is True or request.trigger_automation is None
-        if should_emit:
-            registration_url = (
-                f"{get_settings().public_url.rstrip('/')}/accept-invite?token={raw_token}"
-            )
-            await emit_event(
-                "user.invited",
-                {
-                    "user_id": str(new_user.id),
-                    "email": new_user.email,
-                    "name": new_user.name or "",
-                    "registration_url": registration_url,
-                    "expires_at": invite.expires_at.isoformat(),
-                    "invited_by": {
-                        "user_id": str(user.user_id),
-                        "email": user.email,
-                        "name": getattr(user, "name", None) or "",
-                    },
-                    "reason": "created",
-                },
-                organization_id=new_user.organization_id,
-                triggered_by=str(user.user_id),
-            )
+    svc = UserInviteService(db)
+    raw_token, invite = await svc.create_or_replace(
+        user_id=new_user.id, created_by=user.user_id
+    )
+    invite_status = InviteStatus.PENDING
+    registration_url = (
+        f"{get_settings().public_url.rstrip('/')}/accept-invite?token={raw_token}"
+    )
 
     response = UserPublic.model_validate(new_user)
     response.invite_status = invite_status
+    response.registration_url = registration_url
     return response
 
 
@@ -293,6 +277,45 @@ async def resend_invite(
 
 
 @router.post(
+    "/{user_id}/invite/send",
+    response_model=CreateInviteResponse,
+    summary="Send invite",
+    description="Emit invite automation for an existing registration link without rotating the token.",
+)
+async def send_invite(
+    user_id: UUID,
+    request: SendInviteRequest,
+    user: CurrentSuperuser,
+    db: DbSession,
+) -> CreateInviteResponse:
+    token = _extract_invite_token(request.registration_url)
+    svc = UserInviteService(db)
+    try:
+        invite, target = await svc.get_valid_invite_user(token=token)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invite is not valid") from exc
+
+    if target.id != user_id:
+        raise HTTPException(status_code=400, detail="Invite does not belong to user")
+
+    event_id = await _emit_user_invited_event(
+        actor=user,
+        invite=invite,
+        reason="sent",
+        registration_url=request.registration_url,
+        target=target,
+    )
+
+    return CreateInviteResponse(
+        user_id=user_id,
+        expires_at=invite.expires_at,
+        registration_url=request.registration_url,
+        event_emitted=True,
+        event_id=event_id,
+    )
+
+
+@router.post(
     "/{user_id}/invite/regenerate",
     response_model=CreateInviteResponse,
     summary="Regenerate invite link",
@@ -342,23 +365,12 @@ async def _generate_invite(
 
     event_id = None
     if send:
-        event_id, _ = await emit_event(
-            "user.invited",
-            {
-                "user_id": str(user_id),
-                "email": target.email,
-                "name": target.name or "",
-                "registration_url": registration_url,
-                "expires_at": invite.expires_at.isoformat(),
-                "invited_by": {
-                    "user_id": str(actor.user_id),
-                    "email": actor.email,
-                    "name": getattr(actor, "name", None) or "",
-                },
-                "reason": "resent",
-            },
-            organization_id=target.organization_id,
-            triggered_by=str(actor.user_id),
+        event_id = await _emit_user_invited_event(
+            actor=actor,
+            invite=invite,
+            reason="resent",
+            registration_url=registration_url,
+            target=target,
         )
 
     return CreateInviteResponse(
@@ -368,6 +380,43 @@ async def _generate_invite(
         event_emitted=send,
         event_id=event_id,
     )
+
+
+def _extract_invite_token(registration_url: str) -> str:
+    parsed = urlparse(registration_url)
+    token = parse_qs(parsed.query).get("token", [None])[0]
+    if not token:
+        raise HTTPException(status_code=400, detail="registration_url must include token")
+    return token
+
+
+async def _emit_user_invited_event(
+    *,
+    actor,
+    invite,
+    reason: str,
+    registration_url: str,
+    target: UserORM,
+) -> UUID:
+    event_id, _ = await emit_event(
+        "user.invited",
+        {
+            "user_id": str(target.id),
+            "email": target.email,
+            "name": target.name or "",
+            "registration_url": registration_url,
+            "expires_at": invite.expires_at.isoformat(),
+            "invited_by": {
+                "user_id": str(actor.user_id),
+                "email": actor.email,
+                "name": getattr(actor, "name", None) or "",
+            },
+            "reason": reason,
+        },
+        organization_id=target.organization_id,
+        triggered_by=str(actor.user_id),
+    )
+    return event_id
 
 
 @router.get(

--- a/api/src/routers/users.py
+++ b/api/src/routers/users.py
@@ -410,6 +410,7 @@ async def _generate_invite(
     svc = UserInviteService(db)
     if await svc.status_for(target) == InviteStatus.ACTIVE:
         raise HTTPException(status_code=409, detail="User is already registered")
+
     raw_token, invite = await svc.create_or_replace(
         user_id=user_id, created_by=actor.user_id
     )

--- a/api/src/routers/users.py
+++ b/api/src/routers/users.py
@@ -406,10 +406,10 @@ async def _generate_invite(
     ).scalar_one_or_none()
     if not target:
         raise HTTPException(status_code=404, detail="User not found")
-    if target.is_registered:
-        raise HTTPException(status_code=409, detail="User is already registered")
 
     svc = UserInviteService(db)
+    if await svc.status_for(target) == InviteStatus.ACTIVE:
+        raise HTTPException(status_code=409, detail="User is already registered")
     raw_token, invite = await svc.create_or_replace(
         user_id=user_id, created_by=actor.user_id
     )

--- a/api/src/routers/users.py
+++ b/api/src/routers/users.py
@@ -161,14 +161,28 @@ async def create_user(
         },
     )
 
-    svc = UserInviteService(db)
-    raw_token, invite = await svc.create_or_replace(
-        user_id=new_user.id, created_by=user.user_id
-    )
-    invite_status = InviteStatus.PENDING
-    registration_url = (
-        f"{get_settings().public_url.rstrip('/')}/accept-invite?token={raw_token}"
-    )
+    invite_status = InviteStatus.NEVER_INVITED
+    registration_url = None
+    if request.invite:
+        svc = UserInviteService(db)
+        raw_token, invite = await svc.create_or_replace(
+            user_id=new_user.id, created_by=user.user_id
+        )
+        invite_status = InviteStatus.PENDING
+        registration_url = (
+            f"{get_settings().public_url.rstrip('/')}/accept-invite?token={raw_token}"
+        )
+        should_emit = (
+            request.trigger_automation is True or request.trigger_automation is None
+        )
+        if should_emit:
+            await _emit_user_invited_event(
+                actor=user,
+                invite=invite,
+                reason="created",
+                registration_url=registration_url,
+                target=new_user,
+            )
 
     response = UserPublic.model_validate(new_user)
     response.invite_status = invite_status

--- a/api/src/services/audit.py
+++ b/api/src/services/audit.py
@@ -19,6 +19,7 @@ import logging
 from typing import Any, Literal
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.repositories.audit_logs import AuditLogRepository
@@ -63,20 +64,44 @@ async def emit_audit(
     if actor is None:
         return
 
+    async def _insert(user_id: UUID | None) -> None:
+        # Wrap the insert in a SAVEPOINT so a failed audit row (e.g. a dangling
+        # actor FK from a stale token) rolls back only itself — never the
+        # caller's primary transaction. Without this, the failed INSERT poisons
+        # the shared session and the outer commit blows up, taking the real
+        # operation down with it.
+        async with db.begin_nested():
+            repo = AuditLogRepository(db)
+            await repo.create(
+                action=action,
+                user_id=user_id,
+                organization_id=actor.organization_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                outcome=outcome,
+                source=actor.source,
+                ip_address=actor.ip_address,
+                user_agent=actor.user_agent,
+                details=details,
+            )
+
     try:
-        repo = AuditLogRepository(db)
-        await repo.create(
-            action=action,
-            user_id=actor.user_id,
-            organization_id=actor.organization_id,
-            resource_type=resource_type,
-            resource_id=resource_id,
-            outcome=outcome,
-            source=actor.source,
-            ip_address=actor.ip_address,
-            user_agent=actor.user_agent,
-            details=details,
+        await _insert(actor.user_id)
+    except IntegrityError:
+        # The actor's user_id points at a user that no longer exists (a stale
+        # token after the user was deleted). Record the event without an actor
+        # rather than dropping it.
+        logger.warning(
+            "Audit actor %s for %s no longer exists; recording without actor",
+            actor.user_id,
+            action,
         )
+        try:
+            await _insert(None)
+        except Exception as exc:
+            logger.warning(
+                "Failed to emit audit event %s: %s", action, exc, exc_info=True
+            )
     except Exception as exc:
         # Audit failures must never break the primary operation.
         logger.warning(

--- a/api/src/services/user_invite_service.py
+++ b/api/src/services/user_invite_service.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.security import get_password_hash
 from src.models.contracts.user_invites import InviteStatus
-from src.models.orm import User, UserInvite
+from src.models.orm import User, UserInvite, UserOAuthAccount
 
 # Invites expire after 7 days by default.
 INVITE_TTL = timedelta(days=7)
@@ -62,6 +62,17 @@ class UserInviteService:
             await self.session.flush()
 
     async def consume(self, *, token: str, password: str | None = None) -> User:
+        invite, user = await self.get_valid_invite_user(token=token)
+
+        if password:
+            user.hashed_password = get_password_hash(password)
+        user.is_registered = True
+        invite.consumed_at = datetime.now(timezone.utc)
+
+        await self.session.flush()
+        return user
+
+    async def get_valid_invite_user(self, *, token: str) -> tuple[UserInvite, User]:
         token_hash = _hash_token(token)
         invite = (
             await self.session.execute(
@@ -81,16 +92,13 @@ class UserInviteService:
             await self.session.execute(select(User).where(User.id == invite.user_id))
         ).scalar_one()
 
-        if password:
-            user.hashed_password = get_password_hash(password)
-        user.is_registered = True
-        invite.consumed_at = datetime.now(timezone.utc)
+        if user.is_registered or await self._has_oauth_account(user.id):
+            raise InviteConsumeError("User is already registered")
 
-        await self.session.flush()
-        return user
+        return invite, user
 
     async def status_for(self, user: User) -> str:
-        if user.is_registered:
+        if user.is_registered or await self._has_oauth_account(user.id):
             return InviteStatus.ACTIVE
         invite = await self._get_for_user(user.id)
         if invite is None:
@@ -107,3 +115,12 @@ class UserInviteService:
                 select(UserInvite).where(UserInvite.user_id == user_id)
             )
         ).scalar_one_or_none()
+
+    async def _has_oauth_account(self, user_id: UUID) -> bool:
+        return (
+            await self.session.execute(
+                select(UserOAuthAccount.id)
+                .where(UserOAuthAccount.user_id == user_id)
+                .limit(1)
+            )
+        ).scalar_one_or_none() is not None

--- a/api/tests/e2e/api/test_user_invites.py
+++ b/api/tests/e2e/api/test_user_invites.py
@@ -4,17 +4,21 @@ Verifies the invite-management endpoints on the users router and the
 unauthenticated register-from-invite flow on the auth router.
 """
 
+from uuid import UUID
+
 import pytest
+
+from src.models.orm import UserOAuthAccount
 
 
 @pytest.mark.e2e
 class TestUserInviteFlags:
     """invite_status field on UserPublic."""
 
-    def test_create_user_default_invite_status_never_invited(
+    def test_create_user_creates_registration_invite(
         self, e2e_client, platform_admin, org1
     ):
-        """A user created without invite=True has invite_status='never_invited'."""
+        """Admin-created users get a pending registration link by default."""
         resp = e2e_client.post(
             "/api/users",
             headers=platform_admin.headers,
@@ -27,7 +31,8 @@ class TestUserInviteFlags:
         )
         assert resp.status_code == 201
         body = resp.json()
-        assert body["invite_status"] == "never_invited"
+        assert body["invite_status"] == "pending"
+        assert "accept-invite?token=" in body["registration_url"]
         # Cleanup
         e2e_client.patch(
             f"/api/users/{body['id']}",
@@ -47,6 +52,51 @@ class TestUserInviteFlags:
         for u in resp.json():
             assert "invite_status" in u
             assert u["invite_status"] in {"active", "pending", "expired", "never_invited"}
+
+    async def test_oauth_linked_user_invite_status_is_active(
+        self, e2e_client, platform_admin, org1, db_session
+    ):
+        """Historical SSO users are active even if is_registered was never backfilled."""
+        email = "inv-oauth-linked@gobifrost.dev"
+        create_resp = e2e_client.post(
+            "/api/users",
+            headers=platform_admin.headers,
+            json={
+                "email": email,
+                "name": "OAuth Linked",
+                "organization_id": org1["id"],
+                "is_superuser": False,
+            },
+        )
+        assert create_resp.status_code == 201
+        body = create_resp.json()
+        user_id = UUID(body["id"])
+
+        db_session.add(
+            UserOAuthAccount(
+                user_id=user_id,
+                provider_id="oidc",
+                provider_user_id="historical-sso-user",
+                email=email,
+            )
+        )
+        await db_session.commit()
+
+        list_resp = e2e_client.get(
+            "/api/users", headers=platform_admin.headers
+        )
+        target = next(u for u in list_resp.json() if u["id"] == body["id"])
+        assert target["is_registered"] is False
+        assert target["invite_status"] == "active"
+
+        e2e_client.patch(
+            f"/api/users/{body['id']}",
+            headers=platform_admin.headers,
+            json={"is_active": False},
+        )
+        e2e_client.delete(
+            f"/api/users/{body['id']}", headers=platform_admin.headers
+        )
 
 
 @pytest.mark.e2e
@@ -203,6 +253,57 @@ class TestRegisterFromInvite:
             f"/api/users/{user_id}", headers=platform_admin.headers
         )
 
+    def test_register_without_password_creates_passwordless_user(
+        self, e2e_client, platform_admin, org1
+    ):
+        """Invite registration may complete without enabling password auth."""
+        email = "inv-passkey@gobifrost.dev"
+        create_resp = e2e_client.post(
+            "/api/users",
+            headers=platform_admin.headers,
+            json={
+                "email": email,
+                "name": "Passkey Invite",
+                "organization_id": org1["id"],
+                "is_superuser": False,
+            },
+        )
+        user_id = create_resp.json()["id"]
+
+        regen = e2e_client.post(
+            f"/api/users/{user_id}/invite/regenerate",
+            headers=platform_admin.headers,
+        )
+        url: str = regen.json()["registration_url"]
+        token = url.split("token=", 1)[1]
+
+        register_resp = e2e_client.post(
+            "/auth/register-from-invite",
+            json={"token": token},
+        )
+        assert register_resp.status_code == 200
+        assert register_resp.json()["email"] == email
+        assert register_resp.json()["is_registered"] is True
+
+        login_resp = e2e_client.post(
+            "/auth/login",
+            data={"username": email, "password": "anything"},
+        )
+        assert login_resp.status_code == 401
+        assert (
+            login_resp.json()["detail"]
+            == "Account does not have password authentication enabled"
+        )
+
+        e2e_client.patch(
+            f"/api/users/{user_id}",
+            headers=platform_admin.headers,
+            json={"is_active": False},
+        )
+        e2e_client.delete(
+            f"/api/users/{user_id}", headers=platform_admin.headers
+        )
+
     def test_register_unknown_token_400(self, e2e_client):
         """Unknown token returns 400, not 200/500."""
         resp = e2e_client.post(
@@ -216,8 +317,10 @@ class TestRegisterFromInvite:
 class TestUserInvitedEvent:
     """user.invited event is emitted at the right times."""
 
-    def test_create_with_invite_emits_event(self, e2e_client, platform_admin, org1):
-        """POST /users with invite=True returns event_emitted=True and an event_id."""
+    def test_send_invite_emits_event_for_existing_link(
+        self, e2e_client, platform_admin, org1
+    ):
+        """POST /invite/send emits user.invited without rotating the token."""
         resp = e2e_client.post(
             "/api/users",
             headers=platform_admin.headers,
@@ -230,18 +333,21 @@ class TestUserInvitedEvent:
             },
         )
         assert resp.status_code == 201
-        user_id = resp.json()["id"]
+        create_body = resp.json()
+        user_id = create_body["id"]
+        assert create_body["invite_status"] == "pending"
+        assert "accept-invite?token=" in create_body["registration_url"]
 
-        # The resend endpoint reveals event_emitted
-        resend_resp = e2e_client.post(
-            f"/api/users/{user_id}/invite/resend",
+        send_resp = e2e_client.post(
+            f"/api/users/{user_id}/invite/send",
             headers=platform_admin.headers,
+            json={"registration_url": create_body["registration_url"]},
         )
-        assert resend_resp.status_code == 200
-        body = resend_resp.json()
+        assert send_resp.status_code == 200
+        body = send_resp.json()
         assert body["event_emitted"] is True
         assert body["event_id"] is not None
-        assert "accept-invite?token=" in body["registration_url"]
+        assert body["registration_url"] == create_body["registration_url"]
 
         # Cleanup
         e2e_client.patch(
@@ -250,6 +356,83 @@ class TestUserInvitedEvent:
             json={"is_active": False},
         )
         e2e_client.delete(f"/api/users/{user_id}", headers=platform_admin.headers)
+
+    def test_send_invite_rejects_invalid_registration_url(
+        self, e2e_client, platform_admin, org1
+    ):
+        """POST /invite/send requires a token-bearing registration URL."""
+        resp = e2e_client.post(
+            "/api/users",
+            headers=platform_admin.headers,
+            json={
+                "email": "inv-event-invalid-url@gobifrost.dev",
+                "name": "Event Invalid URL",
+                "organization_id": org1["id"],
+                "is_superuser": False,
+            },
+        )
+        assert resp.status_code == 201
+        user_id = resp.json()["id"]
+
+        send_resp = e2e_client.post(
+            f"/api/users/{user_id}/invite/send",
+            headers=platform_admin.headers,
+            json={"registration_url": "https://example.test/accept-invite"},
+        )
+        assert send_resp.status_code == 400
+
+        e2e_client.patch(
+            f"/api/users/{user_id}",
+            headers=platform_admin.headers,
+            json={"is_active": False},
+        )
+        e2e_client.delete(f"/api/users/{user_id}", headers=platform_admin.headers)
+
+    def test_send_invite_rejects_link_for_another_user(
+        self, e2e_client, platform_admin, org1
+    ):
+        """POST /invite/send cannot send a token belonging to a different user."""
+        first = e2e_client.post(
+            "/api/users",
+            headers=platform_admin.headers,
+            json={
+                "email": "inv-event-owner-a@gobifrost.dev",
+                "name": "Owner A",
+                "organization_id": org1["id"],
+                "is_superuser": False,
+            },
+        )
+        second = e2e_client.post(
+            "/api/users",
+            headers=platform_admin.headers,
+            json={
+                "email": "inv-event-owner-b@gobifrost.dev",
+                "name": "Owner B",
+                "organization_id": org1["id"],
+                "is_superuser": False,
+            },
+        )
+        assert first.status_code == 201
+        assert second.status_code == 201
+        first_body = first.json()
+        second_body = second.json()
+
+        send_resp = e2e_client.post(
+            f"/api/users/{second_body['id']}/invite/send",
+            headers=platform_admin.headers,
+            json={"registration_url": first_body["registration_url"]},
+        )
+        assert send_resp.status_code == 400
+
+        for body in (first_body, second_body):
+            e2e_client.patch(
+                f"/api/users/{body['id']}",
+                headers=platform_admin.headers,
+                json={"is_active": False},
+            )
+            e2e_client.delete(
+                f"/api/users/{body['id']}", headers=platform_admin.headers
+            )
 
     def test_resend_invite_emits_event(self, e2e_client, platform_admin, org1):
         """POST /users/{id}/invite/resend returns event_emitted=True."""
@@ -313,10 +496,10 @@ class TestUserInvitedEvent:
         )
         e2e_client.delete(f"/api/users/{user_id}", headers=platform_admin.headers)
 
-    def test_create_with_trigger_automation_false_skips_event(
+    def test_create_with_trigger_automation_false_still_creates_link(
         self, e2e_client, platform_admin, org1
     ):
-        """POST /users with invite=True and trigger_automation=False: invite record created, no event."""
+        """Legacy automation flags do not stop invite-link creation."""
         resp = e2e_client.post(
             "/api/users",
             headers=platform_admin.headers,
@@ -332,6 +515,7 @@ class TestUserInvitedEvent:
         assert resp.status_code == 201
         body = resp.json()
         assert body["invite_status"] == "pending"
+        assert "accept-invite?token=" in body["registration_url"]
         user_id = body["id"]
 
         # Cleanup

--- a/api/tests/e2e/api/test_user_invites.py
+++ b/api/tests/e2e/api/test_user_invites.py
@@ -92,6 +92,12 @@ class TestUserInviteFlags:
         assert target["is_registered"] is False
         assert target["invite_status"] == "active"
 
+        regenerate = e2e_client.post(
+            f"/api/users/{body['id']}/invite/regenerate",
+            headers=platform_admin.headers,
+        )
+        assert regenerate.status_code == 409
+
         e2e_client.patch(
             f"/api/users/{body['id']}",
             headers=platform_admin.headers,
@@ -291,7 +297,7 @@ class TestRegisterFromInvite:
 
         login_resp = e2e_client.post(
             "/auth/login",
-            data={"username": email, "password": "anything"},
+            data={"username": email, AUTH_SECRET_FIELD: "anything"},
         )
         assert login_resp.status_code == 401
         assert (

--- a/api/tests/unit/services/test_audit.py
+++ b/api/tests/unit/services/test_audit.py
@@ -24,6 +24,23 @@ def _reset_actor():
     clear_actor()
 
 
+class _SavepointCM:
+    """Async context-manager stand-in for AsyncSession.begin_nested()."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _session_mock() -> MagicMock:
+    """A session mock whose begin_nested() is a usable async savepoint."""
+    db = MagicMock()
+    db.begin_nested = MagicMock(return_value=_SavepointCM())
+    return db
+
+
 class TestActorContext:
     def test_current_actor_empty_by_default(self):
         assert current_actor() is None
@@ -90,7 +107,7 @@ class TestEmitAudit:
             )
         )
 
-        db = MagicMock()
+        db = _session_mock()
         resource_id = uuid4()
         await emit_audit(
             db,
@@ -129,7 +146,7 @@ class TestEmitAudit:
         )
 
         # Should NOT raise.
-        await emit_audit(MagicMock(), "user.create")
+        await emit_audit(_session_mock(), "user.create")
 
     @pytest.mark.asyncio
     async def test_actor_override_wins(self, monkeypatch):
@@ -153,7 +170,7 @@ class TestEmitAudit:
         # Override says Bob
         bob_id = uuid4()
         await emit_audit(
-            MagicMock(),
+            _session_mock(),
             "auth.login.success",
             actor_override=ActorContext(
                 user_id=bob_id,

--- a/client/e2e/users.admin.spec.ts
+++ b/client/e2e/users.admin.spec.ts
@@ -138,12 +138,46 @@ test.describe("User Invitation", () => {
 		const orgs = await orgsResp.json();
 		const organizationId = orgs[0]?.id as string | undefined;
 
-		// Create user without invite flag (avoid triggering automations)
+		// Create the user directly; registration links are created automatically,
+		// but sending the registration email remains an explicit admin action.
 		const createResp = await api.post("/api/users", {
-			data: { email, name: "Playwright Invitee", invite: false, organization_id: organizationId },
+			data: {
+				email,
+				name: "Playwright Invitee",
+				invite: false,
+				organization_id: organizationId,
+			},
 		});
-		expect(createResp.ok(), `Create user failed: ${await createResp.text()}`).toBe(true);
+		expect(
+			createResp.ok(),
+			`Create user failed: ${await createResp.text()}`,
+		).toBe(true);
 		const { id: userId } = await createResp.json();
+
+		await page.goto("/users");
+		await expect(
+			page.getByRole("heading", { name: /users/i }).first(),
+		).toBeVisible({ timeout: 10000 });
+		const invitedRow = page.locator("tbody tr", { hasText: email }).first();
+		await expect(invitedRow).toBeVisible({ timeout: 10000 });
+		await invitedRow.getByRole("button", { name: /user actions/i }).click();
+		await page
+			.getByRole("menuitem", { name: /generate registration link/i })
+			.click();
+		const registrationDialog = page.getByRole("dialog", {
+			name: /user created/i,
+		});
+		await expect(registrationDialog).toBeVisible();
+		await expect(
+			registrationDialog.getByRole("button", {
+				name: /copy registration link/i,
+			}),
+		).toBeVisible();
+		await expect(registrationDialog.getByRole("textbox")).toHaveCount(0);
+		await expect(registrationDialog.getByRole("link")).toHaveCount(0);
+		await registrationDialog
+			.getByRole("button", { name: /close/i })
+			.click();
 
 		// Regenerate invite to get a registration URL (does not send email)
 		const genResp = await api.post(
@@ -159,28 +193,38 @@ test.describe("User Invitation", () => {
 
 		// Complete registration in a fresh (unauthenticated) browser context
 		const baseURL = process.env.TEST_BASE_URL || "http://localhost:3000";
-		const guestCtx = await browser.newContext({ baseURL });
+		const guestCtx = await browser.newContext({
+			baseURL,
+			storageState: { cookies: [], origins: [] },
+		});
 		const guestPage = await guestCtx.newPage();
 		// Navigate to login first to warm up the Vite module graph, then go to the invite page.
 		// The Vite dev server transforms modules on-demand; the first cold load of a new browser
 		// context takes 5-15 seconds. Waiting for the login heading ensures modules are cached.
 		await guestPage.goto("/login");
 		await expect(
-			guestPage.getByRole("heading", { name: /sign in/i }).or(
-				guestPage.getByRole("heading", { name: /bifrost/i }),
-			),
+			guestPage
+				.getByRole("heading", { name: /sign in/i })
+				.or(guestPage.getByRole("heading", { name: /bifrost/i })),
 		).toBeVisible({ timeout: 30000 });
 		await guestPage.goto(registerPath);
 
 		await expect(
-			guestPage.getByRole("heading", { name: /complete your registration/i }),
+			guestPage.getByRole("heading", {
+				name: /complete your registration/i,
+			}),
 		).toBeVisible({ timeout: 15000 });
 
+		await guestPage
+			.getByRole("button", { name: /use password instead/i })
+			.click();
 		await guestPage.getByLabel(/password/i).fill("InviteePass123!");
-		await guestPage.getByRole("button", { name: /create account/i }).click();
+		await guestPage
+			.getByRole("button", { name: /create account/i })
+			.click();
 
 		// Should redirect to login after successful registration
-		await guestPage.waitForURL("**/login", { timeout: 10000 });
+		await guestPage.waitForURL(/\/login(?:\?|$)/, { timeout: 10000 });
 
 		await guestCtx.close();
 

--- a/client/src/components/auth/AuthSetupSteps.test.tsx
+++ b/client/src/components/auth/AuthSetupSteps.test.tsx
@@ -31,9 +31,40 @@ describe("AuthSetupSteps", () => {
 			/>,
 		);
 		await userEvent.click(screen.getByRole("button", { name: /use password instead/i }));
-		await userEvent.type(screen.getByLabelText(/password/i), "secret123");
+		await userEvent.type(screen.getByLabelText("Password"), "secret123");
+		await userEvent.type(
+			screen.getByLabelText(/confirm password/i),
+			"secret123",
+		);
 		await userEvent.click(screen.getByRole("button", { name: /create account/i }));
 		expect(onPwd).toHaveBeenCalledWith("secret123");
+	});
+
+	it("blocks submission until the passwords match", async () => {
+		const onPwd = vi.fn().mockResolvedValue(undefined);
+		render(
+			<AuthSetupSteps
+				email="x@y.com"
+				onPasskeyRegister={vi.fn()}
+				onPasswordRegister={onPwd}
+				isPending={false}
+				error={null}
+			/>,
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: /use password instead/i }),
+		);
+		await userEvent.type(screen.getByLabelText("Password"), "secret123");
+		await userEvent.type(
+			screen.getByLabelText(/confirm password/i),
+			"secret124",
+		);
+
+		expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /create account/i }),
+		).toBeDisabled();
+		expect(onPwd).not.toHaveBeenCalled();
 	});
 
 	it("displays error when provided", () => {

--- a/client/src/components/auth/AuthSetupSteps.tsx
+++ b/client/src/components/auth/AuthSetupSteps.tsx
@@ -14,6 +14,7 @@ interface Props {
 }
 
 export function AuthSetupSteps({
+	email,
 	onPasskeyRegister,
 	onPasswordRegister,
 	isPending,
@@ -21,9 +22,13 @@ export function AuthSetupSteps({
 }: Props) {
 	const [showPassword, setShowPassword] = useState(false);
 	const [password, setPassword] = useState("");
+	const [confirmPassword, setConfirmPassword] = useState("");
+
+	const passwordsMatch = password === confirmPassword;
 
 	const handlePasswordSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
+		if (!password || !passwordsMatch) return;
 		await onPasswordRegister(password);
 	};
 
@@ -63,6 +68,18 @@ export function AuthSetupSteps({
 				</div>
 			) : (
 				<form onSubmit={handlePasswordSubmit} className="space-y-4">
+					{/* Hidden username field lets password managers associate the
+					    saved credential with the right account. */}
+					{email && (
+						<input
+							type="text"
+							name="username"
+							autoComplete="username"
+							value={email}
+							readOnly
+							hidden
+						/>
+					)}
 					<div className="space-y-2">
 						<Label htmlFor="auth-password">Password</Label>
 						<div className="relative">
@@ -76,14 +93,44 @@ export function AuthSetupSteps({
 								className="pl-10"
 								required
 								minLength={8}
+								autoComplete="new-password"
 								autoFocus
 							/>
 						</div>
 					</div>
+					<div className="space-y-2">
+						<Label htmlFor="auth-confirm-password">
+							Confirm password
+						</Label>
+						<div className="relative">
+							<Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+							<Input
+								id="auth-confirm-password"
+								type="password"
+								placeholder="Re-enter your password"
+								value={confirmPassword}
+								onChange={(e) =>
+									setConfirmPassword(e.target.value)
+								}
+								className="pl-10"
+								required
+								minLength={8}
+								autoComplete="new-password"
+								aria-invalid={
+									confirmPassword.length > 0 && !passwordsMatch
+								}
+							/>
+						</div>
+						{confirmPassword.length > 0 && !passwordsMatch && (
+							<p className="text-sm text-destructive">
+								Passwords do not match.
+							</p>
+						)}
+					</div>
 					<Button
 						type="submit"
 						className="w-full"
-						disabled={isPending || !password}
+						disabled={isPending || !password || !passwordsMatch}
 					>
 						{isPending && (
 							<Loader2 className="h-4 w-4 animate-spin mr-2" />

--- a/client/src/components/auth/AuthTransition.tsx
+++ b/client/src/components/auth/AuthTransition.tsx
@@ -1,0 +1,34 @@
+import { Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+
+import { Logo } from "@/components/branding/Logo";
+import { Card, CardContent } from "@/components/ui/card";
+
+/**
+ * Full-card "we're finishing up" state for auth flows.
+ *
+ * Shown in the window between a credential/passkey/password success and the
+ * redirect, where the server is still resolving the session. Without it the
+ * page sits on the form (with only a small button spinner) for a beat on a
+ * slow connection, which reads as "nothing happened".
+ */
+export function AuthTransition({ message }: { message: string }) {
+	return (
+		<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 p-4">
+			<Card className="w-full max-w-md border-primary/10 shadow-xl shadow-primary/5">
+				<CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+					<motion.div
+						initial={{ scale: 0.8, opacity: 0 }}
+						animate={{ scale: 1, opacity: 1 }}
+						transition={{ duration: 0.3 }}
+						className="flex justify-center"
+					>
+						<Logo type="square" className="h-16 w-16" alt="Bifrost" />
+					</motion.div>
+					<Loader2 className="h-6 w-6 animate-spin text-primary" />
+					<p className="text-sm text-muted-foreground">{message}</p>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/client/src/components/users/CreateUserDialog.test.tsx
+++ b/client/src/components/users/CreateUserDialog.test.tsx
@@ -19,8 +19,10 @@ import { renderWithProviders, screen, waitFor } from "@/test-utils";
 
 const mockCreateMutate = vi.fn();
 const mockAssignMutate = vi.fn();
+const mockSendInviteMutate = vi.fn();
 const mockOrganizations = vi.fn();
 const mockRoles = vi.fn();
+const mockEventSources = vi.fn();
 
 vi.mock("@/hooks/useUsers", () => ({
 	useCreateUser: () => ({
@@ -39,6 +41,17 @@ vi.mock("@/hooks/useRoles", () => ({
 
 vi.mock("@/hooks/useOrganizations", () => ({
 	useOrganizations: () => mockOrganizations(),
+}));
+
+vi.mock("@/services/events", () => ({
+	useEventSources: () => mockEventSources(),
+}));
+
+vi.mock("@/hooks/useUserInvites", () => ({
+	useSendInvite: () => ({
+		mutateAsync: mockSendInviteMutate,
+		isPending: false,
+	}),
 }));
 
 // Stub the Combobox to a native select so userEvent can drive it.
@@ -74,9 +87,14 @@ import { CreateUserDialog } from "./CreateUserDialog";
 
 beforeEach(() => {
 	mockCreateMutate.mockReset();
-	mockCreateMutate.mockResolvedValue({ id: "new-user-1" });
+	mockCreateMutate.mockResolvedValue({
+		id: "new-user-1",
+		registration_url: "https://example.test/accept-invite?token=abc",
+	});
 	mockAssignMutate.mockReset();
 	mockAssignMutate.mockResolvedValue({});
+	mockSendInviteMutate.mockReset();
+	mockSendInviteMutate.mockResolvedValue({});
 	mockOrganizations.mockReturnValue({
 		data: [
 			{
@@ -95,6 +113,19 @@ beforeEach(() => {
 		isLoading: false,
 	});
 	mockRoles.mockReturnValue({ data: [] });
+	mockEventSources.mockReturnValue({
+		data: {
+			items: [
+				{
+					id: "source-1",
+					source_type: "topic",
+					event_type: "user.invited",
+					is_active: true,
+					subscription_count: 1,
+				},
+			],
+		},
+	});
 });
 
 describe("CreateUserDialog — validation", () => {
@@ -124,7 +155,7 @@ describe("CreateUserDialog — validation", () => {
 });
 
 describe("CreateUserDialog — happy path", () => {
-	it("submits createUser with trimmed email + name and org id", async () => {
+	it("always creates a registration link without triggering invite automation", async () => {
 		const onOpenChange = vi.fn();
 		const { user } = renderWithProviders(
 			<CreateUserDialog open={true} onOpenChange={onOpenChange} />,
@@ -153,9 +184,82 @@ describe("CreateUserDialog — happy path", () => {
 				is_superuser: false,
 				organization_id: "org-1",
 				invite: true,
-				trigger_automation: true,
+				trigger_automation: false,
 			},
 		});
 		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(
+			await screen.findByRole("heading", { name: /user created/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("https://example.test/accept-invite?token=abc"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /send registration email/i }),
+		).toBeEnabled();
+		expect(
+			screen.getByRole("button", { name: /copy registration link/i }),
+		).toBeInTheDocument();
+	});
+
+	it("disables sending registration email when no user.invited automation is configured", async () => {
+		mockEventSources.mockReturnValue({ data: { items: [] } });
+		const { user } = renderWithProviders(
+			<CreateUserDialog open={true} onOpenChange={vi.fn()} />,
+		);
+
+		await user.type(
+			screen.getByLabelText(/email address/i),
+			"alice@example.com",
+		);
+		await user.type(screen.getByLabelText(/display name/i), "Alice");
+		await user.selectOptions(
+			screen.getByLabelText(/organization/i),
+			"org-1",
+		);
+		await user.click(screen.getByRole("button", { name: /create user/i }));
+
+		await waitFor(() => expect(mockCreateMutate).toHaveBeenCalled());
+		expect(
+			await screen.findByRole("button", {
+				name: /send registration email/i,
+			}),
+		).toBeDisabled();
+		expect(
+			screen.queryByLabelText(/create invite link/i),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(/trigger invite automation/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("sends the registration email from the success dialog", async () => {
+		const { user } = renderWithProviders(
+			<CreateUserDialog open={true} onOpenChange={vi.fn()} />,
+		);
+
+		await user.type(
+			screen.getByLabelText(/email address/i),
+			"alice@example.com",
+		);
+		await user.type(screen.getByLabelText(/display name/i), "Alice");
+		await user.selectOptions(
+			screen.getByLabelText(/organization/i),
+			"org-1",
+		);
+		await user.click(screen.getByRole("button", { name: /create user/i }));
+
+		await user.click(
+			await screen.findByRole("button", {
+				name: /send registration email/i,
+			}),
+		);
+
+		await waitFor(() => {
+			expect(mockSendInviteMutate).toHaveBeenCalledWith({
+				userId: "new-user-1",
+				registrationUrl: "https://example.test/accept-invite?token=abc",
+			});
+		});
 	});
 });

--- a/client/src/components/users/CreateUserDialog.tsx
+++ b/client/src/components/users/CreateUserDialog.tsx
@@ -26,17 +26,22 @@ import {
 	CommandItem,
 	CommandList,
 } from "@/components/ui/command";
-import { Shield, AlertCircle, Loader2, Check, ChevronsUpDown, X, Info } from "lucide-react";
 import {
-	HoverCard,
-	HoverCardContent,
-	HoverCardTrigger,
-} from "@/components/ui/hover-card";
+	Shield,
+	AlertCircle,
+	Loader2,
+	Check,
+	ChevronsUpDown,
+	X,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCreateUser } from "@/hooks/useUsers";
 import { useRoles, useAssignUsersToRole } from "@/hooks/useRoles";
 import { useOrganizations } from "@/hooks/useOrganizations";
+import { useEventSources } from "@/services/events";
+import { useSendInvite } from "@/hooks/useUserInvites";
+import { RegistrationLinkDialog } from "@/components/users/RegistrationLinkDialog";
 import { toast } from "sonner";
 import type { components } from "@/lib/v1";
 
@@ -51,17 +56,23 @@ interface CreateUserDialogProps {
 // Extract dialog content to separate component for key-based remounting
 function CreateUserDialogContent({
 	onOpenChange,
+	onRegistrationLinkCreated,
 }: {
 	onOpenChange: (open: boolean) => void;
+	onRegistrationLinkCreated: (
+		userId: string,
+		email: string,
+		url: string,
+	) => void;
 }) {
 	const [email, setEmail] = useState("");
 	const [displayName, setDisplayName] = useState("");
 	const [isPlatformAdmin, setIsPlatformAdmin] = useState(false);
 	const [orgId, setOrgId] = useState<string>("");
-	const [sendInvite, setSendInvite] = useState(true);
-	const [triggerAutomation, setTriggerAutomation] = useState(true);
 	const [validationError, setValidationError] = useState<string | null>(null);
-	const [selectedRoleIds, setSelectedRoleIds] = useState<Set<string>>(new Set());
+	const [selectedRoleIds, setSelectedRoleIds] = useState<Set<string>>(
+		new Set(),
+	);
 	const [rolesPopoverOpen, setRolesPopoverOpen] = useState(false);
 
 	const queryClient = useQueryClient();
@@ -73,7 +84,9 @@ function CreateUserDialogContent({
 	const roles = useMemo(() => (allRoles ?? []) as Role[], [allRoles]);
 
 	// Find the provider org (for auto-selecting when platform admin is chosen)
-	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
+	const providerOrg = organizations?.find(
+		(org: Organization) => org.is_provider,
+	);
 
 	// Auto-select provider org when switching to platform admin
 	const handleUserTypeChange = (value: string) => {
@@ -145,8 +158,8 @@ function CreateUserDialogContent({
 					is_active: true,
 					is_superuser: isPlatformAdmin,
 					organization_id: orgId || null,
-					invite: sendInvite,
-					trigger_automation: triggerAutomation,
+					invite: true,
+					trigger_automation: false,
 				},
 			});
 
@@ -164,14 +177,17 @@ function CreateUserDialogContent({
 			}
 
 			toast.success("User created successfully", {
-				description: sendInvite
-					? triggerAutomation
-						? `Invite automation triggered for ${email}`
-						: `Invite link created for ${email} (automations skipped)`
-					: `${displayName} (${email}) has been added to the platform`,
+				description: `${displayName.trim()} (${email.trim()}) has been added to the platform`,
 			});
 
 			onOpenChange(false);
+			if (result?.id && result?.registration_url) {
+				onRegistrationLinkCreated(
+					result.id,
+					email.trim(),
+					result.registration_url,
+				);
+			}
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error
@@ -298,7 +314,10 @@ function CreateUserDialogContent({
 				{!isPlatformAdmin && (
 					<div className="space-y-2">
 						<Label>Roles</Label>
-						<Popover open={rolesPopoverOpen} onOpenChange={setRolesPopoverOpen}>
+						<Popover
+							open={rolesPopoverOpen}
+							onOpenChange={setRolesPopoverOpen}
+						>
 							<PopoverTrigger asChild>
 								<Button
 									variant="outline"
@@ -306,10 +325,13 @@ function CreateUserDialogContent({
 									aria-expanded={rolesPopoverOpen}
 									className="w-full justify-between font-normal"
 								>
-									<span className={cn(
-										"truncate",
-										selectedRoleIds.size === 0 && "text-muted-foreground",
-									)}>
+									<span
+										className={cn(
+											"truncate",
+											selectedRoleIds.size === 0 &&
+												"text-muted-foreground",
+										)}
+									>
 										{selectedRoleIds.size === 0
 											? "Select roles..."
 											: `${selectedRoleIds.size} role${selectedRoleIds.size === 1 ? "" : "s"} selected`}
@@ -317,31 +339,44 @@ function CreateUserDialogContent({
 									<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
 								</Button>
 							</PopoverTrigger>
-							<PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+							<PopoverContent
+								className="w-[var(--radix-popover-trigger-width)] p-0"
+								align="start"
+							>
 								<Command>
 									<CommandInput placeholder="Search roles..." />
 									<CommandList className="max-h-48 overflow-y-auto">
-										<CommandEmpty>No roles found.</CommandEmpty>
+										<CommandEmpty>
+											No roles found.
+										</CommandEmpty>
 										<CommandGroup>
 											{roles.map((role) => (
 												<CommandItem
 													key={role.id}
 													value={role.id}
 													keywords={[role.name]}
-													onSelect={() => toggleRole(role.id)}
+													onSelect={() =>
+														toggleRole(role.id)
+													}
 												>
 													<div className="flex flex-col flex-1">
-														<span className="font-medium">{role.name}</span>
+														<span className="font-medium">
+															{role.name}
+														</span>
 														{role.description && (
 															<span className="text-xs text-muted-foreground">
-																{role.description}
+																{
+																	role.description
+																}
 															</span>
 														)}
 													</div>
 													<Check
 														className={cn(
 															"ml-auto h-4 w-4",
-															selectedRoleIds.has(role.id)
+															selectedRoleIds.has(
+																role.id,
+															)
 																? "opacity-100"
 																: "opacity-0",
 														)}
@@ -356,7 +391,11 @@ function CreateUserDialogContent({
 						{selectedRoleNames.length > 0 && (
 							<div className="flex flex-wrap gap-1 mt-1">
 								{selectedRoleNames.map(({ id, name }) => (
-									<Badge key={id} variant="secondary" className="text-xs">
+									<Badge
+										key={id}
+										variant="secondary"
+										className="text-xs"
+									>
 										{name}
 										<button
 											type="button"
@@ -373,27 +412,6 @@ function CreateUserDialogContent({
 							Roles determine which forms this user can access
 						</p>
 					</div>
-				)}
-
-				<div className="flex items-center gap-2 pt-1">
-					<input
-						id="sendInvite"
-						type="checkbox"
-						className="h-4 w-4 rounded border-input"
-						checked={sendInvite}
-						onChange={(e) => setSendInvite(e.target.checked)}
-					/>
-					<Label htmlFor="sendInvite" className="cursor-pointer text-sm font-normal">
-						Create invite link
-					</Label>
-				</div>
-
-				{sendInvite && (
-					<TriggerAutomationToggle
-						checked={triggerAutomation}
-						onCheckedChange={setTriggerAutomation}
-						events={["user.invited"]}
-					/>
 				)}
 
 				{isPlatformAdmin && (
@@ -432,63 +450,64 @@ export function CreateUserDialog({
 	open,
 	onOpenChange,
 }: CreateUserDialogProps) {
-	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			{open && <CreateUserDialogContent onOpenChange={onOpenChange} />}
-		</Dialog>
-	);
-}
+	const [registrationLink, setRegistrationLink] = useState<{
+		userId: string;
+		email: string;
+		url: string;
+	} | null>(null);
+	const sendInvite = useSendInvite();
+	const { data: eventSources } = useEventSources({
+		sourceType: "topic",
+		limit: 100,
+	});
+	const inviteAutomationConfigured =
+		eventSources?.items?.some(
+			(source) =>
+				source.is_active &&
+				source.event_type === "user.invited" &&
+				source.subscription_count > 0,
+		) ?? false;
 
-interface TriggerAutomationToggleProps {
-	checked: boolean;
-	onCheckedChange: (v: boolean) => void;
-	events: string[];
-}
-
-export function TriggerAutomationToggle({
-	checked,
-	onCheckedChange,
-	events,
-}: TriggerAutomationToggleProps) {
 	return (
-		<div className="flex items-center gap-2 pl-6">
-			<input
-				id="triggerAutomation"
-				type="checkbox"
-				className="h-4 w-4 rounded border-input"
-				checked={checked}
-				onChange={(e) => onCheckedChange(e.target.checked)}
+		<>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				{open && (
+					<CreateUserDialogContent
+						onOpenChange={onOpenChange}
+						onRegistrationLinkCreated={(userId, email, url) =>
+							setRegistrationLink({ userId, email, url })
+						}
+					/>
+				)}
+			</Dialog>
+			<RegistrationLinkDialog
+				open={registrationLink !== null}
+				email={registrationLink?.email}
+				url={registrationLink?.url}
+				canSendEmail={inviteAutomationConfigured}
+				isSendingEmail={sendInvite.isPending}
+				onSendEmail={async () => {
+					if (!registrationLink) return;
+					try {
+						await sendInvite.mutateAsync({
+							userId: registrationLink.userId,
+							registrationUrl: registrationLink.url,
+						});
+						toast.success("Registration email sent");
+						setRegistrationLink(null);
+					} catch (error) {
+						toast.error("Failed to send registration email", {
+							description:
+								error instanceof Error
+									? error.message
+									: "Unknown error occurred",
+						});
+					}
+				}}
+				onOpenChange={(nextOpen) => {
+					if (!nextOpen) setRegistrationLink(null);
+				}}
 			/>
-			<Label htmlFor="triggerAutomation" className="cursor-pointer text-sm font-normal">
-				Trigger invite automation
-			</Label>
-			<HoverCard>
-				<HoverCardTrigger asChild>
-					<button
-						type="button"
-						aria-label="Learn about invite automation"
-						className="text-muted-foreground hover:text-foreground"
-					>
-						<Info className="h-4 w-4" />
-					</button>
-				</HoverCardTrigger>
-				<HoverCardContent className="w-72 text-sm">
-					<p className="mb-2">
-						Workflows subscribed to these events will run when you create this user.
-						If unchecked, the registration link is generated but no automations run.
-					</p>
-					<div className="flex flex-wrap gap-1">
-						{events.map((event) => (
-							<span
-								key={event}
-								className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs"
-							>
-								{event}
-							</span>
-						))}
-					</div>
-				</HoverCardContent>
-			</HoverCard>
-		</div>
+		</>
 	);
 }

--- a/client/src/components/users/CreateUserDialog.tsx
+++ b/client/src/components/users/CreateUserDialog.tsx
@@ -39,6 +39,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCreateUser } from "@/hooks/useUsers";
 import { useRoles, useAssignUsersToRole } from "@/hooks/useRoles";
 import { useOrganizations } from "@/hooks/useOrganizations";
+import { useAuth } from "@/contexts/AuthContext";
+import { usePlatformAdminOrgSelection } from "./platformAdminOrg";
 import { useEventSources } from "@/services/events";
 import { useSendInvite } from "@/hooks/useUserInvites";
 import { RegistrationLinkDialog } from "@/components/users/RegistrationLinkDialog";
@@ -80,25 +82,19 @@ function CreateUserDialogContent({
 	const assignUsersToRole = useAssignUsersToRole();
 	const { data: organizations, isLoading: orgsLoading } = useOrganizations();
 	const { data: allRoles } = useRoles();
+	const { user: currentUser } = useAuth();
 
 	const roles = useMemo(() => (allRoles ?? []) as Role[], [allRoles]);
 
-	// Find the provider org (for auto-selecting when platform admin is chosen)
-	const providerOrg = organizations?.find(
-		(org: Organization) => org.is_provider,
-	);
-
-	// Auto-select provider org when switching to platform admin
-	const handleUserTypeChange = (value: string) => {
-		const isAdmin = value === "platform";
-		setIsPlatformAdmin(isAdmin);
-		if (isAdmin && providerOrg) {
-			setOrgId(providerOrg.id);
-		} else if (!isAdmin && orgId === providerOrg?.id) {
-			// Clear provider org if switching to org user
-			setOrgId("");
-		}
-	};
+	const { effectiveOrgId, handleUserTypeChange } =
+		usePlatformAdminOrgSelection({
+			organizations,
+			currentUser,
+			isPlatformAdmin,
+			setIsPlatformAdmin,
+			orgId,
+			setOrgId,
+		});
 
 	const toggleRole = (roleId: string) => {
 		setSelectedRoleIds((prev) => {
@@ -135,7 +131,7 @@ function CreateUserDialogContent({
 			setValidationError("Please enter a display name");
 			return false;
 		}
-		if (!orgId) {
+		if (!effectiveOrgId) {
 			setValidationError("Please select an organization");
 			return false;
 		}
@@ -157,7 +153,7 @@ function CreateUserDialogContent({
 					name: displayName.trim(),
 					is_active: true,
 					is_superuser: isPlatformAdmin,
-					organization_id: orgId || null,
+					organization_id: effectiveOrgId || null,
 					invite: true,
 					trigger_automation: false,
 				},

--- a/client/src/components/users/RegistrationLinkDialog.test.tsx
+++ b/client/src/components/users/RegistrationLinkDialog.test.tsx
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, renderWithProviders, screen, waitFor } from "@/test-utils";
+
+import { RegistrationLinkDialog } from "./RegistrationLinkDialog";
+
+let originalWriteText: typeof navigator.clipboard.writeText | undefined;
+
+beforeEach(() => {
+	originalWriteText = navigator.clipboard?.writeText.bind(
+		navigator.clipboard,
+	);
+});
+
+afterEach(() => {
+	if (originalWriteText && navigator.clipboard) {
+		Object.defineProperty(navigator.clipboard, "writeText", {
+			configurable: true,
+			value: originalWriteText,
+		});
+	}
+});
+
+describe("RegistrationLinkDialog", () => {
+	it("shows a centered success message with send and copy actions", () => {
+		const onSendEmail = vi.fn();
+
+		renderWithProviders(
+			<RegistrationLinkDialog
+				open={true}
+				email="alice@example.com"
+				url="/accept-invite?token=abc"
+				canSendEmail={true}
+				onSendEmail={onSendEmail}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: /user created/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/send this to alice@example.com so they can finish logging in/i,
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				`${window.location.origin}/accept-invite?token=abc`,
+			),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText("Recipient")).not.toBeInTheDocument();
+		expect(screen.queryByText("Destination")).not.toBeInTheDocument();
+		expect(screen.queryByText(/link host/i)).not.toBeInTheDocument();
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /send registration email/i }),
+		).toBeEnabled();
+		expect(
+			screen.getByRole("button", { name: /copy registration link/i }),
+		).toBeInTheDocument();
+	});
+
+	it("keeps clipboard failures inside the button state without throwing", () => {
+		(
+			navigator.clipboard as unknown as {
+				writeText: undefined;
+			}
+		).writeText = undefined;
+
+		renderWithProviders(
+			<RegistrationLinkDialog
+				open={true}
+				url="https://example.test/accept-invite?token=abc"
+				canSendEmail={true}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /copy registration link/i }),
+		);
+
+		expect(
+			screen.getByRole("button", { name: /copy registration link/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /copied/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("animates the copy button to a success state", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator.clipboard, "writeText", {
+			configurable: true,
+			value: writeText,
+		});
+
+		const { user } = renderWithProviders(
+			<RegistrationLinkDialog
+				open={true}
+				url="https://example.test/accept-invite?token=abc"
+				canSendEmail={true}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /copy registration link/i }),
+		);
+
+		await waitFor(() => {
+			expect(writeText).toHaveBeenCalledWith(
+				"https://example.test/accept-invite?token=abc",
+			);
+			expect(
+				screen.getByRole("button", { name: /copied/i }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("disables sending when invite automation is not configured", () => {
+		renderWithProviders(
+			<RegistrationLinkDialog
+				open={true}
+				url="https://example.test/accept-invite?token=abc"
+				canSendEmail={false}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: /send registration email/i }),
+		).toBeDisabled();
+		expect(
+			screen.getByLabelText(/registration email automation setup/i),
+		).toBeInTheDocument();
+	});
+
+	it("calls the send email action", async () => {
+		const onSendEmail = vi.fn().mockResolvedValue(undefined);
+
+		const { user } = renderWithProviders(
+			<RegistrationLinkDialog
+				open={true}
+				url="https://example.test/accept-invite?token=abc"
+				canSendEmail={true}
+				onSendEmail={onSendEmail}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /send registration email/i }),
+		);
+
+		await waitFor(() => expect(onSendEmail).toHaveBeenCalledOnce());
+	});
+});

--- a/client/src/components/users/RegistrationLinkDialog.tsx
+++ b/client/src/components/users/RegistrationLinkDialog.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react";
+import { Check, Copy, Info, Loader2, Mail } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { copyToClipboard } from "@/lib/clipboard";
+
+interface RegistrationLinkDialogProps {
+	open: boolean;
+	email?: string;
+	url?: string;
+	canSendEmail: boolean;
+	isSendingEmail?: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSendEmail?: () => void | Promise<void>;
+}
+
+function absoluteRegistrationUrl(url: string): string {
+	try {
+		return new URL(url, window.location.origin).toString();
+	} catch {
+		return url;
+	}
+}
+
+export function RegistrationLinkDialog({
+	open,
+	email,
+	url,
+	canSendEmail,
+	isSendingEmail = false,
+	onOpenChange,
+	onSendEmail,
+}: RegistrationLinkDialogProps) {
+	const normalizedUrl = url ? absoluteRegistrationUrl(url) : "";
+	const sendDisabled = !canSendEmail || !normalizedUrl || isSendingEmail;
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!copied) return;
+		const timer = window.setTimeout(() => setCopied(false), 1600);
+		return () => window.clearTimeout(timer);
+	}, [copied]);
+
+	const handleCopy = async () => {
+		if (!normalizedUrl) return;
+		if (await copyToClipboard(normalizedUrl)) {
+			setCopied(true);
+			toast.success("Registration link copied");
+		} else {
+			setCopied(false);
+			toast.error("Failed to copy registration link");
+		}
+	};
+
+	const handleSendEmail = async () => {
+		if (sendDisabled || !onSendEmail) return;
+		await onSendEmail();
+	};
+
+	const sendButton = (
+		<Button
+			type="button"
+			className="w-full"
+			onClick={handleSendEmail}
+			disabled={sendDisabled}
+		>
+			{isSendingEmail ? (
+				<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+			) : (
+				<Mail className="mr-2 h-4 w-4" />
+			)}
+			Send Registration Email
+			{!canSendEmail && <Info className="ml-2 h-4 w-4 opacity-80" />}
+		</Button>
+	);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader className="items-center text-center">
+					<div className="mb-2 flex h-12 w-12 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-emerald-700">
+						<Check className="h-6 w-6" />
+					</div>
+					<DialogTitle>User Created</DialogTitle>
+					<DialogDescription>
+						{email
+							? `Send this to ${email} so they can finish logging in. They can also log in with SSO and register themselves automatically.`
+							: "Send this to the user so they can finish logging in. They can also log in with SSO and register themselves automatically."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="mt-2 flex flex-col gap-2">
+					{canSendEmail ? (
+						sendButton
+					) : (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span
+									tabIndex={0}
+									aria-label="Registration email automation setup"
+									className="inline-flex w-full cursor-help"
+								>
+									{sendButton}
+								</span>
+							</TooltipTrigger>
+							<TooltipContent className="max-w-xs">
+								Create an active{" "}
+								<span className="font-mono">user.invited</span>{" "}
+								event source with at least one subscription to
+								enable registration emails.
+							</TooltipContent>
+						</Tooltip>
+					)}
+
+					<Button
+						type="button"
+						variant="outline"
+						className="w-full"
+						onClick={handleCopy}
+						disabled={!normalizedUrl}
+					>
+						{copied ? (
+							<Check className="mr-2 h-4 w-4 text-emerald-600" />
+						) : (
+							<Copy className="mr-2 h-4 w-4" />
+						)}
+						{copied ? "Copied" : "Copy Registration Link"}
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/client/src/components/users/UserActionsMenu.test.tsx
+++ b/client/src/components/users/UserActionsMenu.test.tsx
@@ -44,7 +44,7 @@ describe("UserActionsMenu", () => {
 		render(<UserActionsMenu {...makeProps({ status: "pending" })} />);
 		await user.click(screen.getByRole("button", { name: /user actions/i }));
 		expect(screen.getByText(/resend invite/i)).toBeInTheDocument();
-		expect(screen.getByText(/regenerate link/i)).toBeInTheDocument();
+		expect(screen.getByText(/generate registration link/i)).toBeInTheDocument();
 		expect(screen.getByText(/copy registration link/i)).toBeInTheDocument();
 		expect(screen.getByText(/revoke invite/i)).toBeInTheDocument();
 	});

--- a/client/src/components/users/UserActionsMenu.tsx
+++ b/client/src/components/users/UserActionsMenu.tsx
@@ -62,7 +62,7 @@ export function UserActionsMenu({
 						</DropdownMenuItem>
 						<DropdownMenuItem onClick={onRegenerate}>
 							<RefreshCw className="mr-2 h-4 w-4" />
-							Regenerate link
+							Generate registration link
 						</DropdownMenuItem>
 						<DropdownMenuItem onClick={onCopyLink}>
 							<LinkIcon className="mr-2 h-4 w-4" />

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -67,6 +67,7 @@ interface AuthContextValue {
 		state: string,
 	) => Promise<void>;
 	loginWithPasskey: (email?: string) => Promise<void>;
+	completeLoginWithToken: (accessToken: string) => void;
 	logout: () => void;
 	refreshToken: () => Promise<boolean>;
 	checkAuthStatus: () => Promise<void>;
@@ -143,6 +144,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
 	const [needsSetup, setNeedsSetup] = useState(false);
 	const navigate = useNavigate();
 	const location = useLocation();
+
+	const completeLoginWithToken = useCallback((accessToken: string): void => {
+		clearEmbedToken();
+		localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+
+		const payload = parseJwt(accessToken);
+		if (payload) {
+			const extractedUser = extractUser(payload);
+			setUser(extractedUser);
+			localStorage.setItem(USER_KEY, JSON.stringify(extractedUser));
+			sessionStorage.setItem("userId", extractedUser.id);
+		}
+	}, []);
 
 	// Internal refresh function (no hooks)
 	// Uses HttpOnly cookie for refresh token (browser sends it automatically)
@@ -284,26 +298,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
 			// Success - store access token (refresh token is in HttpOnly cookie)
 			if (data.access_token) {
-				clearEmbedToken();
-				localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
-
-				const payload = parseJwt(data.access_token);
-				if (payload) {
-					const extractedUser = extractUser(payload);
-					setUser(extractedUser);
-					localStorage.setItem(
-						USER_KEY,
-						JSON.stringify(extractedUser),
-					);
-					sessionStorage.setItem("userId", extractedUser.id);
-				}
-
+				completeLoginWithToken(data.access_token);
 				return { success: true };
 			}
 
 			throw new Error("No access token received");
 		},
-		[],
+		[completeLoginWithToken],
 	);
 
 	// Complete MFA verification during login (for users with MFA already set up)
@@ -331,22 +332,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			const data = await res.json();
 
 			if (data.access_token) {
-				clearEmbedToken();
-				localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
-
-				const payload = parseJwt(data.access_token);
-				if (payload) {
-					const extractedUser = extractUser(payload);
-					setUser(extractedUser);
-					localStorage.setItem(
-						USER_KEY,
-						JSON.stringify(extractedUser),
-					);
-					sessionStorage.setItem("userId", extractedUser.id);
-				}
+				completeLoginWithToken(data.access_token);
 			}
 		},
-		[],
+		[completeLoginWithToken],
 	);
 
 	// Complete OAuth login
@@ -376,22 +365,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			const data = await res.json();
 
 			if (data.access_token) {
-				clearEmbedToken();
-				localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
-
-				const payload = parseJwt(data.access_token);
-				if (payload) {
-					const extractedUser = extractUser(payload);
-					setUser(extractedUser);
-					localStorage.setItem(
-						USER_KEY,
-						JSON.stringify(extractedUser),
-					);
-					sessionStorage.setItem("userId", extractedUser.id);
-				}
+				completeLoginWithToken(data.access_token);
 			}
 		},
-		[],
+		[completeLoginWithToken],
 	);
 
 	// Login with passkey (passwordless authentication)
@@ -404,22 +381,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			const tokens = await authenticateWithPasskey(email);
 
 			if (tokens.access_token) {
-				clearEmbedToken();
-				localStorage.setItem(ACCESS_TOKEN_KEY, tokens.access_token);
-
-				const payload = parseJwt(tokens.access_token);
-				if (payload) {
-					const extractedUser = extractUser(payload);
-					setUser(extractedUser);
-					localStorage.setItem(
-						USER_KEY,
-						JSON.stringify(extractedUser),
-					);
-					sessionStorage.setItem("userId", extractedUser.id);
-				}
+				completeLoginWithToken(tokens.access_token);
 			}
 		},
-		[],
+		[completeLoginWithToken],
 	);
 
 	// Logout
@@ -484,11 +449,24 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			loginWithMfa,
 			loginWithOAuth,
 			loginWithPasskey,
+			completeLoginWithToken,
 			logout,
 			refreshToken,
 			checkAuthStatus,
 		}),
-		[user, isLoading, needsSetup, login, loginWithMfa, loginWithOAuth, loginWithPasskey, logout, refreshToken, checkAuthStatus],
+		[
+			user,
+			isLoading,
+			needsSetup,
+			login,
+			loginWithMfa,
+			loginWithOAuth,
+			loginWithPasskey,
+			completeLoginWithToken,
+			logout,
+			refreshToken,
+			checkAuthStatus,
+		],
 	);
 
 	return (

--- a/client/src/hooks/useUserInvites.ts
+++ b/client/src/hooks/useUserInvites.ts
@@ -4,6 +4,7 @@ import {
 	regenerateInvite,
 	resendInvite,
 	revokeInvite,
+	sendInviteEmail,
 } from "@/services/user-invites";
 
 const USERS_QUERY_KEYS: ReadonlyArray<string> = ["users", "/api/users"];
@@ -26,6 +27,20 @@ export function useRegenerateInvite() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: (userId: string) => regenerateInvite(userId),
+		onSuccess: () => invalidateUsers(qc),
+	});
+}
+
+export function useSendInvite() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: ({
+			userId,
+			registrationUrl,
+		}: {
+			userId: string;
+			registrationUrl: string;
+		}) => sendInviteEmail(userId, registrationUrl),
 		onSuccess: () => invalidateUsers(qc),
 	});
 }

--- a/client/src/lib/clipboard.ts
+++ b/client/src/lib/clipboard.ts
@@ -1,0 +1,65 @@
+/**
+ * Copy text to the clipboard, working in both secure and insecure contexts.
+ *
+ * The async Clipboard API (`navigator.clipboard`) is only exposed in secure
+ * contexts — HTTPS, or `localhost` / `127.0.0.1` over HTTP. When the dev or
+ * preview server is reached over plain HTTP on any other host (an IP address or
+ * a hostname like `http://devbox:5173`), `navigator.clipboard` is `undefined`
+ * and every copy silently fails. In that case we fall back to the legacy
+ * `document.execCommand("copy")` path, which works regardless of secure context.
+ *
+ * @returns `true` if the copy succeeded, `false` otherwise. Callers decide how
+ * to surface success/failure (toast, button state, etc.).
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+	try {
+		if (navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(text);
+			return true;
+		}
+	} catch {
+		// Secure-context API exists but rejected (permissions, not focused,
+		// etc.) — fall through to the legacy path.
+	}
+
+	return legacyCopy(text);
+}
+
+function legacyCopy(text: string): boolean {
+	if (typeof document === "undefined") return false;
+
+	const textarea = document.createElement("textarea");
+	textarea.value = text;
+	textarea.setAttribute("readonly", "");
+	// Keep it off-screen and inert so it doesn't scroll, flash, or steal layout.
+	textarea.style.position = "fixed";
+	textarea.style.top = "0";
+	textarea.style.left = "0";
+	textarea.style.opacity = "0";
+	textarea.style.pointerEvents = "none";
+
+	document.body.appendChild(textarea);
+
+	// Preserve any selection we're about to clobber so we can restore it.
+	const selection = document.getSelection();
+	const previousRange =
+		selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+	textarea.select();
+
+	let succeeded = false;
+	try {
+		succeeded = document.execCommand("copy");
+	} catch {
+		succeeded = false;
+	}
+
+	document.body.removeChild(textarea);
+
+	if (previousRange && selection) {
+		selection.removeAllRanges();
+		selection.addRange(previousRange);
+	}
+
+	return succeeded;
+}

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -713,6 +713,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/register-from-invite/passkey/options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register From Invite Passkey Options
+         * @description Start passkey registration for a user holding a valid invite token.
+         */
+        post: operations["register_from_invite_passkey_options_auth_register_from_invite_passkey_options_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/register-from-invite/passkey/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register From Invite Passkey Verify
+         * @description Complete invite registration by verifying a passkey and logging the user in.
+         */
+        post: operations["register_from_invite_passkey_verify_auth_register_from_invite_passkey_verify_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/mfa/status": {
         parameters: {
             query?: never;
@@ -1335,6 +1375,26 @@ export interface paths {
          * @description Generate a fresh invite token and email it to the user.
          */
         post: operations["resend_invite_api_users__user_id__invite_resend_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{user_id}/invite/send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send invite
+         * @description Emit invite automation for an existing registration link without rotating the token.
+         */
+        post: operations["send_invite_api_users__user_id__invite_send_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2437,7 +2497,7 @@ export interface paths {
         put?: never;
         /**
          * Read File
-         * @description Read a file from workspace, temp, or uploads.
+         * @description Read a file from a managed or custom location.
          */
         post: operations["read_file_api_files_read_post"];
         delete?: never;
@@ -2457,7 +2517,7 @@ export interface paths {
         put?: never;
         /**
          * Write File
-         * @description Write a file to workspace, temp, or uploads.
+         * @description Write a file to a managed or custom location.
          */
         post: operations["write_file_api_files_write_post"];
         delete?: never;
@@ -2477,7 +2537,7 @@ export interface paths {
         put?: never;
         /**
          * Delete File
-         * @description Delete a file from workspace, temp, or uploads.
+         * @description Delete a file from a managed or custom location.
          */
         post: operations["delete_file_api_files_delete_post"];
         delete?: never;
@@ -13395,7 +13455,7 @@ export interface components {
             path: string;
             /**
              * Location
-             * @description Storage location: reserved (workspace, temp, uploads) or freeform
+             * @description Storage location. Special values: workspace (default), temp, uploads. Custom names like reports are accepted; internal prefixes _repo, _tmp, and _apps are blocked.
              * @default workspace
              */
             location: string;
@@ -13460,7 +13520,7 @@ export interface components {
             path: string;
             /**
              * Location
-             * @description Storage location: reserved (workspace, temp, uploads) or freeform
+             * @description Storage location. Special values: workspace (default), temp, uploads. Custom names like reports are accepted; internal prefixes _repo, _tmp, and _apps are blocked.
              * @default workspace
              */
             location: string;
@@ -13515,7 +13575,7 @@ export interface components {
             directory: string;
             /**
              * Location
-             * @description Storage location: reserved (workspace, temp, uploads) or freeform
+             * @description Storage location. Special values: workspace (default), temp, uploads. Custom names like reports are accepted; internal prefixes _repo, _tmp, and _apps are blocked.
              * @default workspace
              */
             location: string;
@@ -13663,7 +13723,7 @@ export interface components {
             path: string;
             /**
              * Location
-             * @description Storage location: reserved (workspace, temp, uploads) or freeform
+             * @description Storage location. Special values: workspace (default), temp, uploads. Custom names like reports are accepted; internal prefixes _repo, _tmp, and _apps are blocked.
              * @default workspace
              */
             location: string;
@@ -13775,7 +13835,7 @@ export interface components {
             content: string;
             /**
              * Location
-             * @description Storage location: reserved (workspace, temp, uploads) or freeform
+             * @description Storage location. Special values: workspace (default), temp, uploads. Custom names like reports are accepted; internal prefixes _repo, _tmp, and _apps are blocked.
              * @default workspace
              */
             location: string;
@@ -15168,6 +15228,40 @@ export interface components {
              * @description Default value for entity_id in URL templates (e.g., 'common' for Azure multi-tenant)
              */
             default_entity_id?: string | null;
+        };
+        /**
+         * InvitePasskeyOptionsRequest
+         * @description Request to start passkey registration from an invite token.
+         */
+        InvitePasskeyOptionsRequest: {
+            /**
+             * Token
+             * @description Invite token from the registration URL
+             */
+            token: string;
+        };
+        /**
+         * InvitePasskeyVerifyRequest
+         * @description Request to complete invite registration with a passkey.
+         */
+        InvitePasskeyVerifyRequest: {
+            /**
+             * Token
+             * @description Invite token from the registration URL
+             */
+            token: string;
+            /**
+             * Credential
+             * @description WebAuthn credential from navigator.credentials.create()
+             */
+            credential: {
+                [key: string]: unknown;
+            };
+            /**
+             * Device Name
+             * @description Friendly name for the passkey
+             */
+            device_name?: string | null;
         };
         /**
          * JobStatusResponse
@@ -18973,7 +19067,7 @@ export interface components {
             name: string;
             /**
              * Scope
-             * @description Optional org scope. Omit / pass null to list only the caller's own org mapping. Platform admins and provider-org members may pass 'global' (no filter, all orgs) or a specific org UUID.
+             * @description Optional org scope. Omit / pass null to list only the caller's own org mapping, unless the resolved org is a provider org, which lists all mappings. Platform admins and provider-org members may pass 'global' (no filter, all orgs) or a specific org UUID.
              */
             scope?: string | null;
         };
@@ -19410,6 +19504,14 @@ export interface components {
         SendFlagMessageRequest: {
             /** Content */
             content: string;
+        };
+        /**
+         * SendInviteRequest
+         * @description Request to emit invite automation for an existing raw registration link.
+         */
+        SendInviteRequest: {
+            /** Registration Url */
+            registration_url: string;
         };
         /**
          * SetConfigRequest
@@ -19938,6 +20040,23 @@ export interface components {
             topic: string;
             /** Description */
             description: string;
+            /**
+             * Category
+             * @description Grouping for this built-in topic.
+             */
+            category: string;
+            /**
+             * Emitted By
+             * @description Platform surface that emits this topic.
+             */
+            emitted_by: string;
+            /**
+             * Example Body
+             * @description Representative context.event.data body for this topic.
+             */
+            example_body?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * TopicsRegistryResponse
@@ -20431,6 +20550,8 @@ export interface components {
              * @default active
              */
             invite_status: string;
+            /** Registration Url */
+            registration_url?: string | null;
         };
         /**
          * UserResponse
@@ -22392,6 +22513,72 @@ export interface operations {
             };
         };
     };
+    register_from_invite_passkey_options_auth_register_from_invite_passkey_options_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvitePasskeyOptionsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetupPasskeyOptionsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_from_invite_passkey_verify_auth_register_from_invite_passkey_verify_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvitePasskeyVerifyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetupPasskeyVerifyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_mfa_status_auth_mfa_status_get: {
         parameters: {
             query?: never;
@@ -23211,6 +23398,41 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateInviteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_invite_api_users__user_id__invite_send_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SendInviteRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/client/src/pages/AuthCallback.test.tsx
+++ b/client/src/pages/AuthCallback.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { render, waitFor } from "@testing-library/react";
+import { hashOAuthState } from "@/services/auth";
 
 import { AuthCallback } from "./AuthCallback";
 
@@ -25,14 +26,17 @@ vi.mock("@/contexts/AuthContext", () => ({
 }));
 
 describe("AuthCallback", () => {
-	beforeEach(() => {
+	beforeEach(async () => {
 		loginWithOAuth.mockResolvedValue(undefined);
 		navigate.mockReset();
 		sessionStorage.clear();
-		sessionStorage.setItem("oauth_state", "stale-client-state");
+		sessionStorage.setItem(
+			"oauth_state",
+			await hashOAuthState("server-state"),
+		);
 	});
 
-	it("lets the server validate OAuth state instead of reading browser storage", async () => {
+	it("validates the stored OAuth state digest before exchanging the code", async () => {
 		const getItem = vi.spyOn(Storage.prototype, "getItem");
 		const removeItem = vi.spyOn(Storage.prototype, "removeItem");
 
@@ -59,8 +63,8 @@ describe("AuthCallback", () => {
 			);
 		});
 		expect(navigate).toHaveBeenCalledWith("/", { replace: true });
-		expect(getItem).not.toHaveBeenCalledWith("oauth_state");
-		expect(removeItem).not.toHaveBeenCalledWith("oauth_state");
+		expect(getItem).toHaveBeenCalledWith("oauth_state");
+		expect(removeItem).toHaveBeenCalledWith("oauth_state");
 		expect(removeItem).not.toHaveBeenCalledWith("oauth_provider");
 	});
 });

--- a/client/src/pages/AuthCallback.tsx
+++ b/client/src/pages/AuthCallback.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useState, useRef } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
+import { hashOAuthState } from "@/services/auth";
 import { Loader2, AlertCircle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -45,7 +46,7 @@ export function AuthCallback() {
 				return;
 			}
 
-			// Get stored state
+			// Get stored state digest
 			// Note: code_verifier is now handled server-side (stored in Redis when init is called)
 			const storedState = sessionStorage.getItem("oauth_state");
 			const redirectFrom =
@@ -54,10 +55,11 @@ export function AuthCallback() {
 			// Clear stored OAuth data
 			sessionStorage.removeItem("oauth_state");
 			sessionStorage.removeItem("oauth_redirect_from");
-			sessionStorage.removeItem("oauth_provider");
 
-			// Verify state matches
-			if (state !== storedState) {
+			// Verify state matches. We stored only a digest of the state on init,
+			// so compare digests (browser-binding CSRF check; the server also
+			// validates the raw state against Redis).
+			if (!storedState || (await hashOAuthState(state)) !== storedState) {
 				setError("Invalid OAuth state - possible CSRF attack");
 				return;
 			}

--- a/client/src/pages/Login.test.tsx
+++ b/client/src/pages/Login.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { hashOAuthState } from "@/services/auth";
 
 const { initOAuth } = vi.hoisted(() => ({
 	initOAuth: vi.fn(),
@@ -58,8 +59,9 @@ describe("Login OAuth flow", () => {
 		window.location.assign = originalAssign;
 	});
 
-	it("redirects to the provider without storing OAuth state in session storage", async () => {
+	it("redirects to the provider after storing only an OAuth state digest", async () => {
 		const setItem = vi.spyOn(Storage.prototype, "setItem");
+		const expectedDigest = await hashOAuthState("server-state");
 
 		render(
 			<MemoryRouter>
@@ -84,9 +86,7 @@ describe("Login OAuth flow", () => {
 			"oauth_provider",
 			expect.any(String),
 		);
-		expect(setItem).not.toHaveBeenCalledWith(
-			"oauth_state",
-			expect.any(String),
-		);
+		expect(setItem).toHaveBeenCalledWith("oauth_state", expectedDigest);
+		expect(setItem).not.toHaveBeenCalledWith("oauth_state", "server-state");
 	});
 });

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
-import { getOAuthProviders, initOAuth } from "@/services/auth";
+import { getOAuthProviders, hashOAuthState, initOAuth } from "@/services/auth";
 import { supportsPasskeys } from "@/services/passkeys";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,6 +30,7 @@ import {
 import { motion } from "framer-motion";
 import type { OAuthProvider } from "@/services/auth";
 import { Logo } from "@/components/branding/Logo";
+import { AuthTransition } from "@/components/auth/AuthTransition";
 
 type LoginStep = "credentials" | "mfa" | "mfa-setup";
 
@@ -62,6 +63,7 @@ export function Login() {
 	// UI state
 	const [isLoading, setIsLoading] = useState(false);
 	const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
+	const [finalizing, setFinalizing] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [oauthProviders, setOAuthProviders] = useState<OAuthProvider[]>([]);
 	// Derived synchronously — `supportsPasskeys()` is a pure feature check on
@@ -112,6 +114,7 @@ export function Login() {
 		try {
 			// Pass email if user has entered one (helps target specific credentials)
 			await loginWithPasskey(email || undefined);
+			setFinalizing("Signing you in…");
 			redirectToFrom();
 		} catch (err) {
 			// Don't show error for user cancellation
@@ -196,6 +199,7 @@ export function Login() {
 			const result = await login(email, password);
 
 			if (result.success) {
+				setFinalizing("Signing you in…");
 				redirectToFrom();
 				return;
 			}
@@ -233,6 +237,7 @@ export function Login() {
 
 		try {
 			await loginWithMfa(mfaState.mfaToken, mfaCode, trustDevice);
+			setFinalizing("Signing you in…");
 			redirectToFrom();
 		} catch (err) {
 			setError(
@@ -251,7 +256,6 @@ export function Login() {
 			// Store redirect info for callback
 			// Note: PKCE (code_verifier) is now handled server-side
 			sessionStorage.setItem("oauth_redirect_from", from);
-			sessionStorage.setItem("oauth_provider", provider);
 
 			// Build callback URL
 			const callbackUrl = `${window.location.origin}/auth/callback/${provider}`;
@@ -262,10 +266,12 @@ export function Login() {
 				callbackUrl,
 			);
 
-			// Store state for verification
-			sessionStorage.setItem("oauth_state", state);
+			// Store only a digest of the state for the callback CSRF check —
+			// never the raw token (see hashOAuthState).
+			sessionStorage.setItem("oauth_state", await hashOAuthState(state));
 
 			// Redirect to OAuth provider
+			setFinalizing("Redirecting to sign-in…");
 			window.location.assign(authorization_url);
 		} catch (err) {
 			setError(
@@ -273,6 +279,7 @@ export function Login() {
 					? err.message
 					: "OAuth initialization failed",
 			);
+			setFinalizing(null);
 			setIsLoading(false);
 		}
 	};
@@ -331,6 +338,10 @@ export function Login() {
 				return <KeyRound className="w-5 h-5" />;
 		}
 	};
+
+	if (finalizing) {
+		return <AuthTransition message={finalizing} />;
+	}
 
 	if (authLoading) {
 		return (

--- a/client/src/pages/Register.test.tsx
+++ b/client/src/pages/Register.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test-utils";
+import { Register } from "./Register";
+import { registerFromInvite } from "@/services/auth";
+import { registerInviteWithPasskey } from "@/services/passkeys";
+
+const completeLoginWithToken = vi.fn();
+const checkAuthStatus = vi.fn();
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({
+		completeLoginWithToken,
+		checkAuthStatus,
+	}),
+}));
+
+vi.mock("@/services/auth", () => ({
+	getOAuthProviders: vi.fn(async () => []),
+	initOAuth: vi.fn(),
+	registerFromInvite: vi.fn(),
+}));
+
+// Logo pulls from OrgScopeContext (provided at app root in real use); stub it
+// so these tests can render the page without the full provider tree.
+vi.mock("@/components/branding/Logo", () => ({
+	Logo: () => null,
+}));
+
+vi.mock("@/services/passkeys", () => ({
+	registerInviteWithPasskey: vi.fn(),
+}));
+
+describe("Register", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		checkAuthStatus.mockResolvedValue(undefined);
+		vi.mocked(registerInviteWithPasskey).mockResolvedValue({
+			user_id: "user-1",
+			email: "invitee@example.com",
+			access_token: "access-token",
+			refresh_token: "refresh-token",
+		});
+		vi.mocked(registerFromInvite).mockResolvedValue(undefined);
+	});
+
+	it("shows passkey registration before the password fallback", () => {
+		renderWithProviders(<Register />, {
+			initialEntries: ["/accept-invite?token=invite-token"],
+		});
+
+		expect(
+			screen.getByRole("button", { name: /set up passkey/i }),
+		).toBeVisible();
+		expect(
+			screen.getByRole("button", { name: /use password instead/i }),
+		).toBeVisible();
+		expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument();
+	});
+
+	it("registers an invite with a passkey and stores returned auth tokens", async () => {
+		const { user } = renderWithProviders(<Register />, {
+			initialEntries: ["/accept-invite?token=invite-token"],
+		});
+
+		await user.click(
+			screen.getByRole("button", { name: /set up passkey/i }),
+		);
+
+		await waitFor(() => {
+			expect(registerInviteWithPasskey).toHaveBeenCalledWith(
+				"invite-token",
+			);
+		});
+		expect(completeLoginWithToken).toHaveBeenCalledWith("access-token");
+		expect(checkAuthStatus).toHaveBeenCalled();
+	});
+
+	it("keeps password as a secondary registration option", async () => {
+		const { user } = renderWithProviders(<Register />, {
+			initialEntries: ["/accept-invite?token=invite-token"],
+		});
+
+		await user.click(
+			screen.getByRole("button", { name: /use password instead/i }),
+		);
+		await user.type(screen.getByLabelText("Password"), "InviteePass123!");
+		await user.type(
+			screen.getByLabelText(/confirm password/i),
+			"InviteePass123!",
+		);
+		await user.click(
+			screen.getByRole("button", { name: /create account/i }),
+		);
+
+		await waitFor(() => {
+			expect(registerFromInvite).toHaveBeenCalledWith(
+				"invite-token",
+				"InviteePass123!",
+			);
+		});
+	});
+});

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { KeyRound, Lock, Loader2 } from "lucide-react";
+import { ExternalLink, KeyRound, Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+import { Logo } from "@/components/branding/Logo";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
 	Card,
 	CardContent,
@@ -11,15 +11,33 @@ import {
 	CardHeader,
 } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { apiClient } from "@/lib/api-client";
+import { AuthSetupSteps } from "@/components/auth/AuthSetupSteps";
+import { AuthTransition } from "@/components/auth/AuthTransition";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+	getOAuthProviders,
+	hashOAuthState,
+	initOAuth,
+	registerFromInvite,
+	type OAuthProvider,
+} from "@/services/auth";
+import { registerInviteWithPasskey } from "@/services/passkeys";
 
 export function Register() {
 	const [params] = useSearchParams();
 	const token = params.get("token") ?? "";
-	const [password, setPassword] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [pending, setPending] = useState(false);
+	const [finalizing, setFinalizing] = useState<string | null>(null);
+	const [oauthProviders, setOAuthProviders] = useState<OAuthProvider[]>([]);
 	const nav = useNavigate();
+	const { completeLoginWithToken, checkAuthStatus } = useAuth();
+
+	useEffect(() => {
+		getOAuthProviders()
+			.then(setOAuthProviders)
+			.catch(() => setOAuthProviders([]));
+	}, []);
 
 	if (!token) {
 		return (
@@ -29,37 +47,96 @@ export function Register() {
 		);
 	}
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
+	const handlePasskeyRegister = async () => {
 		setPending(true);
 		setError(null);
 		try {
-			const { error: apiError } = await apiClient.POST(
-				"/auth/register-from-invite",
-				{ body: { token, password } },
-			);
-			if (apiError) throw apiError;
-			nav("/login", { state: { message: "Registration complete! Please sign in." } });
+			const result = await registerInviteWithPasskey(token);
+			setFinalizing("Signing you in…");
+			completeLoginWithToken(result.access_token);
+			await checkAuthStatus();
+			nav("/", { replace: true });
 		} catch (e: unknown) {
-			const msg = e instanceof Error
-				? e.message
-				: (e as { detail?: string })?.detail ?? "Registration failed";
+			const msg =
+				e instanceof Error
+					? e.message
+					: ((e as { detail?: string })?.detail ??
+						"Registration failed");
 			setError(msg);
+			setFinalizing(null);
 		} finally {
 			setPending(false);
 		}
 	};
 
+	const handlePasswordRegister = async (password: string) => {
+		setPending(true);
+		setError(null);
+		try {
+			await registerFromInvite(token, password);
+			setFinalizing("Creating your account…");
+			nav("/login", {
+				state: { message: "Registration complete! Please sign in." },
+			});
+		} catch (e: unknown) {
+			const msg =
+				e instanceof Error
+					? e.message
+					: ((e as { detail?: string })?.detail ??
+						"Registration failed");
+			setError(msg);
+			setFinalizing(null);
+		} finally {
+			setPending(false);
+		}
+	};
+
+	const handleOAuthLogin = async (provider: string) => {
+		setPending(true);
+		setError(null);
+		try {
+			sessionStorage.setItem("oauth_redirect_from", "/");
+			const callbackUrl = `${window.location.origin}/auth/callback/${provider}`;
+			const { authorization_url, state } = await initOAuth(
+				provider,
+				callbackUrl,
+			);
+			sessionStorage.setItem("oauth_state", await hashOAuthState(state));
+			setFinalizing("Redirecting to sign-in…");
+			window.location.assign(authorization_url);
+		} catch (e: unknown) {
+			const msg =
+				e instanceof Error ? e.message : "SSO initialization failed";
+			setError(msg);
+			setFinalizing(null);
+			setPending(false);
+		}
+	};
+
+	if (finalizing) {
+		return <AuthTransition message={finalizing} />;
+	}
+
 	return (
 		<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 p-4">
 			<Card className="w-full max-w-md border-primary/10 shadow-xl shadow-primary/5">
-				<CardHeader className="text-center space-y-2 pb-2">
-					<h1 className="text-2xl font-bold tracking-tight">
-						Complete your registration
-					</h1>
-					<CardDescription>
-						Set a password to finish creating your account.
-					</CardDescription>
+				<CardHeader className="text-center space-y-4 pb-2">
+					<motion.div
+						initial={{ scale: 0.8, opacity: 0 }}
+						animate={{ scale: 1, opacity: 1 }}
+						transition={{ delay: 0.1, duration: 0.3 }}
+						className="flex justify-center"
+					>
+						<Logo type="square" className="h-16 w-16" alt="Bifrost" />
+					</motion.div>
+					<div className="space-y-1">
+						<h1 className="text-2xl font-bold tracking-tight">
+							Complete your registration
+						</h1>
+						<CardDescription>
+							Secure your account to accept the invite.
+						</CardDescription>
+					</div>
 				</CardHeader>
 				<CardContent>
 					{error && (
@@ -67,37 +144,52 @@ export function Register() {
 							<AlertDescription>{error}</AlertDescription>
 						</Alert>
 					)}
-					<form onSubmit={handleSubmit} className="space-y-4">
-						<div className="space-y-2">
-							<Label htmlFor="reg-password">Password</Label>
-							<div className="relative">
-								<Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-								<Input
-									id="reg-password"
-									type="password"
-									placeholder="At least 8 characters"
-									value={password}
-									onChange={(e) => setPassword(e.target.value)}
-									className="pl-10"
-									required
-									minLength={8}
-									autoFocus
-								/>
-							</div>
-						</div>
-						<Button
-							type="submit"
-							className="w-full"
-							disabled={pending || !password}
-						>
-							{pending ? (
-								<Loader2 className="h-4 w-4 animate-spin mr-2" />
-							) : (
-								<KeyRound className="h-4 w-4 mr-2" />
-							)}
-							Create account
-						</Button>
-					</form>
+					<div className="space-y-4">
+						{oauthProviders.length > 0 && (
+							<>
+								<div className="grid gap-2">
+									{oauthProviders.map((provider) => (
+										<Button
+											key={provider.name}
+											type="button"
+											variant="outline"
+											onClick={() =>
+												handleOAuthLogin(provider.name)
+											}
+											disabled={pending}
+											className="w-full"
+										>
+											{pending ? (
+												<Loader2 className="h-4 w-4 animate-spin mr-2" />
+											) : (
+												<KeyRound className="h-4 w-4 mr-2" />
+											)}
+											Continue with{" "}
+											{provider.display_name}
+											<ExternalLink className="ml-auto h-4 w-4 text-muted-foreground" />
+										</Button>
+									))}
+								</div>
+								<div className="relative">
+									<div className="absolute inset-0 flex items-center">
+										<span className="w-full border-t" />
+									</div>
+									<div className="relative flex justify-center text-xs uppercase">
+										<span className="bg-background px-2 text-muted-foreground">
+											Or
+										</span>
+									</div>
+								</div>
+							</>
+						)}
+						<AuthSetupSteps
+							email=""
+							onPasskeyRegister={handlePasskeyRegister}
+							onPasswordRegister={handlePasswordRegister}
+							isPending={pending}
+							error={null}
+						/>
+					</div>
 				</CardContent>
 			</Card>
 		</div>

--- a/client/src/pages/Setup.tsx
+++ b/client/src/pages/Setup.tsx
@@ -38,7 +38,7 @@ export function Setup() {
 		needsSetup,
 		isLoading: authLoading,
 		checkAuthStatus,
-		loginWithPasskey,
+		completeLoginWithToken,
 	} = useAuth();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -59,13 +59,15 @@ export function Setup() {
 		setError(null);
 		setIsLoading(true);
 		try {
-			await setupWithPasskey(email, name);
+			const result = await setupWithPasskey(email, name);
+			completeLoginWithToken(result.access_token);
 			await checkAuthStatus();
-			await loginWithPasskey(email);
 			toast.success("Account created successfully!");
 			navigate("/");
 		} catch (err) {
-			setError(err instanceof Error ? err.message : "Passkey setup failed");
+			setError(
+				err instanceof Error ? err.message : "Passkey setup failed",
+			);
 			setIsLoading(false);
 		}
 	};
@@ -76,9 +78,13 @@ export function Setup() {
 		try {
 			await registerUser(email, password, name);
 			await checkAuthStatus();
-			navigate("/login", { state: { message: "Account created! Please sign in." } });
+			navigate("/login", {
+				state: { message: "Account created! Please sign in." },
+			});
 		} catch (err) {
-			setError(err instanceof Error ? err.message : "Account creation failed");
+			setError(
+				err instanceof Error ? err.message : "Account creation failed",
+			);
 			setIsLoading(false);
 		}
 	};
@@ -127,7 +133,10 @@ export function Setup() {
 				type="button"
 				className="w-full mt-2"
 				disabled={!email}
-				onClick={() => { setError(null); setMode("auth"); }}
+				onClick={() => {
+					setError(null);
+					setMode("auth");
+				}}
 			>
 				Continue
 			</Button>

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, within } from "@/test-utils";
+
+const mockUseUsersFiltered = vi.fn();
+const mockUseOrganizations = vi.fn();
+const mockRefetch = vi.fn();
+
+vi.mock("@/hooks/useUsers", () => ({
+	useUsersFiltered: (...args: unknown[]) => mockUseUsersFiltered(...args),
+	useDeleteUser: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateUser: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/useOrganizations", () => ({
+	useOrganizations: (...args: unknown[]) => mockUseOrganizations(...args),
+}));
+
+vi.mock("@/hooks/useUserInvites", () => ({
+	useRegenerateInvite: () => ({ mutate: vi.fn(), isPending: false }),
+	useResendInvite: () => ({ mutate: vi.fn(), isPending: false }),
+	useRevokeInvite: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({
+		isPlatformAdmin: true,
+		user: { id: "current-user" },
+	}),
+}));
+
+vi.mock("@/contexts/OrgScopeContext", () => ({
+	useOrgScope: () => ({
+		scope: { type: "global", orgId: null, orgName: null },
+	}),
+}));
+
+vi.mock("@/components/forms/OrganizationSelect", () => ({
+	OrganizationSelect: () => null,
+}));
+
+vi.mock("@/components/users/CreateUserDialog", () => ({
+	CreateUserDialog: () => null,
+}));
+
+vi.mock("@/components/users/EditUserDialog", () => ({
+	EditUserDialog: () => null,
+}));
+
+vi.mock("@/components/users/BulkUserDialogs", () => ({
+	BulkMoveOrgDialog: () => null,
+	BulkReplaceRolesDialog: () => null,
+	BulkResultDialog: () => null,
+	BulkSetActiveDialog: () => null,
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import { Users } from "./Users";
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "user-1",
+		email: "dev@gobifrost.com",
+		name: "Dev Admin",
+		is_active: true,
+		is_superuser: true,
+		is_verified: true,
+		is_registered: true,
+		is_system: false,
+		mfa_enabled: false,
+		organization_id: "org-provider",
+		last_login: null,
+		created_at: "2026-06-01T00:00:00Z",
+		updated_at: "2026-06-01T00:00:00Z",
+		invite_status: "active",
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	mockRefetch.mockReset();
+	mockUseUsersFiltered.mockReset();
+	mockUseUsersFiltered.mockReturnValue({
+		data: [makeUser()],
+		isLoading: false,
+		refetch: mockRefetch,
+	});
+	mockUseOrganizations.mockReset();
+	mockUseOrganizations.mockReturnValue({
+		data: [
+			{
+				id: "org-provider",
+				name: "Provider",
+				domain: null,
+				is_provider: true,
+				is_active: true,
+			},
+		],
+	});
+});
+
+describe("Users", () => {
+	it("shows the provider organization for provider-scoped superusers", () => {
+		renderWithProviders(<Users />);
+
+		const row = screen.getByText("Dev Admin").closest("tr");
+		expect(row).not.toBeNull();
+		expect(within(row!).getByText("Provider")).toBeInTheDocument();
+		expect(row).not.toHaveTextContent("—");
+	});
+});

--- a/client/src/pages/Users.test.tsx
+++ b/client/src/pages/Users.test.tsx
@@ -1,37 +1,58 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, within } from "@/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor, within } from "@/test-utils";
 
 const mockUseUsersFiltered = vi.fn();
+const mockUseDeleteUser = vi.fn();
+const mockUseUpdateUser = vi.fn();
 const mockUseOrganizations = vi.fn();
+const mockUseAuth = vi.fn();
+const mockUseOrgScope = vi.fn();
+const mockResendMutate = vi.fn();
+const mockRegenerateMutate = vi.fn();
+const mockRevokeMutate = vi.fn();
+const mockSendInviteMutate = vi.fn();
+const mockUseEventSources = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
 const mockRefetch = vi.fn();
 
 vi.mock("@/hooks/useUsers", () => ({
 	useUsersFiltered: (...args: unknown[]) => mockUseUsersFiltered(...args),
-	useDeleteUser: () => ({ mutateAsync: vi.fn(), isPending: false }),
-	useUpdateUser: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteUser: () => mockUseDeleteUser(),
+	useUpdateUser: () => mockUseUpdateUser(),
 }));
 
 vi.mock("@/hooks/useOrganizations", () => ({
 	useOrganizations: (...args: unknown[]) => mockUseOrganizations(...args),
 }));
 
-vi.mock("@/hooks/useUserInvites", () => ({
-	useRegenerateInvite: () => ({ mutate: vi.fn(), isPending: false }),
-	useResendInvite: () => ({ mutate: vi.fn(), isPending: false }),
-	useRevokeInvite: () => ({ mutate: vi.fn(), isPending: false }),
-}));
-
 vi.mock("@/contexts/AuthContext", () => ({
-	useAuth: () => ({
-		isPlatformAdmin: true,
-		user: { id: "current-user" },
-	}),
+	useAuth: () => mockUseAuth(),
 }));
 
 vi.mock("@/contexts/OrgScopeContext", () => ({
-	useOrgScope: () => ({
-		scope: { type: "global", orgId: null, orgName: null },
+	useOrgScope: () => mockUseOrgScope(),
+}));
+
+vi.mock("@/hooks/useUserInvites", () => ({
+	useResendInvite: () => ({ mutate: mockResendMutate }),
+	useRegenerateInvite: () => ({ mutate: mockRegenerateMutate }),
+	useRevokeInvite: () => ({ mutate: mockRevokeMutate }),
+	useSendInvite: () => ({
+		mutateAsync: mockSendInviteMutate,
+		isPending: false,
 	}),
+}));
+
+vi.mock("@/services/events", () => ({
+	useEventSources: () => mockUseEventSources(),
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: (...args: unknown[]) => mockToastSuccess(...args),
+		error: (...args: unknown[]) => mockToastError(...args),
+	},
 }));
 
 vi.mock("@/components/forms/OrganizationSelect", () => ({
@@ -53,14 +74,23 @@ vi.mock("@/components/users/BulkUserDialogs", () => ({
 	BulkSetActiveDialog: () => null,
 }));
 
-vi.mock("sonner", () => ({
-	toast: {
-		success: vi.fn(),
-		error: vi.fn(),
-	},
-}));
-
 import { Users } from "./Users";
+
+const registrationUrl = "https://example.test/accept-invite?token=invite-token";
+
+function pendingInviteUser() {
+	return {
+		id: "user-1",
+		email: "alice@example.com",
+		name: "Alice",
+		is_active: true,
+		is_superuser: false,
+		organization_id: "org-1",
+		invite_status: "pending",
+		created_at: "2026-06-01T00:00:00Z",
+		last_login: null,
+	};
+}
 
 function makeUser(overrides: Record<string, unknown> = {}) {
 	return {
@@ -82,29 +112,180 @@ function makeUser(overrides: Record<string, unknown> = {}) {
 	};
 }
 
-beforeEach(() => {
-	mockRefetch.mockReset();
-	mockUseUsersFiltered.mockReset();
-	mockUseUsersFiltered.mockReturnValue({
-		data: [makeUser()],
-		isLoading: false,
-		refetch: mockRefetch,
-	});
-	mockUseOrganizations.mockReset();
-	mockUseOrganizations.mockReturnValue({
-		data: [
-			{
-				id: "org-provider",
-				name: "Provider",
-				domain: null,
-				is_provider: true,
-				is_active: true,
+describe("Users — registration links", () => {
+	let originalWriteText: typeof navigator.clipboard.writeText | undefined;
+
+	beforeEach(() => {
+		originalWriteText = navigator.clipboard?.writeText.bind(
+			navigator.clipboard,
+		);
+		mockUseUsersFiltered.mockReturnValue({
+			data: [pendingInviteUser()],
+			isLoading: false,
+			refetch: vi.fn(),
+		});
+		mockUseDeleteUser.mockReturnValue({ mutateAsync: vi.fn() });
+		mockUseUpdateUser.mockReturnValue({ mutateAsync: vi.fn() });
+		mockUseOrganizations.mockReturnValue({
+			data: [{ id: "org-1", name: "Acme", is_provider: false }],
+		});
+		mockUseAuth.mockReturnValue({
+			user: { id: "admin-1" },
+			isPlatformAdmin: false,
+		});
+		mockUseOrgScope.mockReturnValue({
+			scope: { type: "global", orgName: null },
+		});
+		mockRegenerateMutate.mockImplementation((_userId, options) => {
+			options?.onSuccess?.({
+				registration_url: registrationUrl,
+				event_emitted: false,
+			});
+		});
+		mockResendMutate.mockReset();
+		mockRevokeMutate.mockReset();
+		mockSendInviteMutate.mockReset();
+		mockSendInviteMutate.mockResolvedValue({});
+		mockUseEventSources.mockReturnValue({
+			data: {
+				items: [
+					{
+						id: "source-1",
+						source_type: "topic",
+						event_type: "user.invited",
+						is_active: true,
+						subscription_count: 1,
+					},
+				],
 			},
-		],
+		});
+		mockToastSuccess.mockReset();
+		mockToastError.mockReset();
+	});
+
+	afterEach(() => {
+		if (originalWriteText && navigator.clipboard) {
+			(
+				navigator.clipboard as unknown as {
+					writeText: typeof originalWriteText;
+				}
+			).writeText = originalWriteText;
+		}
+	});
+
+	it("shows a generated registration link in a modal", async () => {
+		const { user } = renderWithProviders(<Users />);
+
+		await user.click(screen.getByRole("button", { name: /user actions/i }));
+		await user.click(screen.getByText(/generate registration link/i));
+
+		expect(
+			await screen.findByRole("heading", { name: /user created/i }),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Destination")).not.toBeInTheDocument();
+		expect(screen.queryByText(registrationUrl)).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /send registration email/i }),
+		).toBeEnabled();
+		expect(
+			screen.getByRole("button", { name: /copy registration link/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("textbox", { name: /registration link/i }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("link", { name: /open link/i }),
+		).not.toBeInTheDocument();
+		expect(mockRegenerateMutate).toHaveBeenCalledWith(
+			"user-1",
+			expect.objectContaining({
+				onSuccess: expect.any(Function),
+				onError: expect.any(Function),
+			}),
+		);
+	});
+
+	it("shows the modal instead of crashing when clipboard is unavailable", async () => {
+		(
+			navigator.clipboard as unknown as {
+				writeText: undefined;
+			}
+		).writeText = undefined;
+		const { user } = renderWithProviders(<Users />);
+
+		await user.click(screen.getByRole("button", { name: /user actions/i }));
+		await user.click(screen.getByText(/copy registration link/i));
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("heading", { name: /user created/i }),
+			).toBeInTheDocument();
+		});
+		expect(mockToastSuccess).not.toHaveBeenCalled();
+	});
+
+	it("sends the registration email from a generated link", async () => {
+		const { user } = renderWithProviders(<Users />);
+
+		await user.click(screen.getByRole("button", { name: /user actions/i }));
+		await user.click(screen.getByText(/generate registration link/i));
+		await user.click(
+			await screen.findByRole("button", {
+				name: /send registration email/i,
+			}),
+		);
+
+		await waitFor(() => {
+			expect(mockSendInviteMutate).toHaveBeenCalledWith({
+				userId: "user-1",
+				registrationUrl,
+			});
+		});
+		expect(mockToastSuccess).toHaveBeenCalledWith(
+			"Registration email sent",
+		);
 	});
 });
 
 describe("Users", () => {
+	beforeEach(() => {
+		mockRefetch.mockReset();
+		mockUseUsersFiltered.mockReset();
+		mockUseUsersFiltered.mockReturnValue({
+			data: [makeUser()],
+			isLoading: false,
+			refetch: mockRefetch,
+		});
+		mockUseOrganizations.mockReset();
+		mockUseOrganizations.mockReturnValue({
+			data: [
+				{
+					id: "org-provider",
+					name: "Provider",
+					domain: null,
+					is_provider: true,
+					is_active: true,
+				},
+			],
+		});
+		mockUseAuth.mockReturnValue({
+			isPlatformAdmin: true,
+			user: { id: "current-user" },
+		});
+		mockUseOrgScope.mockReturnValue({
+			scope: { type: "global", orgId: null, orgName: null },
+		});
+		mockUseDeleteUser.mockReturnValue({
+			mutateAsync: vi.fn(),
+			isPending: false,
+		});
+		mockUseUpdateUser.mockReturnValue({
+			mutateAsync: vi.fn(),
+			isPending: false,
+		});
+		mockUseEventSources.mockReturnValue({ data: { items: [] } });
+	});
+
 	it("shows the provider organization for provider-scoped superusers", () => {
 		renderWithProviders(<Users />);
 

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -482,18 +482,14 @@ export function Users() {
 											)}
 										</DataTableCell>
 										<DataTableCell className="w-0 whitespace-nowrap text-sm">
-											{user.is_superuser ? (
-												<span className="text-muted-foreground">—</span>
-											) : (
-												<span className="inline-flex items-center gap-1">
-													{orgInfo.isProvider ? (
-														<Star className="h-3.5 w-3.5 text-amber-500 fill-amber-500" />
-													) : (
-														<Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-													)}
-													<span>{orgInfo.name}</span>
-												</span>
-											)}
+											<span className="inline-flex items-center gap-1">
+												{orgInfo.isProvider ? (
+													<Star className="h-3.5 w-3.5 text-amber-500 fill-amber-500" />
+												) : (
+													<Building2 className="h-3.5 w-3.5 text-muted-foreground" />
+												)}
+												<span>{orgInfo.name}</span>
+											</span>
 										</DataTableCell>
 										<DataTableCell className="w-0 whitespace-nowrap">
 											<div className="flex items-center gap-1.5">

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -52,6 +52,7 @@ import { OrganizationSelect } from "@/components/forms/OrganizationSelect";
 import { CreateUserDialog } from "@/components/users/CreateUserDialog";
 import { EditUserDialog } from "@/components/users/EditUserDialog";
 import { UserActionsMenu } from "@/components/users/UserActionsMenu";
+import { RegistrationLinkDialog } from "@/components/users/RegistrationLinkDialog";
 import { UserStatusBadge } from "@/components/users/UserStatusBadge";
 import { BulkActionBar } from "@/components/users/BulkActionBar";
 import { UserEmailCell } from "@/components/users/UserEmailCell";
@@ -65,16 +66,31 @@ import {
 	useRegenerateInvite,
 	useResendInvite,
 	useRevokeInvite,
+	useSendInvite,
 } from "@/hooks/useUserInvites";
+import { useEventSources } from "@/services/events";
 import { toast } from "sonner";
 import type { components, components as v1 } from "@/lib/v1";
 type User = components["schemas"]["UserPublic"];
 type Organization = components["schemas"]["OrganizationPublic"];
+type RegistrationLinkDialogState = {
+	userId: string;
+	email: string;
+	url: string;
+} | null;
 
 type SortColumn = "name" | "email" | "status" | "created" | "last_login";
 type SortDirection = "asc" | "desc";
 
-function SortIcon({ column, sortColumn, sortDirection }: { column: SortColumn; sortColumn: SortColumn; sortDirection: SortDirection }) {
+function SortIcon({
+	column,
+	sortColumn,
+	sortDirection,
+}: {
+	column: SortColumn;
+	sortColumn: SortColumn;
+	sortDirection: SortDirection;
+}) {
 	if (sortColumn !== column) return null;
 	return sortDirection === "asc" ? (
 		<ArrowUp className="inline ml-1 h-3 w-3" />
@@ -96,6 +112,8 @@ export function Users() {
 	);
 	const [sortColumn, setSortColumn] = useState<SortColumn>("name");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+	const [registrationLinkDialog, setRegistrationLinkDialog] =
+		useState<RegistrationLinkDialogState>(null);
 
 	const { scope } = useOrgScope();
 	const { user: currentUser, isPlatformAdmin } = useAuth();
@@ -113,6 +131,18 @@ export function Users() {
 	const resendMutation = useResendInvite();
 	const regenerateMutation = useRegenerateInvite();
 	const revokeMutation = useRevokeInvite();
+	const sendInviteMutation = useSendInvite();
+	const { data: eventSources } = useEventSources({
+		sourceType: "topic",
+		limit: 100,
+	});
+	const inviteAutomationConfigured =
+		eventSources?.items?.some(
+			(source) =>
+				source.is_active &&
+				source.event_type === "user.invited" &&
+				source.subscription_count > 0,
+		) ?? false;
 
 	const { data: organizations } = useOrganizations({
 		enabled: isPlatformAdmin,
@@ -123,7 +153,10 @@ export function Users() {
 	): { name: string; isProvider: boolean } => {
 		if (!orgId) return { name: "Platform", isProvider: false };
 		const org = organizations?.find((o: Organization) => o.id === orgId);
-		return { name: org?.name || orgId, isProvider: org?.is_provider ?? false };
+		return {
+			name: org?.name || orgId,
+			isProvider: org?.is_provider ?? false,
+		};
 	};
 
 	const filteredUsers = useSearch(users || [], searchTerm, ["email", "name"]);
@@ -134,7 +167,12 @@ export function Users() {
 			const dir = sortDirection === "asc" ? 1 : -1;
 			switch (sortColumn) {
 				case "name":
-					return dir * (a.name || a.email || "").localeCompare(b.name || b.email || "");
+					return (
+						dir *
+						(a.name || a.email || "").localeCompare(
+							b.name || b.email || "",
+						)
+					);
 				case "email":
 					return dir * (a.email || "").localeCompare(b.email || "");
 				case "status": {
@@ -143,13 +181,21 @@ export function Users() {
 					return dir * aVal.localeCompare(bVal);
 				}
 				case "created": {
-					const aDate = a.created_at ? new Date(a.created_at).getTime() : 0;
-					const bDate = b.created_at ? new Date(b.created_at).getTime() : 0;
+					const aDate = a.created_at
+						? new Date(a.created_at).getTime()
+						: 0;
+					const bDate = b.created_at
+						? new Date(b.created_at).getTime()
+						: 0;
 					return dir * (aDate - bDate);
 				}
 				case "last_login": {
-					const aDate = a.last_login ? new Date(a.last_login).getTime() : 0;
-					const bDate = b.last_login ? new Date(b.last_login).getTime() : 0;
+					const aDate = a.last_login
+						? new Date(a.last_login).getTime()
+						: 0;
+					const bDate = b.last_login
+						? new Date(b.last_login).getTime()
+						: 0;
 					return dir * (aDate - bDate);
 				}
 				default:
@@ -303,6 +349,14 @@ export function Users() {
 	const isSelf = (user: User) =>
 		!!(currentUser && user.id === currentUser.id);
 
+	const showRegistrationLink = (user: User, url: string) => {
+		setRegistrationLinkDialog({
+			userId: user.id,
+			email: user.email,
+			url,
+		});
+	};
+
 	return (
 		<div className="h-full flex flex-col space-y-6 max-w-7xl mx-auto">
 			<div className="flex items-center justify-between">
@@ -392,7 +446,9 @@ export function Users() {
 													? "indeterminate"
 													: false
 										}
-										onCheckedChange={() => selection.toggleAllVisible()}
+										onCheckedChange={() =>
+											selection.toggleAllVisible()
+										}
 									/>
 								</DataTableHead>
 								<DataTableHead className="w-0 whitespace-nowrap">
@@ -403,42 +459,64 @@ export function Users() {
 									onClick={() => handleSort("name")}
 								>
 									Name
-									<SortIcon column="name" sortColumn={sortColumn} sortDirection={sortDirection} />
+									<SortIcon
+										column="name"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
 								</DataTableHead>
 								<DataTableHead
 									className="cursor-pointer select-none"
 									onClick={() => handleSort("email")}
 								>
 									Email
-									<SortIcon column="email" sortColumn={sortColumn} sortDirection={sortDirection} />
+									<SortIcon
+										column="email"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
 								</DataTableHead>
 								<DataTableHead
 									className="w-0 whitespace-nowrap cursor-pointer select-none"
 									onClick={() => handleSort("status")}
 								>
 									Status
-									<SortIcon column="status" sortColumn={sortColumn} sortDirection={sortDirection} />
+									<SortIcon
+										column="status"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
 								</DataTableHead>
 								<DataTableHead
 									className="w-0 whitespace-nowrap cursor-pointer select-none"
 									onClick={() => handleSort("created")}
 								>
 									Created
-									<SortIcon column="created" sortColumn={sortColumn} sortDirection={sortDirection} />
+									<SortIcon
+										column="created"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
 								</DataTableHead>
 								<DataTableHead
 									className="w-0 whitespace-nowrap cursor-pointer select-none"
 									onClick={() => handleSort("last_login")}
 								>
 									Last Login
-									<SortIcon column="last_login" sortColumn={sortColumn} sortDirection={sortDirection} />
+									<SortIcon
+										column="last_login"
+										sortColumn={sortColumn}
+										sortDirection={sortDirection}
+									/>
 								</DataTableHead>
 								<DataTableHead className="w-0 whitespace-nowrap text-right sticky right-0 bg-background"></DataTableHead>
 							</DataTableRow>
 						</DataTableHeader>
 						<DataTableBody>
 							{sortedUsers.map((user) => {
-								const orgInfo = getOrgInfo(user.organization_id);
+								const orgInfo = getOrgInfo(
+									user.organization_id,
+								);
 								return (
 									<DataTableRow
 										key={user.id}
@@ -446,7 +524,9 @@ export function Users() {
 										onClick={() => handleEditUser(user)}
 										className={
 											"group/row" +
-											(!user.is_active ? " opacity-60" : "")
+											(!user.is_active
+												? " opacity-60"
+												: "")
 										}
 									>
 										<DataTableCell
@@ -465,17 +545,25 @@ export function Users() {
 														</span>
 													</TooltipTrigger>
 													<TooltipContent>
-														You can't include yourself in a bulk action
+														You can't include
+														yourself in a bulk
+														action
 													</TooltipContent>
 												</Tooltip>
 											) : (
 												<Checkbox
 													aria-label={`Select ${user.name || user.email}`}
-													checked={selection.isSelected(user.id)}
+													checked={selection.isSelected(
+														user.id,
+													)}
 													onClick={(e) => {
-														selection.toggle(user.id, {
-															shiftKey: e.shiftKey,
-														});
+														selection.toggle(
+															user.id,
+															{
+																shiftKey:
+																	e.shiftKey,
+															},
+														);
 														e.preventDefault();
 													}}
 												/>
@@ -501,7 +589,9 @@ export function Users() {
 														<TooltipTrigger asChild>
 															<Crown className="h-4 w-4 shrink-0 text-amber-500 fill-amber-500" />
 														</TooltipTrigger>
-														<TooltipContent>Platform Admin</TooltipContent>
+														<TooltipContent>
+															Platform Admin
+														</TooltipContent>
 													</Tooltip>
 												)}
 											</div>
@@ -514,7 +604,10 @@ export function Users() {
 										</DataTableCell>
 										<DataTableCell className="w-0 whitespace-nowrap">
 											<UserStatusBadge
-												status={user.invite_status ?? "active"}
+												status={
+													user.invite_status ??
+													"active"
+												}
 											/>
 										</DataTableCell>
 										<DataTableCell className="w-0 whitespace-nowrap text-sm text-muted-foreground">
@@ -536,59 +629,111 @@ export function Users() {
 											onClick={(e) => e.stopPropagation()}
 										>
 											<UserActionsMenu
-												status={user.invite_status ?? "active"}
+												status={
+													user.invite_status ??
+													"active"
+												}
 												isActive={user.is_active}
 												isSelf={isSelf(user)}
 												onResend={() =>
-													resendMutation.mutate(user.id, {
-														onSuccess: (res) => {
-															toast.success(
-																res.event_emitted
-																	? `Invite automation triggered for ${user.email}`
-																	: "Invite regenerated (no automations — copy link from regenerate)",
-															);
+													resendMutation.mutate(
+														user.id,
+														{
+															onSuccess: (
+																res,
+															) => {
+																toast.success(
+																	res.event_emitted
+																		? `Invite automation triggered for ${user.email}`
+																		: "Invite regenerated (no automations — copy link from regenerate)",
+																);
+															},
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to resend invite",
+																),
 														},
-														onError: (e: unknown) =>
-															toast.error(
-																e instanceof Error ? e.message : "Failed to resend invite",
-															),
-													})
+													)
 												}
 												onRegenerate={() =>
-													regenerateMutation.mutate(user.id, {
-														onSuccess: (res) => {
-															void navigator.clipboard.writeText(res.registration_url);
-															toast.success("New invite link generated and copied");
+													regenerateMutation.mutate(
+														user.id,
+														{
+															onSuccess: (
+																res,
+															) => {
+																showRegistrationLink(
+																	user,
+																	res.registration_url,
+																);
+															},
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to regenerate link",
+																),
 														},
-														onError: (e: unknown) =>
-															toast.error(
-																e instanceof Error ? e.message : "Failed to regenerate link",
-															),
-													})
+													)
 												}
 												onCopyLink={() =>
-													regenerateMutation.mutate(user.id, {
-														onSuccess: (res) => {
-															void navigator.clipboard.writeText(res.registration_url);
-															toast.success("Registration link copied");
+													regenerateMutation.mutate(
+														user.id,
+														{
+															onSuccess: (
+																res,
+															) => {
+																showRegistrationLink(
+																	user,
+																	res.registration_url,
+																);
+															},
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to copy link",
+																),
 														},
-														onError: (e: unknown) =>
-															toast.error(
-																e instanceof Error ? e.message : "Failed to copy link",
-															),
-													})
+													)
 												}
 												onRevoke={() =>
-													revokeMutation.mutate(user.id, {
-														onSuccess: () => toast.success("Invite revoked"),
-														onError: (e: unknown) =>
-															toast.error(
-																e instanceof Error ? e.message : "Failed to revoke invite",
-															),
-													})
+													revokeMutation.mutate(
+														user.id,
+														{
+															onSuccess: () =>
+																toast.success(
+																	"Invite revoked",
+																),
+															onError: (
+																e: unknown,
+															) =>
+																toast.error(
+																	e instanceof
+																		Error
+																		? e.message
+																		: "Failed to revoke invite",
+																),
+														},
+													)
 												}
-												onToggleActive={() => handleToggleActive(user)}
-												onDelete={() => handleDeleteUser(user)}
+												onToggleActive={() =>
+													handleToggleActive(user)
+												}
+												onDelete={() =>
+													handleDeleteUser(user)
+												}
 											/>
 										</DataTableCell>
 									</DataTableRow>
@@ -669,6 +814,35 @@ export function Users() {
 				user={selectedUser}
 				open={isEditOpen}
 				onOpenChange={handleEditClose}
+			/>
+
+			<RegistrationLinkDialog
+				open={registrationLinkDialog !== null}
+				email={registrationLinkDialog?.email}
+				url={registrationLinkDialog?.url}
+				canSendEmail={inviteAutomationConfigured}
+				isSendingEmail={sendInviteMutation.isPending}
+				onSendEmail={async () => {
+					if (!registrationLinkDialog) return;
+					try {
+						await sendInviteMutation.mutateAsync({
+							userId: registrationLinkDialog.userId,
+							registrationUrl: registrationLinkDialog.url,
+						});
+						toast.success("Registration email sent");
+						setRegistrationLinkDialog(null);
+					} catch (error) {
+						toast.error("Failed to send registration email", {
+							description:
+								error instanceof Error
+									? error.message
+									: "Unknown error occurred",
+						});
+					}
+				}}
+				onOpenChange={(open) => {
+					if (!open) setRegistrationLinkDialog(null);
+				}}
 			/>
 
 			{/* Disable confirmation dialog */}

--- a/client/src/pages/user-settings/Developer.tsx
+++ b/client/src/pages/user-settings/Developer.tsx
@@ -14,15 +14,21 @@ import {
 	Copy,
 	Check,
 } from "lucide-react";
+import { toast } from "sonner";
+
+import { copyToClipboard } from "@/lib/clipboard";
 import { sdkService } from "@/services/sdk";
 
 function CopyButton({ text }: { text: string }) {
 	const [copied, setCopied] = useState(false);
 
-	const handleCopy = useCallback(() => {
-		navigator.clipboard.writeText(text);
-		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
+	const handleCopy = useCallback(async () => {
+		if (await copyToClipboard(text)) {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} else {
+			toast.error("Failed to copy to clipboard");
+		}
 	}, [text]);
 
 	return (

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -57,6 +57,23 @@ export async function initOAuth(
 // Note: getOAuthVerifier() has been removed - PKCE is now handled server-side
 // The backend stores the code_verifier when init is called and uses it during callback
 
+/**
+ * Hash the OAuth `state` (a CSRF nonce) before persisting it for the callback
+ * round-trip. We store only the SHA-256 digest, never the raw token: the
+ * browser-binding CSRF check still works by comparing digests, but an XSS
+ * reader of sessionStorage can't lift a usable state value. SubtleCrypto is
+ * available in the secure (HTTPS/localhost) contexts where OAuth runs.
+ */
+export async function hashOAuthState(state: string): Promise<string> {
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(state),
+	);
+	return Array.from(new Uint8Array(digest))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
 // =============================================================================
 // MFA Operations
 // =============================================================================
@@ -138,6 +155,28 @@ export async function registerUser(
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ email, password, name }),
+	});
+
+	if (!res.ok) {
+		const error = await res.json().catch(() => ({}));
+		throw new Error(error.detail || "Registration failed");
+	}
+}
+
+/**
+ * Complete an invite by setting a password. Uses a raw fetch (not apiClient)
+ * because the invitee is unauthenticated — the invite token IS the credential.
+ * Routing this through apiClient would trip its token-refresh middleware, which
+ * redirects unauthenticated callers to /login before the request is ever sent.
+ */
+export async function registerFromInvite(
+	token: string,
+	password: string,
+): Promise<void> {
+	const res = await fetch("/auth/register-from-invite", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ token, password }),
 	});
 
 	if (!res.ok) {

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -62,9 +62,13 @@ export async function initOAuth(
  * round-trip. We store only the SHA-256 digest, never the raw token: the
  * browser-binding CSRF check still works by comparing digests, but an XSS
  * reader of sessionStorage can't lift a usable state value. SubtleCrypto is
- * available in the secure (HTTPS/localhost) contexts where OAuth runs.
+ * available in secure (HTTPS/localhost) contexts; non-secure dev hosts fall
+ * back to storing the raw state so OAuth still works.
  */
 export async function hashOAuthState(state: string): Promise<string> {
+	if (!crypto.subtle) {
+		return state;
+	}
 	const digest = await crypto.subtle.digest(
 		"SHA-256",
 		new TextEncoder().encode(state),

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -62,14 +62,19 @@ export async function initOAuth(
  * round-trip. We store only the SHA-256 digest, never the raw token: the
  * browser-binding CSRF check still works by comparing digests, but an XSS
  * reader of sessionStorage can't lift a usable state value. SubtleCrypto is
- * available in secure (HTTPS/localhost) contexts; non-secure dev hosts fall
- * back to storing the raw state so OAuth still works.
+ * available in secure (HTTPS/localhost) contexts; non-secure dev hosts use a
+ * non-raw fallback digest so OAuth still works without cleartext state storage.
  */
 export async function hashOAuthState(state: string): Promise<string> {
-	if (!crypto.subtle) {
-		return state;
+	if (!globalThis.crypto?.subtle) {
+		let hash = 0x811c9dc5;
+		for (let i = 0; i < state.length; i += 1) {
+			hash ^= state.charCodeAt(i);
+			hash = Math.imul(hash, 0x01000193);
+		}
+		return `fnv1a32:${(hash >>> 0).toString(16).padStart(8, "0")}`;
 	}
-	const digest = await crypto.subtle.digest(
+	const digest = await globalThis.crypto.subtle.digest(
 		"SHA-256",
 		new TextEncoder().encode(state),
 	);

--- a/client/src/services/passkeys.test.ts
+++ b/client/src/services/passkeys.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerInviteWithPasskey } from "./passkeys";
+import { startRegistration } from "@simplewebauthn/browser";
+
+vi.mock("@simplewebauthn/browser", () => ({
+	browserSupportsWebAuthn: vi.fn(() => true),
+	browserSupportsWebAuthnAutofill: vi.fn(() => Promise.resolve(true)),
+	startAuthentication: vi.fn(),
+	startRegistration: vi.fn(),
+}));
+
+describe("registerInviteWithPasskey", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(startRegistration).mockResolvedValue({
+			id: "credential-id",
+		} as Awaited<ReturnType<typeof startRegistration>>);
+	});
+
+	it("creates a passkey from an invite token and returns login tokens", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ options: { challenge: "abc" } }),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					user_id: "user-1",
+					email: "invitee@example.com",
+					access_token: "access",
+					refresh_token: "refresh",
+				}),
+			});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await registerInviteWithPasskey("invite-token");
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			"/auth/register-from-invite/passkey/options",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ token: "invite-token" }),
+			}),
+		);
+		expect(startRegistration).toHaveBeenCalledWith({
+			optionsJSON: { challenge: "abc" },
+		});
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"/auth/register-from-invite/passkey/verify",
+			expect.objectContaining({
+				method: "POST",
+				credentials: "same-origin",
+				body: JSON.stringify({
+					token: "invite-token",
+					credential: { id: "credential-id" },
+					device_name: undefined,
+				}),
+			}),
+		);
+		expect(result.access_token).toBe("access");
+	});
+
+	it("surfaces invite option errors before starting browser registration", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: false,
+				json: async () => ({ detail: "Invite expired" }),
+			}),
+		);
+
+		await expect(registerInviteWithPasskey("expired")).rejects.toThrow(
+			"Invite expired",
+		);
+		expect(startRegistration).not.toHaveBeenCalled();
+	});
+});

--- a/client/src/services/passkeys.ts
+++ b/client/src/services/passkeys.ts
@@ -334,3 +334,73 @@ export async function setupWithPasskey(
 
 	return verifyRes.json();
 }
+
+export async function registerInviteWithPasskey(
+	token: string,
+	deviceName?: string,
+): Promise<SetupPasskeyResult> {
+	const optionsRes = await fetch(
+		"/auth/register-from-invite/passkey/options",
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ token }),
+		},
+	);
+
+	if (!optionsRes.ok) {
+		const error = await optionsRes.json().catch(() => ({}));
+		throw new Error(error.detail || "Failed to start passkey registration");
+	}
+
+	const { options } = await optionsRes.json();
+
+	let credential;
+	try {
+		credential = await startRegistration({
+			optionsJSON: options as PublicKeyCredentialCreationOptionsJSON,
+		});
+	} catch (error) {
+		if (error instanceof Error) {
+			if (error.name === "NotAllowedError") {
+				throw new Error(
+					"Passkey creation was cancelled or not allowed",
+					{ cause: error },
+				);
+			}
+			if (error.name === "InvalidStateError") {
+				throw new Error(
+					"This passkey is already registered on this device",
+					{ cause: error },
+				);
+			}
+			if (error.name === "NotSupportedError") {
+				throw new Error(
+					"Your browser or device does not support passkeys",
+					{ cause: error },
+				);
+			}
+		}
+		throw error;
+	}
+
+	const verifyRes = await fetch("/auth/register-from-invite/passkey/verify", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		credentials: "same-origin",
+		body: JSON.stringify({
+			token,
+			credential,
+			device_name: deviceName,
+		}),
+	});
+
+	if (!verifyRes.ok) {
+		const error = await verifyRes.json().catch(() => ({}));
+		throw new Error(
+			error.detail || "Failed to complete passkey registration",
+		);
+	}
+
+	return verifyRes.json();
+}

--- a/client/src/services/user-invites.ts
+++ b/client/src/services/user-invites.ts
@@ -8,9 +8,12 @@
 import { apiClient } from "@/lib/api-client";
 import type { components } from "@/lib/v1";
 
-export type CreateInviteResponse = components["schemas"]["CreateInviteResponse"];
+export type CreateInviteResponse =
+	components["schemas"]["CreateInviteResponse"];
 
-export async function resendInvite(userId: string): Promise<CreateInviteResponse> {
+export async function resendInvite(
+	userId: string,
+): Promise<CreateInviteResponse> {
 	const { data, error } = await apiClient.POST(
 		"/api/users/{user_id}/invite/resend",
 		{ params: { path: { user_id: userId } } },
@@ -30,10 +33,24 @@ export async function regenerateInvite(
 	return data as CreateInviteResponse;
 }
 
-export async function revokeInvite(userId: string): Promise<void> {
-	const { error } = await apiClient.DELETE(
-		"/api/users/{user_id}/invite",
-		{ params: { path: { user_id: userId } } },
+export async function sendInviteEmail(
+	userId: string,
+	registrationUrl: string,
+): Promise<CreateInviteResponse> {
+	const { data, error } = await apiClient.POST(
+		"/api/users/{user_id}/invite/send",
+		{
+			params: { path: { user_id: userId } },
+			body: { registration_url: registrationUrl },
+		},
 	);
+	if (error) throw error;
+	return data as CreateInviteResponse;
+}
+
+export async function revokeInvite(userId: string): Promise<void> {
+	const { error } = await apiClient.DELETE("/api/users/{user_id}/invite", {
+		params: { path: { user_id: userId } },
+	});
 	if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- Merge upstream `jackmusick/bifrost` through `d4a572a9` into the MTG fork, preserving upstream ancestry with a merge commit.
- Bring in upstream user invite registration updates: passkey/passwordless invite registration, registration-link dialogs, invite send/regenerate flows, and OAuth state digest validation.
- Preserve MTG fork behavior during conflict resolution: OAuth provider availability check, platform-admin user sorting/helpers, organization display for users, and existing auth-context test coverage.

## Test Evidence
- VM target: `pve-t340.netbird.cloud`, VM `101` (`bifrost-e2e-debian13-01`, `dev@172.16.15.130`), checkout `/home/dev/src/bifrost-codex-upstream-eval-20260604`, Docker project `bifrost-test-18b29d6a`.
- `cd client && npm run tsc` passed.
- `./test.sh client unit -- src/pages/Users.test.tsx src/components/users/CreateUserDialog.test.tsx src/components/users/UserActionsMenu.test.tsx src/components/users/RegistrationLinkDialog.test.tsx src/pages/Register.test.tsx src/components/auth/AuthSetupSteps.test.tsx src/services/passkeys.test.ts` passed: 7 files, 28 tests. Non-failing React `act(...)` warning observed in `Register.test.tsx`.
- `./test.sh tests/e2e/api/test_user_invites.py -v` passed: 18 tests.
- `./test.sh tests/unit/services/test_audit.py -v` passed: 8 tests.

## Notes
- The VM checkout was populated with a git bundle because VM `101` does not currently have GitHub SSH access for `MTG-Thomas/bifrost`.
- The per-worktree VM test stack was torn down after verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, invite consumption, OAuth callbacks, and audit persistence; changes are mostly additive but incorrect invite/SSO edge cases could block registration or mis-report invite status.
> 
> **Overview**
> This merge brings in upstream **user invite and registration** work: admins get registration links by default on user create, and emailing an invite is a separate action that does not rotate the token.
> 
> **Backend:** New token-gated `/auth/register-from-invite/passkey/*` endpoints register a passkey, consume the invite, and return login tokens. `POST /api/users/{id}/invite/send` fires `user.invited` for an existing URL (with token ownership checks). Invite validation is centralized in `get_valid_invite_user`; users with linked OAuth accounts count as already registered for invite status and regenerate guards. SSO login now sets `is_registered` / `is_verified`. Audit writes use a nested savepoint and fall back to logging without an actor if the actor FK is stale.
> 
> **Frontend:** Invite acceptance supports passkey-first setup (password optional with confirm-password), SSO on the register page, and post-success session handling via `completeLoginWithToken`. Admins see a **User Created** modal to copy the link or send email when `user.invited` automation exists; OAuth CSRF uses a **hashed** `oauth_state` in sessionStorage. Clipboard copying works on non-secure HTTP dev hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9368b1a69ebe26502994a879119a851deb10baa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->