### PR TITLE
fix: restore platform admin user creation org fallback

### DIFF
--- a/client/src/components/users/CreateUserDialog.test.tsx
+++ b/client/src/components/users/CreateUserDialog.test.tsx
@@ -219,6 +219,8 @@ describe("CreateUserDialog — happy path", () => {
 				is_active: true,
 				is_superuser: true,
 				organization_id: "org-provider",
+				invite: true,
+				trigger_automation: true,
 			},
 		});
 		expect(screen.queryByText(/select an organization/i)).not.toBeInTheDocument();
@@ -262,6 +264,8 @@ describe("CreateUserDialog — happy path", () => {
 		expect(mockCreateMutate.mock.calls[0]![0].body).toMatchObject({
 			is_superuser: true,
 			organization_id: "provider-from-auth",
+			invite: true,
+			trigger_automation: true,
 		});
 		expect(screen.queryByText(/select an organization/i)).not.toBeInTheDocument();
 	});

--- a/client/src/components/users/CreateUserDialog.tsx
+++ b/client/src/components/users/CreateUserDialog.tsx
@@ -37,6 +37,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCreateUser } from "@/hooks/useUsers";
 import { useRoles, useAssignUsersToRole } from "@/hooks/useRoles";
 import { useOrganizations } from "@/hooks/useOrganizations";
+import { useAuth } from "@/contexts/AuthContext";
+import { usePlatformAdminOrgSelection } from "./platformAdminOrg";
 import { toast } from "sonner";
 import type { components } from "@/lib/v1";
 
@@ -69,23 +71,19 @@ function CreateUserDialogContent({
 	const assignUsersToRole = useAssignUsersToRole();
 	const { data: organizations, isLoading: orgsLoading } = useOrganizations();
 	const { data: allRoles } = useRoles();
+	const { user: currentUser } = useAuth();
 
 	const roles = useMemo(() => (allRoles ?? []) as Role[], [allRoles]);
 
-	// Find the provider org (for auto-selecting when platform admin is chosen)
-	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
-
-	// Auto-select provider org when switching to platform admin
-	const handleUserTypeChange = (value: string) => {
-		const isAdmin = value === "platform";
-		setIsPlatformAdmin(isAdmin);
-		if (isAdmin && providerOrg) {
-			setOrgId(providerOrg.id);
-		} else if (!isAdmin && orgId === providerOrg?.id) {
-			// Clear provider org if switching to org user
-			setOrgId("");
-		}
-	};
+	const { effectiveOrgId, handleUserTypeChange } =
+		usePlatformAdminOrgSelection({
+			organizations,
+			currentUser,
+			isPlatformAdmin,
+			setIsPlatformAdmin,
+			orgId,
+			setOrgId,
+		});
 
 	const toggleRole = (roleId: string) => {
 		setSelectedRoleIds((prev) => {
@@ -122,7 +120,7 @@ function CreateUserDialogContent({
 			setValidationError("Please enter a display name");
 			return false;
 		}
-		if (!orgId) {
+		if (!effectiveOrgId) {
 			setValidationError("Please select an organization");
 			return false;
 		}
@@ -144,7 +142,7 @@ function CreateUserDialogContent({
 					name: displayName.trim(),
 					is_active: true,
 					is_superuser: isPlatformAdmin,
-					organization_id: orgId || null,
+					organization_id: effectiveOrgId || null,
 					invite: sendInvite,
 					trigger_automation: triggerAutomation,
 				},


### PR DESCRIPTION
## Summary
- Reuse the shared platform-admin organization resolver in `CreateUserDialog`
- Fall back to the current platform admin's organization when the provider org is missing from the organization query
- Update create-dialog tests to assert the real invite payload for platform-admin creation

## Root Cause
`CreateUserDialog` had older inline provider-org selection logic while `EditUserDialog` already used `usePlatformAdminOrgSelection`. When the organization list was filtered or loaded without the provider org, the create dialog could not resolve the required organization for a new platform administrator.

## Verification
- `npm run test -- CreateUserDialog.test.tsx --run`
- `npm run tsc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI fix aligning create flow with existing edit-user logic; no auth or API contract changes beyond correct org_id on create.
> 
> **Overview**
> **Create User** now uses the shared `usePlatformAdminOrgSelection` hook (same as edit user) instead of inline provider-org picking, so platform admins get a resolved org even when the organizations list omits the provider org.
> 
> Validation and the create payload use **`effectiveOrgId`**, which prefers the provider org and falls back to the signed-in superuser’s `organizationId`. Tests for platform-admin creation now assert **`invite`** and **`trigger_automation`** on the mutation body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b55bc8ab7c2c5f79c16adea104d6c6d6350a920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated user creation dialog tests to verify additional request fields for invitation and automation triggering.

* **Bug Fixes**
  * Improved organization selection logic and form validation in the user creation dialog for platform administrators.
  * User creation requests now consistently include invitation and automation trigger parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->