### PR TITLE
fix: normalize passkey transports for webauthn

### DIFF
--- a/api/src/services/passkey_service.py
+++ b/api/src/services/passkey_service.py
@@ -29,6 +29,7 @@ from webauthn.helpers import (
     parse_registration_credential_json,
 )
 from webauthn.helpers.structs import (
+    AuthenticatorTransport,
     AuthenticatorSelectionCriteria,
     PublicKeyCredentialDescriptor,
     ResidentKeyRequirement,
@@ -46,6 +47,26 @@ PASSKEY_REG_CHALLENGE_PREFIX = "passkey_reg_challenge:"
 PASSKEY_AUTH_CHALLENGE_PREFIX = "passkey_auth_challenge:"
 PASSKEY_SETUP_TOKEN_PREFIX = "passkey_setup:"
 CHALLENGE_TTL_SECONDS = 300  # 5 minutes
+
+
+def _normalize_transports(transports: list | None) -> list[AuthenticatorTransport] | None:
+    """Convert stored JSONB transport strings into py_webauthn enum values."""
+    if not transports:
+        return None
+
+    normalized: list[AuthenticatorTransport] = []
+    for transport in transports:
+        if isinstance(transport, AuthenticatorTransport):
+            normalized.append(transport)
+            continue
+        if not isinstance(transport, str) or not transport:
+            continue
+        try:
+            normalized.append(AuthenticatorTransport(transport))
+        except ValueError:
+            continue
+
+    return normalized or None
 
 
 class PasskeyService:
@@ -93,7 +114,7 @@ class PasskeyService:
         exclude_credentials = [
             PublicKeyCredentialDescriptor(
                 id=passkey.credential_id,
-                transports=passkey.transports if passkey.transports else None,
+                transports=_normalize_transports(passkey.transports),
             )
             for passkey in existing_passkeys
         ]
@@ -223,7 +244,7 @@ class PasskeyService:
                     allow_credentials = [
                         PublicKeyCredentialDescriptor(
                             id=passkey.credential_id,
-                            transports=passkey.transports if passkey.transports else None,
+                            transports=_normalize_transports(passkey.transports),
                         )
                         for passkey in passkeys
                     ]

--- a/api/tests/unit/services/test_passkey_service.py
+++ b/api/tests/unit/services/test_passkey_service.py
@@ -1,0 +1,45 @@
+"""Unit tests for passkey service helpers."""
+
+from webauthn.helpers.structs import AuthenticatorTransport
+from webauthn import generate_registration_options, options_to_json
+from webauthn.helpers.structs import PublicKeyCredentialDescriptor
+
+from src.services.passkey_service import _normalize_transports
+
+
+def test_normalize_transports_converts_stored_strings_to_webauthn_enums():
+    """Stored JSONB strings should be safe to pass back to py_webauthn."""
+    transports = _normalize_transports(["internal", "hybrid"])
+
+    assert transports == [
+        AuthenticatorTransport.INTERNAL,
+        AuthenticatorTransport.HYBRID,
+    ]
+
+
+def test_normalize_transports_ignores_unknown_or_empty_values():
+    """Unexpected stored transport values should not break passkey registration."""
+    transports = _normalize_transports(["internal", "", None, "future-transport"])
+
+    assert transports == [AuthenticatorTransport.INTERNAL]
+
+
+def test_normalized_transports_are_safe_for_registration_options_serialization():
+    """Regression for py_webauthn expecting descriptor transports as enums."""
+    options = generate_registration_options(
+        rp_id="bifrost.example.com",
+        rp_name="Bifrost",
+        user_id=b"test-user-handle",
+        user_name="user@example.com",
+        user_display_name="User",
+        exclude_credentials=[
+            PublicKeyCredentialDescriptor(
+                id=b"existing-credential-id",
+                transports=_normalize_transports(["internal"]),
+            )
+        ],
+    )
+
+    serialized = options_to_json(options)
+
+    assert '"transports": ["internal"]' in serialized


### PR DESCRIPTION
## Summary
- normalize stored passkey transport strings into `py_webauthn` `AuthenticatorTransport` enums before creating WebAuthn credential descriptors
- cover the exact `options_to_json()` registration-options regression that failed in live production

## Live failure
`POST /auth/passkeys/register/options` returned 500 for `thomas@midtowntg.com` with:

```text
AttributeError: 'str' object has no attribute 'value'
```

The failing path was existing `user_passkeys.transports` JSONB values being passed directly into `PublicKeyCredentialDescriptor`; `webauthn 2.7.1` expects enum instances when serializing descriptors.

## Verification
- `python -m pytest api/tests/unit/services/test_passkey_service.py -q`
- `python -m ruff check api/src/services/passkey_service.py api/tests/unit/services/test_passkey_service.py`
- `git diff --check`

## Upstream
Checked `upstream/main`; it has the same direct `transports=passkey.transports if passkey.transports else None` path, so upstream needs this patch too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted auth-path fix with unit tests; no schema or credential verification logic changes beyond transport typing for descriptors.
> 
> **Overview**
> Fixes **500 errors on passkey registration options** when a user already has passkeys: stored `user_passkeys.transports` JSONB strings were passed straight into `PublicKeyCredentialDescriptor`, but **py_webauthn 2.7.1** serializes descriptors with `.value` on **enum** transports, which blew up as `AttributeError: 'str' object has no attribute 'value'`.
> 
> Adds **`_normalize_transports`** to map stored strings (and pass-through enums) to `AuthenticatorTransport`, skipping empty/unknown values. Wires it into **registration** `exclude_credentials` and **authentication** `allow_credentials`. New unit tests cover conversion, bad data tolerance, and **`options_to_json`** regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d28bb5682d150b5b162227651092abe931d2cfe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for passkey transport validation and serialization.

* **Refactor**
  * Improved passkey authentication transport handling for enhanced compatibility across authenticator types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->