### PR TITLE
fix: compare sync content hashes

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -3027,6 +3027,7 @@ async def _sync_files(
             for item in data.get("files_metadata", []):
                 server_metadata[item["path"]] = {
                     "etag": item["etag"],
+                    "content_hash": item.get("content_hash") or "",
                     "last_modified": item["last_modified"],
                     "updated_by": item.get("updated_by", ""),
                 }
@@ -3068,7 +3069,14 @@ async def _sync_files(
                 "rel": rel,
                 "_content": content,
             })
-        elif server_info["etag"] != local_md5:
+            continue
+        server_hash = server_info.get("content_hash") or server_info["etag"]
+        if server_hash == local_md5:
+            # Unchanged
+            matched_server_paths.add(repo_path)
+            continue
+
+        else:
             matched_server_paths.add(repo_path)
             # Content differs — check timestamps
             local_file = path / rel
@@ -3104,10 +3112,6 @@ async def _sync_files(
                 "rel": rel,
                 "_content": content,
             })
-        else:
-            # Unchanged
-            matched_server_paths.add(repo_path)
-
     # Server-only files — always show for pull; --mirror adds delete option
     prefix_filter = repo_prefix + "/" if repo_prefix else ""
     for server_path, server_info in server_metadata.items():

--- a/api/tests/unit/cli/test_sync_content_hash_comparison.py
+++ b/api/tests/unit/cli/test_sync_content_hash_comparison.py
@@ -34,6 +34,7 @@ class _SyncClient:
         self.content_hash = content_hash
         self.storage_etag = storage_etag
         self.last_modified = last_modified or datetime(2000, 1, 1, tzinfo=timezone.utc).isoformat()
+        self.writes: list[dict[str, Any]] = []
 
     async def post(self, endpoint: str, json: dict[str, Any]) -> _Response:
         if endpoint == "/api/files/list":
@@ -47,6 +48,7 @@ class _SyncClient:
                 item["content_hash"] = self.content_hash
             return _Response(200, {"files_metadata": [item]})
         if endpoint == "/api/files/write":
+            self.writes.append(json)
             return _Response(204)
         raise AssertionError(f"unexpected endpoint: {endpoint}")
 
@@ -72,6 +74,7 @@ async def test_sync_skips_unchanged_when_content_hash_matches(workspace: pathlib
     rc = await cli._sync_files(str(workspace), force=True, client=client)
 
     assert rc == 0
+    assert client.writes == []
 
 
 @pytest.mark.asyncio
@@ -92,3 +95,28 @@ async def test_sync_pushes_when_content_hash_differs_even_if_storage_etag_matche
     rc = await cli._sync_files(str(workspace), force=True, client=client)
 
     assert rc == 0
+    assert [write["path"] for write in client.writes] == [rel]
+
+
+@pytest.mark.asyncio
+async def test_sync_pushes_prefixed_path_when_content_hash_differs(
+    workspace: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = "example.py"
+    repo_rel = f"tmp/{rel}"
+    local_bytes = b"print('local v2')\n"
+    (workspace / rel).write_bytes(local_bytes)
+    stale_hash = cli._hash_for_cache(b"print('server v1')\n")
+
+    client = _SyncClient(
+        server_path=repo_rel,
+        content_hash=stale_hash,
+        storage_etag=cli._hash_for_cache(local_bytes),
+    )
+    monkeypatch.setattr(cli, "_detect_repo_prefix", lambda path: "tmp")
+
+    rc = await cli._sync_files(str(workspace), force=True, client=client)
+
+    assert rc == 0
+    assert [write["path"] for write in client.writes] == [repo_rel]


### PR DESCRIPTION
## Summary
- compare local sync candidates against server `content_hash` before falling back to storage ETag
- keep new local files in the push queue without falling through into server comparison
- add regression coverage for stale server hashes, matching hashes, and prefixed paths

Fixes #346

## Verification
- `python -m pytest api/tests/unit/cli/test_sync_content_hash_comparison.py api/tests/unit/cli/test_sync.py api/tests/unit/cli/test_crlf_normalization.py -q`
- `git diff --check -- api/bifrost/cli.py api/tests/unit/cli/test_sync_content_hash_comparison.py`

## Deployment note
CLI-only change. This should not require a platform runtime redeploy unless the distributed CLI package is served from the deployed app image and needs republishing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only sync diff logic with focused unit tests; no server or auth changes.
> 
> **Overview**
> **`bifrost sync` / push** now treats files as unchanged when the local normalized MD5 matches the server’s **`content_hash`**, using storage **`etag`** only when `content_hash` is missing. That stops false “changed” results when cloud storage ETags don’t line up with content hashes (e.g. opaque Azure ETags).
> 
> The compare loop also **`continue`s** after queuing **new locally** files so they no longer fall through into the server diff branch.
> 
> Unit tests assert **no writes** when hashes match, **writes** when `content_hash` is stale but `etag` matches local, and correct **`repo_prefix`** paths on push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 345a3530e7c1d42ba749651dd33318379356366f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->