### PR TITLE
fix: allow platform admin creation without org selection

### DIFF
--- a/client/src/components/users/CreateUserDialog.test.tsx
+++ b/client/src/components/users/CreateUserDialog.test.tsx
@@ -77,6 +77,17 @@ vi.mock("@/components/ui/combobox", () => ({
 
 import { CreateUserDialog } from "./CreateUserDialog";
 
+async function fillPlatformAdminForm(user: {
+	type: (element: Element, text: string) => Promise<void>;
+	selectOptions: (element: Element, values: string | string[]) => Promise<void>;
+	click: (element: Element) => Promise<void>;
+}) {
+	await user.type(screen.getByLabelText(/email address/i), "admin@example.com");
+	await user.type(screen.getByLabelText(/display name/i), "Admin User");
+	await user.selectOptions(screen.getByLabelText(/userType/i), "platform");
+	await user.click(screen.getByRole("button", { name: /create user/i }));
+}
+
 beforeEach(() => {
 	mockCreateMutate.mockReset();
 	mockCreateMutate.mockResolvedValue({ id: "new-user-1" });
@@ -199,17 +210,9 @@ describe("CreateUserDialog — happy path", () => {
 			<CreateUserDialog open={true} onOpenChange={onOpenChange} />,
 		);
 
-		await user.type(
-			screen.getByLabelText(/email address/i),
-			"admin@example.com",
-		);
-		await user.type(screen.getByLabelText(/display name/i), "Admin User");
-		await user.selectOptions(screen.getByLabelText(/userType/i), "platform");
-
 		orgsLoaded = true;
 		rerender(<CreateUserDialog open={true} onOpenChange={onOpenChange} />);
-
-		await user.click(screen.getByRole("button", { name: /create user/i }));
+		await fillPlatformAdminForm(user);
 
 		await waitFor(() => expect(mockCreateMutate).toHaveBeenCalled());
 		expect(mockCreateMutate.mock.calls[0]![0]).toEqual({
@@ -252,18 +255,43 @@ describe("CreateUserDialog — happy path", () => {
 			<CreateUserDialog open={true} onOpenChange={onOpenChange} />,
 		);
 
-		await user.type(
-			screen.getByLabelText(/email address/i),
-			"admin@example.com",
-		);
-		await user.type(screen.getByLabelText(/display name/i), "Admin User");
-		await user.selectOptions(screen.getByLabelText(/userType/i), "platform");
-		await user.click(screen.getByRole("button", { name: /create user/i }));
+		await fillPlatformAdminForm(user);
 
 		await waitFor(() => expect(mockCreateMutate).toHaveBeenCalled());
 		expect(mockCreateMutate.mock.calls[0]![0].body).toMatchObject({
 			is_superuser: true,
 			organization_id: "provider-from-auth",
+			invite: true,
+			trigger_automation: true,
+		});
+		expect(screen.queryByText(/select an organization/i)).not.toBeInTheDocument();
+	});
+
+	it("allows platform admin creation with no organization fallback", async () => {
+		const onOpenChange = vi.fn();
+		mockOrganizations.mockReturnValue({
+			data: [],
+			isLoading: false,
+		});
+		mockAuth.mockReturnValue({
+			user: {
+				id: "admin-user",
+				email: "admin@example.com",
+				isSuperuser: true,
+				organizationId: null,
+			},
+		});
+
+		const { user } = renderWithProviders(
+			<CreateUserDialog open={true} onOpenChange={onOpenChange} />,
+		);
+
+		await fillPlatformAdminForm(user);
+
+		await waitFor(() => expect(mockCreateMutate).toHaveBeenCalled());
+		expect(mockCreateMutate.mock.calls[0]![0].body).toMatchObject({
+			is_superuser: true,
+			organization_id: null,
 			invite: true,
 			trigger_automation: true,
 		});

--- a/client/src/components/users/CreateUserDialog.tsx
+++ b/client/src/components/users/CreateUserDialog.tsx
@@ -120,7 +120,7 @@ function CreateUserDialogContent({
 			setValidationError("Please enter a display name");
 			return false;
 		}
-		if (!effectiveOrgId) {
+		if (!isPlatformAdmin && !effectiveOrgId) {
 			setValidationError("Please select an organization");
 			return false;
 		}


### PR DESCRIPTION
## Summary

- do not block Platform Administrator creation on front-end organization validation
- still sends the provider/current org when the UI can resolve one
- sends organization_id: null for platform admins when org data is filtered or unavailable, which matches the backend contract for superusers

## Verification

- 
pm run test -- CreateUserDialog.test.tsx --run
- 
pm run tsc

## Context

Follow-up to PR #345. Live UI can still show Please select an organization when the current platform admin has no org fallback and the provider org is not present in the organizations query.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UI validation change for superuser creation only; org users still require an organization, and existing org resolution behavior is unchanged.
> 
> **Overview**
> Fixes **Create User** blocking **Platform Administrator** creation when no organization can be resolved in the UI (empty org list and no `organizationId` on the current admin).
> 
> **`validateForm`** now requires an organization only for non–platform-admin users; platform admins can submit without `effectiveOrgId`, and the existing submit path still sends **`organization_id: null`** when nothing is resolved (provider org, auth fallback, or manual selection still apply when available).
> 
> Tests add a shared **`fillPlatformAdminForm`** helper and a case asserting create succeeds with **`organization_id: null`** and no “select an organization” error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde5029065f423de62582b9fb51a813b353f4f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Platform administrators can now create users without being required to select an organization.

* **Tests**
  * Added test coverage for platform admin user creation scenarios when no organization is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->