### PR TITLE
test: cover platform admin invite password login

### DIFF
--- a/api/tests/e2e/api/test_user_invites.py
+++ b/api/tests/e2e/api/test_user_invites.py
@@ -208,6 +208,73 @@ class TestRegisterFromInvite:
             f"/api/users/{user_id}", headers=platform_admin.headers
         )
 
+    def test_platform_admin_invite_sets_password_login_credentials(
+        self, e2e_client, platform_admin
+    ):
+        """Platform admin invite registration sets a usable password hash."""
+        email = "inv-platform-admin@gobifrost.dev"
+        create_resp = e2e_client.post(
+            "/api/users",
+            headers=platform_admin.headers,
+            json={
+                "email": email,
+                "name": "Invited Platform Admin",
+                "organization_id": None,
+                "is_superuser": True,
+                "invite": True,
+                "trigger_automation": False,
+            },
+        )
+        assert create_resp.status_code == 201
+        body = create_resp.json()
+        assert body["invite_status"] == "pending"
+        assert body["organization_id"] is None
+        assert body["is_superuser"] is True
+        user_id = body["id"]
+
+        regen = e2e_client.post(
+            f"/api/users/{user_id}/invite/regenerate",
+            headers=platform_admin.headers,
+        )
+        assert regen.status_code == 200
+        url: str = regen.json()["registration_url"]
+        token = url.split("token=", 1)[1]
+
+        generated_password = secrets.token_urlsafe(18)
+        register_resp = e2e_client.post(
+            "/auth/register-from-invite",
+            json={"token": token, AUTH_SECRET_FIELD: generated_password},
+        )
+        assert register_resp.status_code == 200
+        registered = register_resp.json()
+        assert registered["email"] == email
+        assert registered["is_registered"] is True
+
+        login_resp = e2e_client.post(
+            "/auth/login",
+            data={"username": email, AUTH_SECRET_FIELD: generated_password},
+        )
+        assert login_resp.status_code != 401
+        assert login_resp.json().get("detail") != (
+            "Account does not have password authentication enabled"
+        )
+        login_body = login_resp.json()
+        assert (
+            login_body.get("access_token")
+            or login_body.get("mfa_setup_required")
+            or login_body.get("mfa_required")
+        )
+
+        # Cleanup
+        e2e_client.patch(
+            f"/api/users/{user_id}",
+            headers=platform_admin.headers,
+            json={"is_active": False},
+        )
+        e2e_client.delete(
+            f"/api/users/{user_id}", headers=platform_admin.headers
+        )
+
     def test_register_unknown_token_400(self, e2e_client):
         """Unknown token returns 400, not 200/500."""
         resp = e2e_client.post(

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -67,11 +67,10 @@ services:
     # No ports exposed - all access via Docker network
     tmpfs:
       # Ephemeral storage - prevents Erlang cookie permission issues.
-      # mode=1777 (sticky world-writable) matches the image's own dir perms
-      # so the rabbitmq user can create .erlang.cookie; Docker >= 24 stopped
-      # defaulting tmpfs to 1777 and now creates it 0755 root:root, which
-      # breaks the boot with "Error when reading /var/lib/rabbitmq/.erlang.cookie: eacces".
-      - /var/lib/rabbitmq:mode=1777
+      # RabbitMQ runs as uid 100 / gid 101 in this image. Some Docker hosts
+      # ignore mode-only tmpfs ownership here and leave the mount root-owned,
+      # which breaks boot with ".erlang.cookie: eacces".
+      - /var/lib/rabbitmq:uid=100,gid=101,mode=1777
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "check_running"]
       interval: 5s


### PR DESCRIPTION
## Summary
- Add an e2e regression test for platform-admin invite registration with no organization.
- Verify invite consumption creates credentials that get past password authentication.
- Set RabbitMQ test tmpfs uid/gid explicitly so the test stack boots on Docker hosts that leave mode-only tmpfs mounts root-owned.

## Verification
- python3 -m py_compile api/tests/e2e/api/test_user_invites.py
- git diff --check
- VM codex-dev-01 (codex-vm-netbird), checkout /home/dev/src/codex-close-invite-test-loops: ./test.sh tests/e2e/api/test_user_invites.py::TestRegisterFromInvite::test_platform_admin_invite_sets_password_login_credentials -v -> 1 passed in 14.00s

## Notes
- Direct pve-t340.netbird.cloud DNS did not resolve from this shell, so VM host placement was not re-proven in this run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e coverage and test-stack Docker configuration; no production auth or invite logic is modified.
> 
> **Overview**
> Adds an **e2e regression** for inviting a **platform admin** (`organization_id` null, `is_superuser`, `invite=True`): after `register-from-invite`, **`/auth/login`** must succeed with the chosen password and must not return *Account does not have password authentication enabled*.
> 
> Updates **`docker-compose.test.yml`** so RabbitMQ’s `/var/lib/rabbitmq` tmpfs sets **`uid=100,gid=101`** (with `mode=1777`), fixing `.erlang.cookie: eacces` on hosts that ignore mode-only tmpfs ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06780960e82cdaf64b9a61aaebe3814502296669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for platform admin invitations with password-based authentication workflow.

* **Chores**
  * Updated test environment container configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->