### PR TITLE
Sync latest gobifrost upstream deploy UX

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -401,6 +401,7 @@
 | POST | `/api/settings/oauth/{provider}/test` |
 | GET | `/api/solutions` |
 | POST | `/api/solutions` |
+| GET | `/api/solutions/deploy-jobs/{job_id}` |
 | POST | `/api/solutions/install` |
 | POST | `/api/solutions/install/from-repo` |
 | POST | `/api/solutions/install/preview` |

--- a/api/alembic/versions/20260617_solution_deploy_jobs.py
+++ b/api/alembic/versions/20260617_solution_deploy_jobs.py
@@ -1,0 +1,47 @@
+"""solution_deploy_jobs orchestration table
+
+Tracks an async, observable solution deploy: the deploy endpoint enqueues a
+background task and returns the job id immediately; the task flips
+queued -> running -> succeeded/failed (capturing the error). The CLI polls the
+status endpoint until a terminal status, so it no longer times out client-side
+while the server completes the (sometimes >100s) deploy.
+
+Revision ID: 20260617_solution_deploy_jobs
+Revises: 20260616_merge_appname_captures
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260617_solution_deploy_jobs"
+down_revision = "20260616_merge_appname_captures"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "solution_deploy_jobs",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("install_id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("result", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["install_id"], ["solutions.id"], ondelete="CASCADE"
+        ),
+    )
+    op.create_index(
+        "ix_solution_deploy_jobs_install_id",
+        "solution_deploy_jobs",
+        ["install_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_solution_deploy_jobs_install_id", table_name="solution_deploy_jobs"
+    )
+    op.drop_table("solution_deploy_jobs")

--- a/api/bifrost/_solution_workspace.py
+++ b/api/bifrost/_solution_workspace.py
@@ -1,0 +1,26 @@
+"""Detect Solution workspaces so global _repo commands can refuse to run in them."""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+DESCRIPTOR = "bifrost.solution.yaml"
+
+
+def find_solution_root(start: pathlib.Path) -> pathlib.Path | None:
+    cur = start.resolve()
+    for parent in [cur, *cur.parents]:
+        if (parent / DESCRIPTOR).is_file():
+            return parent
+    return None
+
+
+def assert_not_solution_workspace(path: str, command: str) -> None:
+    root = find_solution_root(pathlib.Path(path)) or find_solution_root(pathlib.Path.cwd())
+    if root is not None:
+        print(
+            f"This is a Solution workspace ({root}). `bifrost {command}` targets the "
+            f"global _repo workspace and is disabled here.\nUse `bifrost solution deploy`.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -130,6 +130,18 @@ def _print_sync_summary(summary: str) -> None:
     print(f"  {_check_glyph()} {summary}")
 
 
+# Module-level TTY override. ``None`` means "detect from the real stdio";
+# tests set this to ``True``/``False`` to exercise the interactive vs
+# line-oriented (non-TTY) progress paths deterministically.
+_is_tty: bool | None = None
+
+
+def _resolve_is_tty() -> bool:
+    if _is_tty is not None:
+        return _is_tty
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
 # ---------------------------------------------------------------------------
 # Shared CLI utilities
 # ---------------------------------------------------------------------------
@@ -1974,14 +1986,23 @@ Examples:
         return 1
 
     resolved = pathlib.Path(parsed.local_path).resolve()
-    if not resolved.exists() or not resolved.is_dir():
-        print(f"Error: {parsed.local_path} is not a valid directory", file=sys.stderr)
+    single_file: str | None = None
+    if resolved.is_file():
+        single_file = parsed.local_path
+        lock_target = resolved.parent
+    elif resolved.is_dir():
+        lock_target = resolved
+    else:
+        print(f"Error: {parsed.local_path} is not a valid file or directory", file=sys.stderr)
         return 1
+
+    from bifrost._solution_workspace import assert_not_solution_workspace
+    assert_not_solution_workspace(parsed.local_path, "push")
 
     # Block push if a watch (or another sync/push) is already running in
     # this workspace — see handle_sync for rationale.
     try:
-        lock = WorkspaceLock(resolved, "push").__enter__()
+        lock = WorkspaceLock(lock_target, "push").__enter__()
     except WorkspaceLockError as e:
         print(f"\nError: {e}", file=sys.stderr)
         return 1
@@ -2000,7 +2021,7 @@ Examples:
         try:
             return asyncio.run(_sync_files(
                 parsed.local_path, mirror=parsed.mirror, validate=parsed.validate, force=parsed.force,
-                client=client,
+                client=client, single_file=single_file, one_way=not parsed.mirror,
             ))
         except KeyboardInterrupt:
             return 130
@@ -2050,6 +2071,9 @@ Examples:
     if not resolved.exists() or not resolved.is_dir():
         print(f"Error: {parsed.local_path} is not a valid directory", file=sys.stderr)
         return 1
+
+    from bifrost._solution_workspace import assert_not_solution_workspace
+    assert_not_solution_workspace(parsed.local_path, "sync")
 
     # Block sync if a watch (or another sync) is already running in this
     # workspace — concurrent watch+sync would issue separate session_ids
@@ -2120,6 +2144,13 @@ Examples:
     if not resolved.exists() or not resolved.is_dir():
         print(f"Error: {parsed.local_path} is not a valid directory", file=sys.stderr)
         return 1
+
+    # Refuse inside a Solution workspace (D1). `watch` only ever syncs to the
+    # global `_repo/` workspace; a Solution developer running it here would
+    # silently push their apps/ and workflows/ to `_repo/` instead of the
+    # install, with no error — actively misleading.
+    from bifrost._solution_workspace import assert_not_solution_workspace
+    assert_not_solution_workspace(parsed.local_path, "watch")
 
     # Acquire the per-workspace lock. Held for the lifetime of the watch
     # process; the kernel releases it on any exit (including crashes), so no
@@ -2228,6 +2259,9 @@ Examples:
     if not resolved.exists() or not resolved.is_dir():
         print(f"Error: {local_path} is not a valid directory", file=sys.stderr)
         return 1
+
+    from bifrost._solution_workspace import assert_not_solution_workspace
+    assert_not_solution_workspace(local_path, "pull")
 
     # Block pull if a watch (or another sync/push/pull) is already running
     # in this workspace — see handle_sync for rationale.
@@ -3099,13 +3133,33 @@ def _should_skip_path(
 def _collect_push_files(
     path: pathlib.Path,
     repo_prefix: str,
+    single_file: str | None = None,
 ) -> tuple[dict[str, str], int]:
     """Walk a directory and collect text files for push.
+
+    When ``single_file`` is set, collect exactly that one file (keyed by its
+    repo path relative to ``path``, with ``repo_prefix`` prepended) instead of
+    walking the directory tree.
 
     Returns (files_dict, skipped_count).
     """
     files: dict[str, str] = {}
     skipped = 0
+
+    if single_file is not None:
+        p = pathlib.Path(single_file).resolve()
+        rel_str = p.relative_to(path).as_posix()
+        repo_path = f"{repo_prefix}/{rel_str}" if repo_prefix else rel_str
+        spec = _build_file_filter(path)
+        if _should_skip_path(rel_str, spec, repo_path):
+            return {}, 1
+        try:
+            raw = _normalize_line_endings(p.read_bytes())
+            files[repo_path] = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            skipped += 1
+        return files, skipped
+
     spec = _build_file_filter(path)
 
     for file_path in sorted(path.rglob("*")):
@@ -3134,6 +3188,8 @@ async def _sync_files(
     validate: bool = False,
     force: bool = False,
     client: "BifrostClient | None" = None,
+    single_file: str | None = None,
+    one_way: bool = False,
 ) -> int:
     """Unified bidirectional sync between local directory and Bifrost platform.
 
@@ -3142,8 +3198,22 @@ async def _sync_files(
     managed separately via `bifrost export` / `bifrost import` and dedicated
     mutation commands (`bifrost orgs`, `bifrost workflows`, etc.); this
     function does not touch `.bifrost/` manifests.
+
+    ``one_way`` (set for plain `bifrost push`) and ``single_file`` (single-file
+    push) both make this a non-interactive one-way push: the per-file selection
+    TUI is never opened and default (push) actions are applied. Only the
+    destructive `--mirror` path or the bidirectional `sync`/`pull` callers keep
+    the interactive TUI. When ``single_file`` is set, ``local_path`` may point
+    at the file itself — the containing directory is used as the sync root.
     """
-    path = pathlib.Path(local_path).resolve()
+    push_only = single_file is not None or one_way
+    if single_file is not None:
+        # Single-file push: anchor the sync root at the file's containing
+        # directory so prefix detection and repo keys stay correct whether
+        # local_path was the file or its directory.
+        path = pathlib.Path(single_file).resolve().parent
+    else:
+        path = pathlib.Path(local_path).resolve()
 
     if not path.exists():
         print(f"Error: path does not exist: {local_path}", file=sys.stderr)
@@ -3159,7 +3229,13 @@ async def _sync_files(
         repo_prefix = _detect_repo_prefix(path)
 
     # ── 1. Collect local files ───────────────────────────────────────────
-    files, skipped = _collect_push_files(path, repo_prefix)
+    # Non-TTY (CI, piped, agent-driven) runs get line-oriented progress so a
+    # large push never looks hung. Detect once up front so the phase banners
+    # can be printed before the slow scan/compare/upload steps.
+    line_progress = push_only and not _resolve_is_tty()
+    if line_progress:
+        print("Scanning files...", flush=True)
+    files, skipped = _collect_push_files(path, repo_prefix, single_file=single_file)
     regular_files = {k: v for k, v in files.items() if not _is_bifrost_path(k)}
 
     # ── 2. Fetch server file metadata ────────────────────────────────────
@@ -3287,6 +3363,12 @@ async def _sync_files(
             "_content": "",
         })
 
+    if push_only:
+        sync_items = [
+            item for item in sync_items
+            if item.get("default_action") == "push"
+        ]
+
     # ── 4. Check if there's anything to sync ─────────────────────────────
     if not sync_items:
         print("Already up to date.")
@@ -3294,14 +3376,28 @@ async def _sync_files(
 
     unchanged = len(regular_files) - len(sync_items)
 
+    if line_progress:
+        print(f"Scanned {len(regular_files)} files, {unchanged} unchanged", flush=True)
+        print("Comparing remote state...", flush=True)
+
     subtitle = f"Scanned {len(regular_files)} file(s), {unchanged} unchanged"
     if skipped:
         subtitle += f", {skipped} skipped"
 
     # ── 6. Interactive TUI or auto-accept ────────────────────────────────
-    _is_tty = sys.stdin.isatty() and sys.stdout.isatty()
+    is_tty = _resolve_is_tty()
+    # _use_tui is the single source of truth for both the selection TUI (below)
+    # AND the progress TUI (further down). When --yes/-y (force), or
+    # BIFROST_NONINTERACTIVE=1, or no TTY, we must use NEITHER — the progress TUI
+    # blocks on "press Enter" when a file errors, which would hang an unattended
+    # run despite skipping the selection TUI (criterion 17).
+    # One-way push (plain `bifrost push` or a single-file push) is never
+    # interactive — it always applies default (push) actions. Only the
+    # destructive --mirror path and the bidirectional sync/pull callers reach
+    # the selection/progress TUI.
+    _use_tui = (not push_only) and _sync_use_tui(force=force, is_tty=is_tty)
 
-    if force or not _is_tty:
+    if not _use_tui:
         # Auto-accept: use default actions
         from bifrost.tui.sync_app import SyncResult
         result = SyncResult()
@@ -3312,7 +3408,7 @@ async def _sync_files(
                 bucket.append(item)
             else:
                 result.skip.append(item)
-        if not _is_tty:
+        if not is_tty:
             push_count = len(result.push)
             pull_count = len(result.pull)
             delete_count = len(result.delete)
@@ -3413,10 +3509,33 @@ async def _sync_files(
         return ", ".join(parts) if parts else "No changes"
 
     errors: list[str] = []
-    if progress_items and _is_tty:
+    if progress_items and _use_tui:
         from bifrost.tui.progress import ProgressApp
         app = ProgressApp("Syncing", progress_items, _do_sync_work, post_fn=_post_sync)
         errors = await app.run_async() or []
+    elif progress_items and line_progress:
+        total = len(progress_items)
+        pushed = 0
+        failed = 0
+        last_print = time.monotonic()
+        for i, (name, data) in enumerate(progress_items, start=1):
+            repo_path = data["item"].get("rel", name)
+            now = time.monotonic()
+            if total <= 50 or i % 25 == 0 or (now - last_print) >= 1.0:
+                print(f"Uploading {i}/{total} {repo_path}", flush=True)
+                last_print = now
+            try:
+                await _do_sync_work(data, name)
+                pushed += 1
+            except Exception as e:
+                failed += 1
+                errors.append(f"{name}: {e}")
+                print(f"  Error: {name}: {e}", file=sys.stderr)
+        print(
+            f"Done: {pushed} pushed, {unchanged} unchanged, "
+            f"{skipped} skipped, {failed} failed",
+            flush=True,
+        )
     elif progress_items:
         for name, data in progress_items:
             try:

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -76,6 +76,8 @@ _DEFAULT_IGNORE_PATTERNS = [
     "dist/",
     "coverage/",
     ".coverage",
+    ".env",
+    ".env.*",
     ".DS_Store",
     "*.pyc",
     # Editor atomic-write turds (e.g. foo.tsx.tmp.12345.1776000000000).

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -1948,7 +1948,7 @@ def handle_push(args: list[str]) -> int:
       bifrost push <path> [--mirror] [--validate]
 
     Args:
-      path: Local directory to push (defaults to ".")
+      path: Local file or directory to push (defaults to ".")
       --mirror: Make target match source exactly (delete files not present locally)
       --validate: Validate after push (for apps)
     """
@@ -1959,7 +1959,7 @@ Usage: bifrost push [path] [options]
 Push local files to Bifrost platform.
 
 Arguments:
-  path                  Local directory to push (default: current directory)
+  path                  Local file or directory to push (default: current directory)
 
 Options:
   --mirror              Make target match source exactly (delete files not present locally)
@@ -1972,6 +1972,7 @@ Use 'bifrost watch' for continuous file watching.
 Examples:
   bifrost push apps/my-app
   bifrost push apps/my-app --mirror
+  bifrost push workflows/my_workflow.py
   bifrost push .
 """.strip())
         return 0

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -17,10 +17,12 @@ load-bearing workflow path.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import json
 import os
 import pathlib
 import subprocess
+import time
 
 import click
 import yaml
@@ -739,6 +741,7 @@ def _collect_workflows(workspace: pathlib.Path) -> list[dict]:
     data = yaml.safe_load(wf_file.read_text()) or {}
     raw = data.get("workflows", {})
     entries: list[dict] = []
+    ws_root = os.path.realpath(workspace)
     # workflows.yaml is keyed by workflow UUID; the display name is body["name"].
     # Pass the FULL body through (not a narrowed subset): the deployer's
     # _upsert_workflows consumes endpoint_enabled/public_endpoint/timeout_seconds/
@@ -748,13 +751,34 @@ def _collect_workflows(workspace: pathlib.Path) -> list[dict]:
     for key, body in raw.items():
         if not isinstance(body, dict):
             continue
-        entries.append({
+        # Carry the workflow's source text so the server's deploy preflight can
+        # compare the manifest name against the decorated @workflow(name=...) —
+        # the value the execution engine actually matches on. Missing/unreadable
+        # source simply omits the field; preflight skips entries without source.
+        source: str | None = None
+        wf_path = body.get("path")
+        if wf_path:
+            # ``body["path"]`` is manifest-controlled; confine it to the
+            # workspace (realpath + startswith — the recognized traversal
+            # barrier) so a crafted path can't read outside the bundle.
+            _src_file = os.path.realpath(os.path.join(ws_root, str(wf_path)))
+            if not _src_file.startswith(ws_root + os.sep):
+                raise click.ClickException(
+                    f"workflow '{key}': path {wf_path!r} escapes the workspace"
+                )
+            src_file = pathlib.Path(_src_file)
+            if src_file.is_file():
+                source = src_file.read_text(encoding="utf-8")
+        entry = {
             **body,
             "id": body.get("id", key),
             "name": body.get("name") or key,
             "function_name": body["function_name"],
             "path": body["path"],
-        })
+        }
+        if source is not None:
+            entry["source"] = source
+        entries.append(entry)
     return entries
 
 
@@ -1281,6 +1305,77 @@ def pull_cmd(path: str, solution_id: str | None, org: str | None, is_global: boo
         raise SystemExit(rc)
 
 
+async def _poll_deploy_job(client, job_id: str, *, interval: float = 3.0) -> int:
+    """Poll a deploy job until terminal, printing a heartbeat each tick.
+
+    The deploy endpoint runs the (often >100s) work as a background job and
+    returns immediately, so the CLI polls for the result instead of holding
+    one long HTTP request that times out client-side (Task 7 bug). Returns 0 on
+    ``succeeded``, 1 on ``failed`` (printing the server-captured error).
+    """
+    start = time.monotonic()
+    while True:
+        resp = await client.get(f"/api/solutions/deploy-jobs/{job_id}")
+        if resp.status_code != 200:
+            click.echo(
+                f"Failed to read deploy status ({resp.status_code}): {resp.text[:200]}",
+                err=True,
+            )
+            return 1
+        body = resp.json()
+        status = body.get("status")
+        if status == "succeeded":
+            click.echo("Deploy complete.")
+            return 0
+        if status == "failed":
+            error = body.get("error") or "unknown error"
+            # Task 20 downgrade gate now surfaces as a failed job — re-attach the
+            # deliberate-override hint so the operator knows how to proceed.
+            if "older than installed" in error:
+                error = f"{error}\nRe-run with --force to downgrade."
+            click.echo(f"Deploy failed: {error}", err=True)
+            return 1
+        elapsed = int(time.monotonic() - start)
+        click.echo(f"Still deploying... {elapsed}s")
+        await asyncio.sleep(interval)
+
+
+# Vendoring modules/ + shared/ into a Solution can balloon the bundle; warn the
+# operator loudly so an accidental dependency tree doesn't ship silently.
+_VENDORED_WARN_THRESHOLD = 200
+
+
+@dataclasses.dataclass
+class BundleSummary:
+    file_count: int
+    size_mb: float
+    warn: bool
+    message: str
+
+
+def summarize_bundle(python_files: dict, apps: list, vendored_count: int) -> BundleSummary:
+    """Count files + bytes in the assembled deploy bundle and flag oversized
+    vendored trees so the operator sees what they're about to upload."""
+    app_files = sum(
+        len(a.get("src_files", {})) + len(a.get("bin_files", {})) for a in apps
+    )
+    count = len(python_files) + app_files
+    size = sum(len(v.encode()) for v in python_files.values())
+    size += sum(
+        len(s.encode()) for a in apps for s in a.get("src_files", {}).values()
+    )
+    mb = round(size / 1_000_000, 1)
+    warn = vendored_count > _VENDORED_WARN_THRESHOLD
+    if warn:
+        msg = (
+            f"This deploy includes {vendored_count} vendored files from modules/ and "
+            f"shared/. Bundle size: {mb} MB."
+        )
+    else:
+        msg = f"Bundle: {count} files, {mb} MB."
+    return BundleSummary(count, mb, warn, msg)
+
+
 @solution_group.command(name="deploy", help="Deploy the current Solution workspace (full replace, non-interactive).")
 @click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
 @click.option("--solution", "solution_id", default=None, help="Target install id (override when ambiguous).")
@@ -1312,6 +1407,7 @@ def deploy_cmd(
         solution_logo_b64 = base64.b64encode(logo_file.read_bytes()).decode("ascii")
         solution_logo_content_type = _LOGO_CONTENT_TYPES.get(logo_file.suffix.lower())
 
+    click.echo("Collecting solution files...")
     python_files = _collect_python_files(workspace)
     workflows = _collect_workflows(workspace)
     tables = _collect_tables(workspace)
@@ -1366,6 +1462,7 @@ def deploy_cmd(
         # Solution is self-contained (criterion 5). When global_repo_access is on
         # the install can reach _repo/ at runtime, so vendoring is skipped.
         bundle_python = python_files
+        vendored: dict[str, str] = {}
         if not descriptor.global_repo_access:
             from bifrost.solution_vendoring import vendor_shared_deps
 
@@ -1382,59 +1479,42 @@ def deploy_cmd(
                 click.echo(f"Vendored {len(vendored)} shared dependency file(s).")
                 bundle_python = {**python_files, **vendored}
 
-        deploy = await client.post(f"/api/solutions/{target_id}/deploy", json={
-            "python_files": bundle_python,
-            "workflows": workflows,
-            "tables": tables,
-            "apps": apps,
-            "forms": forms,
-            "agents": agents,
-            "claims": claims,
-            "config_schemas": config_schemas,
-            "connection_schemas": connection_schemas,
-            "events": events,
-            "readme": readme,
-            "version": descriptor.version,
-            "logo_b64": solution_logo_b64,
-            "logo_content_type": solution_logo_content_type,
-            "force": force,
-        })
-        if deploy.status_code == 409 and "older than installed" in deploy.text:
-            # Task 20 downgrade gate — surface the server's detail and how to
-            # override it deliberately.
-            detail = deploy.json().get("detail", deploy.text)
-            raise click.ClickException(f"{detail}\nRe-run with --force to downgrade.")
-        if deploy.status_code not in (200, 201):
+        summary = summarize_bundle(bundle_python, apps, len(vendored))
+        click.echo(summary.message, err=summary.warn)
+
+        click.echo("Uploading bundle...")
+        # Deploy is async server-side; the POST returns a job id quickly. We give
+        # the upload itself a generous timeout (large bundles) but never block on
+        # the deploy work — that is observed via the poll loop below.
+        deploy = await client.post(
+            f"/api/solutions/{target_id}/deploy",
+            json={
+                "python_files": bundle_python,
+                "workflows": workflows,
+                "tables": tables,
+                "apps": apps,
+                "forms": forms,
+                "agents": agents,
+                "claims": claims,
+                "config_schemas": config_schemas,
+                "connection_schemas": connection_schemas,
+                "events": events,
+                "readme": readme,
+                "version": descriptor.version,
+                "logo_b64": solution_logo_b64,
+                "logo_content_type": solution_logo_content_type,
+                "force": force,
+            },
+            timeout=600,
+        )
+        if deploy.status_code != 202:
+            # Synchronous refusals (git-connected, captured-but-unpulled entities)
+            # come back on the POST itself, before any job is created.
             click.echo(f"Deploy failed: {deploy.status_code} {deploy.text}", err=True)
             return 1
-        body = deploy.json()
-        # Summarize every entity kind that was upserted (not just workflows +
-        # claims) so the operator sees their tables/forms/apps shipped too.
-        kinds = [
-            ("workflow", body.get("workflows_upserted", 0)),
-            ("table", body.get("tables_upserted", 0)),
-            ("app", body.get("apps_upserted", 0)),
-            ("form", body.get("forms_upserted", 0)),
-            ("agent", body.get("agents_upserted", 0)),
-            ("claim", body.get("claims_upserted", 0)),
-        ]
-        upserted = ", ".join(f"{n} {label}(s)" for label, n in kinds if n) or "0 entities"
-        total_deleted = sum(
-            body.get(k, 0)
-            for k in (
-                "workflows_deleted", "tables_deleted", "apps_deleted",
-                "forms_deleted", "agents_deleted", "claims_deleted",
-            )
-        )
-        click.echo(f"Deployed install {target_id}: {upserted} upserted, {total_deleted} deleted.")
-        roles_created = body.get("roles_created") or []
-        if roles_created:
-            click.echo(
-                f"  Auto-created {len(roles_created)} new role(s): "
-                f"{', '.join(roles_created)} "
-                f"(empty — assign members to grant access)."
-            )
-        return 0
+        job_id = deploy.json()["deploy_job_id"]
+        click.echo(f"Deploying install {target_id} (job {job_id})...")
+        return await _poll_deploy_job(client, job_id)
 
     rc = asyncio.run(_run())
     if rc:

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -1407,7 +1407,7 @@ def deploy_cmd(
         solution_logo_b64 = base64.b64encode(logo_file.read_bytes()).decode("ascii")
         solution_logo_content_type = _LOGO_CONTENT_TYPES.get(logo_file.suffix.lower())
 
-    click.echo("Collecting solution files...")
+    click.echo("Scanning solution files...")
     python_files = _collect_python_files(workspace)
     workflows = _collect_workflows(workspace)
     tables = _collect_tables(workspace)
@@ -1419,6 +1419,10 @@ def deploy_cmd(
     connection_schemas = _collect_connection_schemas(workspace)
     events = _collect_events(workspace)
     readme = _collect_readme(workspace)
+    click.echo(
+        f"  found {len(python_files)} python file(s), {len(workflows)} workflow(s), "
+        f"{len(apps)} app(s), {len(forms)} form(s), {len(agents)} agent(s)."
+    )
 
     async def _run() -> int:
         client = BifrostClient.get_instance(require_auth=True)
@@ -1466,6 +1470,12 @@ def deploy_cmd(
         if not descriptor.global_repo_access:
             from bifrost.solution_vendoring import vendor_shared_deps
 
+            # Vendoring scans imports and reads each referenced _repo/ module
+            # over the network one at a time, so it can take a few seconds on a
+            # solution with a deep shared-module graph. Announce it up front so
+            # the wait isn't a silent gap before the bundle summary.
+            click.echo("Vendoring shared dependencies...")
+
             async def _repo_read(path: str) -> str | None:
                 resp = await client.post("/api/files/read", json={
                     "path": path, "location": "workspace", "mode": "cloud",
@@ -1476,8 +1486,10 @@ def deploy_cmd(
 
             vendored = await vendor_shared_deps(python_files, _repo_read)
             if vendored:
-                click.echo(f"Vendored {len(vendored)} shared dependency file(s).")
+                click.echo(f"  vendored {len(vendored)} shared dependency file(s).")
                 bundle_python = {**python_files, **vendored}
+            else:
+                click.echo("  no shared dependencies to vendor.")
 
         summary = summarize_bundle(bundle_python, apps, len(vendored))
         click.echo(summary.message, err=summary.warn)

--- a/api/bifrost/contract_version.py
+++ b/api/bifrost/contract_version.py
@@ -15,7 +15,9 @@ integers agree and fails if a CLI-consumed contract changed without a decision.
 # v4: unified --org standard — SolutionCreate/SolutionBase drop `scope` (install
 #     kind is derived from organization_id); SolutionRepoPreviewRequest gains
 #     organization_id; descriptor no longer carries scope (2026-06-15)
-CONTRACT_VERSION: int = 4
+# v5: Solution deploy is async: POST /deploy returns 202 + deploy_job_id and
+#     callers poll SolutionDeployJobStatus for the deploy summary (2026-06-17)
+CONTRACT_VERSION: int = 5
 
 
 def get_contract_version() -> int:

--- a/api/shared/contract_version.py
+++ b/api/shared/contract_version.py
@@ -16,7 +16,9 @@ or cosmetic changes do NOT bump it. The tripwire in
 # v4: unified --org standard — SolutionCreate/SolutionBase drop `scope` (install
 #     kind is derived from organization_id); SolutionRepoPreviewRequest gains
 #     organization_id; descriptor no longer carries scope (2026-06-15)
-CONTRACT_VERSION: int = 4
+# v5: Solution deploy is async: POST /deploy returns 202 + deploy_job_id and
+#     callers poll SolutionDeployJobStatus for the deploy summary (2026-06-17)
+CONTRACT_VERSION: int = 5
 
 
 def get_contract_version() -> int:

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -143,9 +143,24 @@ async def app_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     if settings.default_user_email and settings.default_user_password:
         await create_default_user()
 
+    from src.core.database import get_session_factory
+    from src.routers.solutions import reconcile_orphaned_deploy_jobs
+
+    try:
+        session_factory = get_session_factory()
+        async with session_factory() as db:
+            count = await reconcile_orphaned_deploy_jobs(db)
+            if count:
+                await db.commit()
+                logger.warning(
+                    "Marked %d orphaned solution deploy job(s) as failed after API startup",
+                    count,
+                )
+    except Exception as e:
+        logger.warning(f"Solution deploy job reconciliation failed: {e}")
+
     # Reconcile file_index with S3 _repo/ in background
     from src.services.file_index_reconciler import reconcile_file_index
-    from src.core.database import get_session_factory
 
     async def _run_reconciler():
         try:

--- a/api/src/models/contracts/solutions.py
+++ b/api/src/models/contracts/solutions.py
@@ -440,27 +440,27 @@ class SolutionDeleteSummary(BaseModel):
     config_values_orphaned: int = 0
 
 
-class SolutionDeployResponse(BaseModel):
-    solution_id: UUID
-    workflows_upserted: int = 0
-    workflows_deleted: int = 0
-    tables_upserted: int = 0
-    tables_deleted: int = 0
-    apps_upserted: int = 0
-    apps_deleted: int = 0
-    forms_upserted: int = 0
-    forms_deleted: int = 0
-    agents_upserted: int = 0
-    agents_deleted: int = 0
-    claims_upserted: int = 0
-    claims_deleted: int = 0
-    # Empty integration shells created for declared connections that did not yet
-    # exist globally (never clobbers a configured integration).
-    integrations_shell_created: int = 0
-    # Names of roles auto-created because the bundle referenced a role missing
-    # from the target env. Created global + empty (grant nothing until assigned).
-    # Surfaced so the operator sees them — and a typo'd role name is visible.
-    roles_created: list[str] = Field(default_factory=list)
+class SolutionDeployEnqueued(BaseModel):
+    """Returned by ``POST /{id}/deploy`` — the deploy runs as a background job;
+    the caller polls ``GET /deploy-jobs/{deploy_job_id}`` for the result."""
+
+    deploy_job_id: UUID
+
+
+class SolutionDeployJobStatus(BaseModel):
+    """Current state of an async deploy job."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    install_id: UUID
+    status: Literal["queued", "running", "succeeded", "failed"]
+    error: str | None = None
+    # Per-entity upsert/delete counts (and auto-created role names), present once
+    # the job ``succeeded``. None while queued/running or on failure.
+    result: dict[str, Any] | None = None
+    created_at: datetime
+    updated_at: datetime
 
 
 class SolutionCaptureRequest(BaseModel):

--- a/api/src/models/orm/__init__.py
+++ b/api/src/models/orm/__init__.py
@@ -47,6 +47,7 @@ from src.models.orm.oauth import OAuthProvider, OAuthToken
 from src.models.orm.organizations import Organization
 from src.models.orm.pending_capture import PendingCaptureORM
 from src.models.orm.solution_config_schema import SolutionConfigSchema
+from src.models.orm.solution_deploy_jobs import SolutionDeployJob
 from src.models.orm.solution_connection_schema import SolutionConnectionSchema
 from src.models.orm.solutions import Solution
 from src.models.orm.custom_claims import CustomClaim
@@ -67,6 +68,7 @@ __all__ = [
     "Solution",
     "SolutionConfigSchema",
     "SolutionConnectionSchema",
+    "SolutionDeployJob",
     "PendingCaptureORM",
     # Applications (App Builder)
     "Application",

--- a/api/src/models/orm/solution_deploy_jobs.py
+++ b/api/src/models/orm/solution_deploy_jobs.py
@@ -1,0 +1,56 @@
+"""Orchestration row for an async, observable solution deploy.
+
+Created when an admin calls ``POST /api/solutions/{id}/deploy``. The endpoint
+enqueues the (sometimes >100s) deploy as an in-process background task and
+returns the ``deploy_job_id`` immediately; the task flips the row ``queued`` →
+``running`` → ``succeeded`` / ``failed`` (capturing the error). API startup
+marks stale queued/running jobs failed so pollers never wait forever after a
+restart. The CLI polls ``GET /api/solutions/deploy-jobs/{id}`` until a terminal
+status.
+
+This decouples deploy from the HTTP request so the CLI no longer hits an httpx
+``ReadTimeout`` while the server completes successfully (Task 7 bug).
+"""
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.orm.base import Base
+
+
+class SolutionDeployJob(Base):
+    __tablename__ = "solution_deploy_jobs"
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    install_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("solutions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="queued"
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    # On success: the per-entity upsert/delete counts the (now async) deploy
+    # produced, so the operator and the poller can still see what shipped.
+    result: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True, default=None
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -634,23 +634,28 @@ async def validate_application(
     errors: list[AppValidationIssue] = []
     warnings: list[AppValidationIssue] = []
 
-    # Check required file structure
-    layout_path = f"{prefix}_layout.tsx"
-    index_path = f"{prefix}pages/index.tsx"
+    # standalone_v2 apps own their createRoot + router; the v1 _layout.tsx /
+    # pages-routing convention (and its <Outlet /> requirement) does not apply.
+    is_v2 = app.app_model == "standalone_v2"
 
-    if layout_path not in files:
-        errors.append(AppValidationIssue(
-            severity="error",
-            file="_layout.tsx",
-            message="Missing required _layout.tsx file",
-        ))
+    # Check required file structure (v1-only — v2 has no _layout/pages convention)
+    if not is_v2:
+        layout_path = f"{prefix}_layout.tsx"
+        index_path = f"{prefix}pages/index.tsx"
 
-    if index_path not in files:
-        warnings.append(AppValidationIssue(
-            severity="warning",
-            file="pages/index.tsx",
-            message="Missing pages/index.tsx (home page)",
-        ))
+        if layout_path not in files:
+            errors.append(AppValidationIssue(
+                severity="error",
+                file="_layout.tsx",
+                message="Missing required _layout.tsx file",
+            ))
+
+        if index_path not in files:
+            warnings.append(AppValidationIssue(
+                severity="warning",
+                file="pages/index.tsx",
+                message="Missing pages/index.tsx (home page)",
+            ))
 
     # Get declared dependencies and track referenced ones
     declared_deps = app.dependencies or {}
@@ -692,8 +697,8 @@ async def validate_application(
                         message="Missing default export. Pages and components must have a default export (e.g., export default function MyComponent() { ... })",
                     ))
 
-            # Check _layout.tsx uses <Outlet /> not {children}
-            if rel_path == "_layout.tsx":
+            # Check _layout.tsx uses <Outlet /> not {children} (v1-only convention)
+            if not is_v2 and rel_path == "_layout.tsx":
                 if "{children}" in content and "Outlet" not in content:
                     errors.append(AppValidationIssue(
                         severity="error",

--- a/api/src/routers/solutions.py
+++ b/api/src/routers/solutions.py
@@ -15,14 +15,15 @@ import json
 import logging
 import os
 import zipfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Body, File, HTTPException, Response, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Body, File, HTTPException, Response, UploadFile, status
 from fastapi import Form as FastapiForm
 from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import noload
 
 from src.core.auth import Context, CurrentSuperuser
@@ -36,8 +37,9 @@ from src.models.contracts.solutions import (
     SolutionDeleteSummary,
     SolutionDependencyPreview,
     SolutionDependencyPreviewRequest,
+    SolutionDeployEnqueued,
+    SolutionDeployJobStatus,
     SolutionDeployRequest,
-    SolutionDeployResponse,
     SolutionEntities,
     SolutionEntitySummary,
     SolutionExistingInstall,
@@ -58,6 +60,7 @@ from src.models.orm.config import Config
 from src.models.orm.custom_claims import CustomClaim
 from src.models.orm.forms import Form
 from src.models.orm.solution_config_schema import SolutionConfigSchema
+from src.models.orm.solution_deploy_jobs import SolutionDeployJob
 from src.models.orm.solutions import Solution as SolutionORM
 from src.models.orm.tables import Table
 from src.models.orm.workflows import Workflow
@@ -67,6 +70,7 @@ from src.services.solutions.deploy import (
     SolutionDeployConflict,
     SolutionDowngradeBlocked,
     SolutionFinalizeIncomplete,
+    SolutionWorkflowNameMismatch,
 )
 
 if TYPE_CHECKING:
@@ -75,6 +79,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/solutions", tags=["Solutions"])
+
+DEPLOY_JOB_ORPHAN_THRESHOLD = timedelta(minutes=15)
+
+
+async def reconcile_orphaned_deploy_jobs(
+    db: AsyncSession,
+    *,
+    older_than: timedelta = DEPLOY_JOB_ORPHAN_THRESHOLD,
+    now: datetime | None = None,
+) -> int:
+    """Fail in-process deploy jobs that cannot survive an API restart."""
+    resolved_now = now or datetime.now(timezone.utc)
+    cutoff = resolved_now - older_than
+    result = await db.execute(
+        select(SolutionDeployJob).where(
+            SolutionDeployJob.status.in_(("queued", "running")),
+            SolutionDeployJob.updated_at < cutoff,
+        )
+    )
+    jobs = list(result.scalars().all())
+    error = (
+        "Deploy did not finish because the API restarted before its in-process "
+        "background task completed. Re-run the deploy; it is idempotent."
+    )
+    for job in jobs:
+        job.status = "failed"
+        job.error = error
+        job.updated_at = resolved_now
+    return len(jobs)
 
 
 @router.post("", response_model=SolutionDTO, status_code=status.HTTP_201_CREATED, summary="Create a Solution install (admin only)")
@@ -853,14 +886,126 @@ async def delete_solution(
     return summary
 
 
+async def _run_deploy_job(job_id: UUID, solution_id: UUID, body: SolutionDeployRequest) -> None:
+    """Execute the deploy under a fresh session (background task).
+
+    Flips the job ``running`` → ``succeeded`` / ``failed``. Deploy errors that
+    were previously surfaced as HTTP status codes are captured into ``error``
+    so the polling caller can inspect them (the HTTP request returned 202 long
+    before this ran). The whole deploy — including the per-install write lock,
+    the DB commit, and the post-commit S3 finalize — happens here so the (often
+    >100s) work no longer blocks the request and times out the CLI (Task 7).
+    """
+    from src.core.database import get_db_context
+    from src.services.solutions.write_lock import (
+        SolutionWriteLockHeld,
+        solution_write_lock,
+    )
+
+    async def _set_status(
+        status_value: str,
+        error: str | None = None,
+        result: dict | None = None,
+    ) -> None:
+        async with get_db_context() as db:
+            job = await db.get(SolutionDeployJob, job_id)
+            if job is None:
+                return
+            job.status = status_value
+            job.error = error
+            job.result = result
+
+    await _set_status("running")
+    deploy_result: dict | None = None
+    try:
+        async with get_db_context() as db:
+            async with solution_write_lock(solution_id):
+                solution = await db.get(SolutionORM, solution_id)
+                if solution is None:
+                    raise SolutionDeployConflict("Solution not found")
+                deployer = SolutionDeployer(db)
+                result = await deployer.deploy(
+                    SolutionBundle(
+                        solution=solution,
+                        python_files=body.python_files,
+                        workflows=body.workflows,
+                        tables=body.tables,
+                        apps=body.apps,
+                        forms=body.forms,
+                        agents=body.agents,
+                        claims=body.claims,
+                        config_schemas=body.config_schemas,
+                        connection_schemas=body.connection_schemas,
+                        events=body.events,
+                        version=body.version,
+                        logo_b64=body.logo_b64,
+                        logo_content_type=body.logo_content_type,
+                        readme=body.readme,
+                    ),
+                    force=body.force,
+                )
+                await db.commit()
+                # S3 only after the DB is durable — a failed commit changes no running
+                # code (P1-c). Still inside the lock so finalize can't race another deploy.
+                await result.finalize_s3()
+                deploy_result = {
+                    "solution_id": str(solution_id),
+                    "workflows_upserted": result.workflows_upserted,
+                    "workflows_deleted": result.workflows_deleted,
+                    "tables_upserted": result.tables_upserted,
+                    "tables_deleted": result.tables_deleted,
+                    "apps_upserted": result.apps_upserted,
+                    "apps_deleted": result.apps_deleted,
+                    "forms_upserted": result.forms_upserted,
+                    "forms_deleted": result.forms_deleted,
+                    "agents_upserted": result.agents_upserted,
+                    "agents_deleted": result.agents_deleted,
+                    "claims_upserted": result.claims_upserted,
+                    "claims_deleted": result.claims_deleted,
+                    "integrations_shell_created": result.integrations_shell_created,
+                    "roles_created": list(result.roles_created),
+                }
+    except SolutionWriteLockHeld:
+        await _set_status(
+            "failed",
+            "A deploy is already in progress for this install; retry shortly.",
+        )
+    except SolutionFinalizeIncomplete:
+        # Storage failed every retry (a real outage). The DB is committed and the
+        # deploy is full-replace + idempotent, so re-running heals it.
+        await _set_status(
+            "failed",
+            "Deploy committed but storage was unavailable after retries. "
+            "Re-run the deploy to complete it (it is idempotent).",
+        )
+    except (
+        SolutionDowngradeBlocked,
+        SolutionDeployConflict,
+        SolutionWorkflowNameMismatch,
+    ) as exc:
+        # Caller errors (downgrade without force, invalid bundle, workflow-name
+        # mismatch). Surfaced as the job error string for the poller to read.
+        await _set_status("failed", str(exc))
+    except Exception:  # noqa: BLE001 — capture any deploy failure onto the job
+        logger.exception("Solution deploy job %s failed", job_id)
+        await _set_status("failed", "Deploy failed unexpectedly; see server logs.")
+    else:
+        await _set_status("succeeded", result=deploy_result)
+
+
 @router.post(
     "/{solution_id}/deploy",
-    response_model=SolutionDeployResponse,
-    summary="Deploy a bundle to an install (full replace, non-interactive, admin only)",
+    response_model=SolutionDeployEnqueued,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Enqueue a deploy to an install (async, full replace, admin only)",
 )
 async def deploy_solution(
-    solution_id: UUID, body: SolutionDeployRequest, ctx: Context, user: CurrentSuperuser
-) -> SolutionDeployResponse:
+    solution_id: UUID,
+    body: SolutionDeployRequest,
+    ctx: Context,
+    user: CurrentSuperuser,
+    background_tasks: BackgroundTasks,
+) -> SolutionDeployEnqueued:
     solution = await ctx.db.get(SolutionORM, solution_id)
     if solution is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Solution not found")
@@ -879,6 +1024,8 @@ async def deploy_solution(
     # silently DELETE it — so we 409-block instead and tell the caller to pull
     # first. An entity absent with NO pending row is a genuine delete (source has
     # demonstrably seen it), and proceeds unchanged. force=True bypasses the block.
+    # These are immediate caller-input errors, so they stay synchronous (the
+    # caller gets a 409 from the request, not a failed job).
     if not body.force:
         from src.models.orm.pending_capture import PendingCaptureORM
         from src.services.solutions.pending import unpulled_blockers
@@ -910,86 +1057,31 @@ async def deploy_solution(
                 ),
             )
 
-    # One writer per install (criterion 6): hold a per-install lock ACROSS the DB
-    # commit AND the post-commit S3 finalize, so two concurrent deploys can't
-    # interleave (A commits, B commits, then A's finalize uploads last → DB from
-    # B but artifacts from A). The app-slug advisory lock inside deploy() is
-    # transaction-scoped and releases at commit, before finalize — so it does NOT
-    # cover this (Codex #12). The git-connected sync holds the same lock.
-    from src.services.solutions.write_lock import (
-        SolutionWriteLockHeld,
-        solution_write_lock,
-    )
+    # Persist the orchestration row before scheduling the task so the caller can
+    # poll for status the instant it has the id.
+    job = SolutionDeployJob(install_id=solution_id, status="queued")
+    ctx.db.add(job)
+    await ctx.db.commit()
+    await ctx.db.refresh(job)
 
-    try:
-        async with solution_write_lock(solution_id):
-            deployer = SolutionDeployer(ctx.db)
-            result = await deployer.deploy(
-                SolutionBundle(
-                    solution=solution,
-                    python_files=body.python_files,
-                    workflows=body.workflows,
-                    tables=body.tables,
-                    apps=body.apps,
-                    forms=body.forms,
-                    agents=body.agents,
-                    claims=body.claims,
-                    config_schemas=body.config_schemas,
-                    connection_schemas=body.connection_schemas,
-                    events=body.events,
-                    version=body.version,
-                    logo_b64=body.logo_b64,
-                    logo_content_type=body.logo_content_type,
-                    readme=body.readme,
-                ),
-                force=body.force,
-            )
-            await ctx.db.commit()
-            # S3 only after the DB is durable — a failed commit changes no running
-            # code (P1-c). Still inside the lock so finalize can't race another deploy.
-            await result.finalize_s3()
-    except SolutionWriteLockHeld as exc:
+    background_tasks.add_task(_run_deploy_job, job.id, solution_id, body)
+    return SolutionDeployEnqueued(deploy_job_id=job.id)
+
+
+@router.get(
+    "/deploy-jobs/{job_id}",
+    response_model=SolutionDeployJobStatus,
+    summary="Poll the status of an async deploy job (admin only)",
+)
+async def get_deploy_job(
+    job_id: UUID, ctx: Context, user: CurrentSuperuser
+) -> SolutionDeployJobStatus:
+    job = await ctx.db.get(SolutionDeployJob, job_id)
+    if job is None:
         raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="A deploy is already in progress for this install; retry shortly.",
-        ) from exc
-    except SolutionDowngradeBlocked as exc:
-        # The bundle's version is older than installed (Task 20). The caller can
-        # re-run with force=true to apply the downgrade deliberately.
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
-    except SolutionDeployConflict as exc:
-        # The bundle is invalid for this install: a foreign/owned entity id, an
-        # app-slug collision with a visible app, or a non-standalone_v2 app. These
-        # are caller errors → 409 with the reason, not an unhandled 500 (Codex #13).
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
-    except SolutionFinalizeIncomplete as exc:
-        # Reached only when storage failed every retry (a real outage), not a
-        # transient blip. The DB is committed and the deploy is full-replace +
-        # idempotent, so re-running heals it; surface 502 so the operator retries.
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=(
-                "Deploy committed but storage was unavailable after retries. "
-                "Re-run the deploy to complete it (it is idempotent)."
-            ),
-        ) from exc
-    return SolutionDeployResponse(
-        solution_id=solution_id,
-        workflows_upserted=result.workflows_upserted,
-        workflows_deleted=result.workflows_deleted,
-        tables_upserted=result.tables_upserted,
-        tables_deleted=result.tables_deleted,
-        apps_upserted=result.apps_upserted,
-        apps_deleted=result.apps_deleted,
-        forms_upserted=result.forms_upserted,
-        forms_deleted=result.forms_deleted,
-        agents_upserted=result.agents_upserted,
-        agents_deleted=result.agents_deleted,
-        claims_upserted=result.claims_upserted,
-        claims_deleted=result.claims_deleted,
-        integrations_shell_created=result.integrations_shell_created,
-        roles_created=result.roles_created,
-    )
+            status_code=status.HTTP_404_NOT_FOUND, detail="Deploy job not found"
+        )
+    return SolutionDeployJobStatus.model_validate(job)
 
 
 @router.post(
@@ -1467,6 +1559,7 @@ async def install_solution(
         SolutionDeployConflict,
         SolutionDowngradeBlocked,
         SolutionFinalizeIncomplete,
+        SolutionWorkflowNameMismatch,
     )
     from src.services.solutions.write_lock import SolutionWriteLockHeld
     from src.services.solutions.zip_install import (
@@ -1547,6 +1640,10 @@ async def install_solution(
         ) from exc
     except SolutionDeployConflict as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except SolutionWorkflowNameMismatch as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     except SolutionFinalizeIncomplete as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/api/src/routers/solutions.py
+++ b/api/src/routers/solutions.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 import zipfile
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
@@ -80,22 +80,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/solutions", tags=["Solutions"])
 
-DEPLOY_JOB_ORPHAN_THRESHOLD = timedelta(minutes=15)
-
-
 async def reconcile_orphaned_deploy_jobs(
     db: AsyncSession,
     *,
-    older_than: timedelta = DEPLOY_JOB_ORPHAN_THRESHOLD,
     now: datetime | None = None,
 ) -> int:
     """Fail in-process deploy jobs that cannot survive an API restart."""
     resolved_now = now or datetime.now(timezone.utc)
-    cutoff = resolved_now - older_than
     result = await db.execute(
         select(SolutionDeployJob).where(
             SolutionDeployJob.status.in_(("queued", "running")),
-            SolutionDeployJob.updated_at < cutoff,
         )
     )
     jobs = list(result.scalars().all())

--- a/api/src/services/execution/service.py
+++ b/api/src/services/execution/service.py
@@ -288,10 +288,17 @@ async def get_workflow_by_id(
         if not callable(obj):
             continue
 
-        # All decorators use _executable_metadata
-        if hasattr(obj, "_executable_metadata"):
+        # All decorators use _executable_metadata.
+        # Match by Python function name (the module attr name), NOT the decorator
+        # display name (meta.name) — mirroring the worker loader
+        # (module_loader.py: "Match by Python function name, not display name").
+        # The DB ``name`` is identity/display only and can legitimately differ
+        # from both the decorator name and function_name (custom @workflow(name=),
+        # CLI rename via PATCH, or a manifest-declared name). function_name is the
+        # stable source-code identity the module was loaded by.
+        if hasattr(obj, "_executable_metadata") and name == workflow_record.function_name:
             meta = getattr(obj, "_executable_metadata", None)
-            if meta and hasattr(meta, 'name') and meta.name == workflow_record.name:
+            if meta:
                 workflow_func = obj
                 # For data providers, convert to WorkflowMetadata for consistent execution
                 if hasattr(meta, 'type') and meta.type == 'data_provider':
@@ -315,7 +322,7 @@ async def get_workflow_by_id(
 
     if not workflow_func or not workflow_metadata:
         raise WorkflowLoadError(
-            f"No decorated function named '{workflow_record.name}' found in {workflow_record.path}"
+            f"No decorated function '{workflow_record.function_name}' found in {workflow_record.path}"
         )
 
     # Enrich metadata from database record

--- a/api/src/services/manifest_import.py
+++ b/api/src/services/manifest_import.py
@@ -1276,8 +1276,16 @@ class ManifestResolver:
                 imported_wf_ids.add(mwf.id)  # Still track as present for event source refs
                 continue
             if await _file_exists(mwf.path):
-                await _prog(f"Importing workflow: {mwf.name or key}")
-                wf_ops = self._resolve_workflow(mwf.name or key, mwf, cache)
+                # Execution resolves a workflow by ``function_name`` (service.py /
+                # module_loader.py both match the Python def name, not the display
+                # name), so the DB ``name`` is identity/display only. Write it the
+                # way registration does: the manifest's declared name, else the
+                # dict key, as the INITIAL value. ``_resolve_workflow`` sets it
+                # only when the DB row's name is unset — it never overwrites a
+                # UI/CLI rename (matching the indexer's source-of-truth rule).
+                resolved_name = mwf.name or key
+                await _prog(f"Importing workflow: {resolved_name}")
+                wf_ops = self._resolve_workflow(resolved_name, mwf, cache)
                 await self._apply_ops(wf_ops, all_ops, dry_run=dry_run, existing_ids=cache.get("wf_ids", set()))
                 imported_wf_ids.add(mwf.id)
 

--- a/api/src/services/solution_deploy_preflight.py
+++ b/api/src/services/solution_deploy_preflight.py
@@ -1,0 +1,60 @@
+"""Deploy preflight: catch a workflow bundle that can never execute.
+
+Execution resolves a workflow by its Python ``function_name`` (both
+``execution/service.py`` and ``execution/module_loader.py`` match the def name,
+not the decorator display name), and the DB ``name`` is identity/display only.
+So a manifest entry whose declared ``name`` differs from the decorated name or
+the function name is NOT an error — it is a legitimate rename.
+
+The one genuinely execution-breaking case is a bundle entry whose
+``function_name`` is not defined in the carried source at all: import would then
+persist a record the engine can never load. ``preflight_workflows`` flags only
+that.
+"""
+from __future__ import annotations
+
+import ast
+
+
+def _source_defines_function(source: str, function_name: str) -> bool:
+    """True if ``function_name`` is defined as a (sync/async) function in source."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # Unparseable source can't be statically verified — don't block on it
+        # (the engine, not preflight, owns runtime import failures).
+        return True
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == function_name
+        for node in ast.walk(tree)
+    )
+
+
+def preflight_workflows(workflows: list[dict]) -> list[str]:
+    """Return execution-breaking errors for a deploy bundle (empty list = OK).
+
+    Each entry is expected to carry ``function_name``, ``path`` and the ``.py``
+    ``source`` text. The only failure flagged is a ``function_name`` that the
+    carried source does not define at all — import would then persist a workflow
+    the execution engine can never load. A manifest ``name`` that differs from
+    the decorated or function name is NOT an error (execution resolves by
+    function_name; the name is identity/display only).
+
+    Entries without source are skipped (nothing to verify against).
+    """
+    errors: list[str] = []
+    for wf in workflows:
+        src = wf.get("source")
+        if not src:
+            continue
+        function_name = wf.get("function_name", "")
+        if not function_name:
+            continue
+        if not _source_defines_function(src, function_name):
+            errors.append(
+                f"Workflow `{wf.get('name')}` points to {wf.get('path')}::"
+                f"{function_name}, but no function named `{function_name}` exists "
+                f"in that source. Fix the manifest's function_name or add the function."
+            )
+    return errors

--- a/api/src/services/solution_deploy_preflight.py
+++ b/api/src/services/solution_deploy_preflight.py
@@ -21,13 +21,13 @@ def _source_defines_function(source: str, function_name: str) -> bool:
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        # Unparseable source can't be statically verified — don't block on it
-        # (the engine, not preflight, owns runtime import failures).
+        # Unparseable source can't be statically verified; the engine owns
+        # runtime import failures and returns the concrete traceback.
         return True
     return any(
         isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and node.name == function_name
-        for node in ast.walk(tree)
+        for node in tree.body
     )
 
 
@@ -46,7 +46,7 @@ def preflight_workflows(workflows: list[dict]) -> list[str]:
     errors: list[str] = []
     for wf in workflows:
         src = wf.get("source")
-        if not src:
+        if src is None:
             continue
         function_name = wf.get("function_name", "")
         if not function_name:

--- a/api/src/services/solutions/deploy.py
+++ b/api/src/services/solutions/deploy.py
@@ -50,6 +50,7 @@ from src.models.orm.solutions import Solution
 from src.models.orm.tables import Table
 from src.models.orm.workflow_roles import WorkflowRole
 from src.models.orm.workflows import Workflow
+from src.services.solution_deploy_preflight import preflight_workflows
 from src.services.solutions.storage import SolutionStorage
 from src.services.sync_ops import Upsert
 
@@ -146,6 +147,16 @@ class SolutionDowngradeBlocked(Exception):
 
     Refused by default (Task 20) — re-run with ``force`` to downgrade. Only
     raised when BOTH versions parse as PEP 440; unordered versions never block.
+    """
+
+
+class SolutionWorkflowNameMismatch(Exception):
+    """A bundle workflow's manifest name diverges from its decorated name.
+
+    The execution engine matches a workflow by ``@workflow(name=...)``; a bundle
+    whose manifest entry name differs from the decorated name in its carried
+    source would deploy a workflow that execution can't resolve. Refused before
+    any write so the operator fixes the manifest or the decorator.
     """
 
 
@@ -350,6 +361,14 @@ class SolutionDeployer:
         # a byte-identical bundle installs independently into N scopes (and a
         # redeploy is stable).
         rb = await self._remapped_bundle(bundle)
+
+        # ── Workflow-name preflight (before ANY writes) ─────────────────────
+        # A bundle whose manifest entry name diverges from its decorated
+        # @workflow(name=...) would deploy a Workflow.name the execution engine
+        # can't resolve. Catch it up front with actionable guidance.
+        name_errors = preflight_workflows(rb.workflows)
+        if name_errors:
+            raise SolutionWorkflowNameMismatch("\n".join(name_errors))
 
         # ── DB-only phase (validates + reconciles; rolls back cleanly) ───────
         await self._upsert_workflows(solution, rb.workflows)

--- a/api/src/services/solutions/deploy.py
+++ b/api/src/services/solutions/deploy.py
@@ -151,13 +151,7 @@ class SolutionDowngradeBlocked(Exception):
 
 
 class SolutionWorkflowNameMismatch(Exception):
-    """A bundle workflow's manifest name diverges from its decorated name.
-
-    The execution engine matches a workflow by ``@workflow(name=...)``; a bundle
-    whose manifest entry name differs from the decorated name in its carried
-    source would deploy a workflow that execution can't resolve. Refused before
-    any write so the operator fixes the manifest or the decorator.
-    """
+    """A bundle workflow's ``function_name`` is missing from its source."""
 
 
 def _is_downgrade(new: str | None, current: str | None) -> bool:
@@ -362,11 +356,19 @@ class SolutionDeployer:
         # redeploy is stable).
         rb = await self._remapped_bundle(bundle)
 
-        # ── Workflow-name preflight (before ANY writes) ─────────────────────
-        # A bundle whose manifest entry name diverges from its decorated
-        # @workflow(name=...) would deploy a Workflow.name the execution engine
-        # can't resolve. Catch it up front with actionable guidance.
-        name_errors = preflight_workflows(rb.workflows)
+        # ── Workflow source preflight (before ANY writes) ───────────────────
+        # Execution resolves by module-level function_name. Populate missing
+        # inline source from python_files so bundles carrying source separately
+        # are still validated before any DB writes.
+        workflows_for_preflight = []
+        for workflow in rb.workflows:
+            enriched = dict(workflow)
+            if enriched.get("source") is None:
+                path = enriched.get("path")
+                if isinstance(path, str) and path in rb.python_files:
+                    enriched["source"] = rb.python_files[path]
+            workflows_for_preflight.append(enriched)
+        name_errors = preflight_workflows(workflows_for_preflight)
         if name_errors:
             raise SolutionWorkflowNameMismatch("\n".join(name_errors))
 

--- a/api/tests/e2e/platform/conftest.py
+++ b/api/tests/e2e/platform/conftest.py
@@ -34,6 +34,65 @@ logger = logging.getLogger(__name__)
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
 
 
+class _DeployResult:
+    """httpx-Response-like shim for the now-async solution deploy.
+
+    Deploy is enqueued (202 + ``deploy_job_id``) and observed by polling
+    ``GET /api/solutions/deploy-jobs/{id}``. This shim lets the many existing
+    e2e call sites keep their ``deploy.status_code`` / ``deploy.json()`` shape:
+    on a succeeded job ``status_code`` is 200 and ``json()`` returns the deploy
+    result counts; on a failed job ``status_code`` is 422 and ``json()`` carries
+    a ``detail`` (mirroring the old synchronous error response).
+    """
+
+    def __init__(self, status_code: int, payload: dict, text: str) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def wait_for_deploy(e2e_client, post_resp, headers, *, timeout_s: float = 30.0):
+    """Given a deploy POST response, return a terminal-state shim.
+
+    A synchronous error (non-202 — git-connected, pending-capture block,
+    downgrade gate) is returned unchanged. A 202 is polled to a terminal job
+    status, then mapped onto the old response shape via :class:`_DeployResult`.
+    """
+    import time as _time
+
+    if post_resp.status_code != 202:
+        return post_resp
+    job_id = post_resp.json()["deploy_job_id"]
+    deadline = _time.monotonic() + timeout_s
+    body: dict = {}
+    while _time.monotonic() < deadline:
+        st = e2e_client.get(f"/api/solutions/deploy-jobs/{job_id}", headers=headers)
+        assert st.status_code == 200, f"status fetch failed: {st.status_code} {st.text}"
+        body = st.json()
+        if body["status"] == "succeeded":
+            result = body.get("result") or {}
+            return _DeployResult(200, result, post_resp.text)
+        if body["status"] == "failed":
+            detail = body.get("error") or "deploy failed"
+            return _DeployResult(422, {"detail": detail}, detail)
+        _time.sleep(0.25)
+    raise AssertionError(f"deploy job {job_id} did not finish in {timeout_s}s: {body}")
+
+
+def deploy_solution(e2e_client, solution_id, headers, body):
+    """POST a deploy bundle and block until the async job is terminal.
+
+    Drop-in for ``e2e_client.post(f"/api/solutions/{id}/deploy", ...)`` that
+    returns a terminal-state shim (see :func:`wait_for_deploy`)."""
+    resp = e2e_client.post(
+        f"/api/solutions/{solution_id}/deploy", headers=headers, json=body
+    )
+    return wait_for_deploy(e2e_client, resp, headers)
+
+
 @pytest.fixture
 def cli_client(e2e_api_url, platform_admin):
     """Bind a ``BifrostClient`` to the E2E API + admin JWT for the CLI run."""

--- a/api/tests/e2e/platform/test_app_validation.py
+++ b/api/tests/e2e/platform/test_app_validation.py
@@ -1,0 +1,100 @@
+"""E2E tests for app validation endpoint v1/v2 branching."""
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import delete
+
+
+async def _make_app(db_session, org_id: str, app_model: str, files: dict[str, str]):
+    """Create an Application ORM row + FileIndex entries, return the app id."""
+    from src.models.orm.applications import Application
+    from src.models.orm.file_index import FileIndex
+
+    slug = f"validate-{app_model}-{uuid4().hex[:8]}"
+    app = Application(
+        id=uuid4(),
+        name=slug,
+        slug=slug,
+        repo_path=f"apps/{slug}",
+        organization_id=UUID(org_id),
+        app_model=app_model,
+    )
+    db_session.add(app)
+    await db_session.flush()
+
+    prefix = app.repo_prefix
+    for rel_path, content in files.items():
+        db_session.add(
+            FileIndex(
+                path=f"{prefix}{rel_path}",
+                content=content,
+                updated_at=datetime.now(timezone.utc),
+            )
+        )
+    await db_session.commit()
+    return app.id
+
+
+async def _delete_app(db_session, app_id):
+    from src.models.orm.applications import Application
+    from src.models.orm.file_index import FileIndex
+
+    app = await db_session.get(Application, app_id)
+    if app is not None:
+        await db_session.execute(
+            delete(FileIndex).where(FileIndex.path.startswith(app.repo_prefix))
+        )
+        await db_session.delete(app)
+    await db_session.commit()
+
+
+@pytest.mark.e2e
+class TestAppValidationModelBranching:
+    async def test_v2_app_skips_layout_check(
+        self, db_session, e2e_client, platform_admin, org1
+    ):
+        """standalone_v2 apps must not be flagged for a missing _layout.tsx."""
+        app_id = await _make_app(
+            db_session,
+            org1["id"],
+            app_model="standalone_v2",
+            files={"index.tsx": "export default () => null"},
+        )
+        try:
+            resp = e2e_client.post(
+                f"/api/applications/{app_id}/validate",
+                headers=platform_admin.headers,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            all_issues = body["errors"] + body["warnings"]
+            assert not any(
+                i["file"] == "_layout.tsx" for i in all_issues
+            ), f"v2 app should not require _layout.tsx, got: {all_issues}"
+        finally:
+            await _delete_app(db_session, app_id)
+
+    async def test_v1_app_still_requires_layout(
+        self, db_session, e2e_client, platform_admin, org1
+    ):
+        """inline_v1 apps still flag a missing _layout.tsx (regression guard)."""
+        app_id = await _make_app(
+            db_session,
+            org1["id"],
+            app_model="inline_v1",
+            files={"pages/index.tsx": "export default () => null"},
+        )
+        try:
+            resp = e2e_client.post(
+                f"/api/applications/{app_id}/validate",
+                headers=platform_admin.headers,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert any(
+                i["file"] == "_layout.tsx" for i in body["errors"]
+            ), "v1 app should still require _layout.tsx"
+        finally:
+            await _delete_app(db_session, app_id)

--- a/api/tests/e2e/platform/test_capture_roundtrip.py
+++ b/api/tests/e2e/platform/test_capture_roundtrip.py
@@ -21,6 +21,7 @@ import zipfile
 
 import pytest
 import yaml
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -113,6 +114,7 @@ def test_capture_roundtrip(e2e_client, platform_admin):
         headers=headers,
         json={"tables": [], "forms": []},
     )
+    blocked = wait_for_deploy(e2e_client, blocked, headers)
     assert blocked.status_code == 409, blocked.text
     detail = blocked.json()["detail"]
     assert "bifrost solution pull" in detail
@@ -154,6 +156,7 @@ def test_capture_roundtrip(e2e_client, platform_admin):
         headers=headers,
         json={"tables": [table_entry], "forms": [form_entry]},
     )
+    ok = wait_for_deploy(e2e_client, ok, headers)
     assert ok.status_code in (200, 201), ok.text
     assert e2e_client.get(f"/api/tables/{table_id}", headers=headers).status_code == 200
     assert e2e_client.get(f"/api/forms/{form_id}", headers=headers).status_code == 200
@@ -165,6 +168,7 @@ def test_capture_roundtrip(e2e_client, platform_admin):
         headers=headers,
         json={"tables": [table_entry], "forms": []},
     )
+    deleted = wait_for_deploy(e2e_client, deleted, headers)
     assert deleted.status_code in (200, 201), deleted.text
     assert deleted.json()["forms_deleted"] >= 1
     assert e2e_client.get(f"/api/forms/{form_id}", headers=headers).status_code == 404

--- a/api/tests/e2e/platform/test_external_users.py
+++ b/api/tests/e2e/platform/test_external_users.py
@@ -25,6 +25,7 @@ import pytest
 from tests.e2e.conftest import write_and_register
 from tests.e2e.fixtures.setup import _register_and_authenticate_user
 from tests.e2e.fixtures.users import E2EUser
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -659,6 +660,7 @@ def ext_install(e2e_client, platform_admin, org1):
             }],
         },
     )
+    deploy = wait_for_deploy(e2e_client, deploy, platform_admin.headers)
     assert deploy.status_code in (200, 201), deploy.text
 
     # The app's DB id is the remapped uuid5(install, manifest_id).

--- a/api/tests/e2e/platform/test_solution_config_e2e.py
+++ b/api/tests/e2e/platform/test_solution_config_e2e.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy import select
 
 from src.models.orm.solution_config_schema import SolutionConfigSchema
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -33,6 +34,7 @@ async def test_deploy_solution_with_config_declaration(e2e_client, platform_admi
             "required": True, "description": "needed", "position": 0,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
 
     rows = (

--- a/api/tests/e2e/platform/test_solution_connection_refs_e2e.py
+++ b/api/tests/e2e/platform/test_solution_connection_refs_e2e.py
@@ -44,6 +44,7 @@ from src.models.orm.integrations import Integration, IntegrationConfigSchema
 from src.models.orm.oauth import OAuthProvider
 from src.models.orm.solution_connection_schema import SolutionConnectionSchema
 from src.models.orm.workflows import Workflow
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -256,6 +257,7 @@ async def test_deploy_creates_integration_shell_and_readme_round_trips(
     dep = e2e_client.post(
         f"/api/solutions/{sid}/deploy", headers=headers, json=deploy_body
     )
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
     assert dep.json()["integrations_shell_created"] == 1, dep.text
 
@@ -285,6 +287,7 @@ async def test_deploy_creates_integration_shell_and_readme_round_trips(
     dep2 = e2e_client.post(
         f"/api/solutions/{sid}/deploy", headers=headers, json=deploy_body
     )
+    dep2 = wait_for_deploy(e2e_client, dep2, headers)
     assert dep2.status_code == 200, dep2.text
     assert dep2.json()["integrations_shell_created"] == 0, (
         "re-deploy must not re-create / clobber the existing integration"

--- a/api/tests/e2e/platform/test_solution_delete.py
+++ b/api/tests/e2e/platform/test_solution_delete.py
@@ -21,6 +21,7 @@ from src.models.orm.solutions import Solution as SolutionORM
 from src.models.orm.tables import Document, Table
 from src.models.orm.workflows import Workflow
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -58,6 +59,7 @@ async def test_delete_cascades_code_entities(e2e_client, platform_admin, db_sess
             "required": True, "description": "needed", "position": 0,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
 
     r = e2e_client.delete(f"/api/solutions/{sid}", headers=headers)
@@ -107,6 +109,7 @@ async def test_delete_orphans_tables_with_data(e2e_client, platform_admin, db_se
             "policies": None,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
     real_tid = solution_entity_id(UUID(sid), UUID(bundle_tid))
 
@@ -179,6 +182,7 @@ async def test_uninstall_with_same_name_repo_table_succeeds(
             "policies": None,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
 
     # 3. Uninstall must succeed — the detach stamps orphaned_at, moving the row
@@ -213,6 +217,7 @@ async def test_delete_orphans_config_values(e2e_client, platform_admin, db_sessi
             "required": True, "description": "needed", "position": 0,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
 
     # Set a value in the install's (global) scope.

--- a/api/tests/e2e/platform/test_solution_deploy_async.py
+++ b/api/tests/e2e/platform/test_solution_deploy_async.py
@@ -1,0 +1,135 @@
+"""End-to-end: solution deploy is async + observable.
+
+The deploy endpoint enqueues a background job and returns a ``deploy_job_id``
+immediately; the operator polls ``GET /api/solutions/deploy-jobs/{id}`` until
+the job reaches a terminal status. This decouples the (sometimes >100s) deploy
+from the HTTP request, which previously timed out client-side while the server
+completed successfully (Task 7 bug).
+"""
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _create_solution(e2e_client, headers, *, slug: str) -> str:
+    resp = e2e_client.post(
+        "/api/solutions",
+        headers=headers,
+        json={
+            "slug": slug,
+            "name": slug.upper(),
+            "scope": "global",
+            "global_repo_access": False,
+        },
+    )
+    assert resp.status_code in (200, 201), f"create failed: {resp.status_code} {resp.text}"
+    return resp.json()["id"]
+
+
+def test_async_deploy_completes(e2e_client, platform_admin):
+    headers = platform_admin.headers
+    slug = f"sol-async-{uuid.uuid4().hex[:8]}"
+    sid = _create_solution(e2e_client, headers, slug=slug)
+
+    wf_name = f"Snap {slug}"
+    source = (
+        "from bifrost import workflow\n\n"
+        f'@workflow(name="{wf_name}")\n'
+        "async def main():\n"
+        "    return 1\n"
+    )
+    resp = e2e_client.post(
+        f"/api/solutions/{sid}/deploy",
+        headers=headers,
+        json={
+            "python_files": {"workflows/snap.py": source},
+            "workflows": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": wf_name,
+                    "function_name": "main",
+                    "path": "workflows/snap.py",
+                    "type": "workflow",
+                    "source": source,
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 202, f"expected 202, got {resp.status_code}: {resp.text}"
+    job_id = resp.json()["deploy_job_id"]
+    assert job_id
+
+    status = None
+    for _ in range(60):
+        st = e2e_client.get(f"/api/solutions/deploy-jobs/{job_id}", headers=headers)
+        assert st.status_code == 200, f"status fetch failed: {st.status_code} {st.text}"
+        body = st.json()
+        status = body["status"]
+        if status in ("succeeded", "failed"):
+            break
+        time.sleep(0.5)
+
+    assert status == "succeeded", f"deploy job did not succeed: {body}"
+    assert body["install_id"] == sid
+
+
+def test_async_deploy_reports_failure(e2e_client, platform_admin):
+    """A bundle whose declared ``function_name`` does not exist in the carried
+    source fails preflight inside the job — the job reaches ``failed`` with the
+    error, not a 500 at enqueue time.
+
+    Note: a manifest *name* (slug) that merely differs from the decorated name is
+    NOT a failure — import persists the decorated name regardless of the slug, so
+    preflight only blocks the genuinely execution-breaking case (the named
+    function is absent from the source). This mirrors the unit/e2e preflight
+    contract in test_deploy_preflight.py / test_solution_deploy_preflight_e2e.py.
+    """
+    headers = platform_admin.headers
+    slug = f"sol-async-fail-{uuid.uuid4().hex[:8]}"
+    sid = _create_solution(e2e_client, headers, slug=slug)
+
+    # Source defines `main`, but the bundle points function_name at `missing`.
+    source = (
+        "from bifrost import workflow\n\n"
+        '@workflow(name="Real Name")\n'
+        "async def main():\n"
+        "    return 1\n"
+    )
+    resp = e2e_client.post(
+        f"/api/solutions/{sid}/deploy",
+        headers=headers,
+        json={
+            "python_files": {"workflows/snap.py": source},
+            "workflows": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "snap",
+                    "function_name": "missing",
+                    "path": "workflows/snap.py",
+                    "type": "workflow",
+                    "source": source,
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 202, f"expected 202, got {resp.status_code}: {resp.text}"
+    job_id = resp.json()["deploy_job_id"]
+
+    status = None
+    for _ in range(60):
+        st = e2e_client.get(f"/api/solutions/deploy-jobs/{job_id}", headers=headers)
+        assert st.status_code == 200
+        body = st.json()
+        status = body["status"]
+        if status in ("succeeded", "failed"):
+            break
+        time.sleep(0.5)
+
+    assert status == "failed", f"expected failed, got {body}"
+    assert body["error"]
+    assert "missing" in body["error"]

--- a/api/tests/e2e/platform/test_solution_deploy_execution.py
+++ b/api/tests/e2e/platform/test_solution_deploy_execution.py
@@ -34,10 +34,13 @@ def _create_solution(e2e_client, headers, *, slug: str, global_repo_access: bool
 
 
 def _deploy(e2e_client, headers, solution_id: str, *, python_files: dict, workflows: list) -> dict:
-    resp = e2e_client.post(
-        f"/api/solutions/{solution_id}/deploy",
-        headers=headers,
-        json={"python_files": python_files, "workflows": workflows},
+    from tests.e2e.platform.conftest import deploy_solution
+
+    resp = deploy_solution(
+        e2e_client,
+        solution_id,
+        headers,
+        {"python_files": python_files, "workflows": workflows},
     )
     assert resp.status_code in (200, 201), f"deploy failed: {resp.status_code} {resp.text}"
     return resp.json()
@@ -83,6 +86,49 @@ def test_deploy_and_run_solution_local_import(e2e_client, platform_admin):
     )
     assert result["status"] == "Success", f"unexpected: {result}"
     assert result["result"] == {"value": 42}
+
+
+def test_deploy_and_run_when_name_diverges_from_function(e2e_client, platform_admin):
+    """Regression for the "Executable 'hello' not found" bug.
+
+    Deploy a workflow whose manifest ``name`` differs from BOTH the decorator
+    display name AND the Python ``function_name``. Execution must still run it —
+    resolution is by ``function_name`` (service.py / module_loader.py), and the
+    DB ``name`` is identity/display only. Before the fix, execution matched the
+    decorator display name against the DB name and raised "Executable not found".
+    """
+    from tests.e2e.conftest import execute_workflow_sync
+
+    headers = platform_admin.headers
+    slug = f"sol-namediv-{uuid.uuid4().hex[:8]}"
+    sid = _create_solution(e2e_client, headers, slug=slug, global_repo_access=False)
+
+    _deploy(
+        e2e_client,
+        headers,
+        sid,
+        python_files={
+            "workflows/snap.py": (
+                "from bifrost import workflow\n\n"
+                '@workflow(name="Sandbox Ticket Snapshot")\n'  # decorator display name
+                "async def snapshot():\n"  # function_name = "snapshot"
+                "    return {'ok': True}\n"
+            ),
+        },
+        workflows=[{
+            "id": str(uuid.uuid4()),
+            "name": "hello",  # manifest name diverges from decorator AND function
+            "function_name": "snapshot",
+            "path": "workflows/snap.py",
+            "type": "workflow",
+        }],
+    )
+
+    result = execute_workflow_sync(
+        e2e_client, headers, "workflows/snap.py::snapshot", request_sync=True
+    )
+    assert result["status"] == "Success", f"name-divergent workflow failed to run: {result}"
+    assert result["result"] == {"ok": True}
 
 
 def test_global_repo_import_blocked_when_flag_off(e2e_client, platform_admin):

--- a/api/tests/e2e/platform/test_solution_deploy_execution.py
+++ b/api/tests/e2e/platform/test_solution_deploy_execution.py
@@ -33,14 +33,22 @@ def _create_solution(e2e_client, headers, *, slug: str, global_repo_access: bool
     return resp.json()["id"]
 
 
-def _deploy(e2e_client, headers, solution_id: str, *, python_files: dict, workflows: list) -> dict:
+def _deploy(
+    e2e_client,
+    headers,
+    solution_id: str,
+    *,
+    python_files: dict,
+    workflows: list,
+    apps: list | None = None,
+) -> dict:
     from tests.e2e.platform.conftest import deploy_solution
 
     resp = deploy_solution(
         e2e_client,
         solution_id,
         headers,
-        {"python_files": python_files, "workflows": workflows},
+        {"python_files": python_files, "workflows": workflows, "apps": apps or []},
     )
     assert resp.status_code in (200, 201), f"deploy failed: {resp.status_code} {resp.text}"
     return resp.json()
@@ -193,37 +201,36 @@ def test_two_installs_same_path_resolve_own_workflow_via_app_id(e2e_client, plat
         slug = f"twin-{marker}-{uuid.uuid4().hex[:8]}"
         sid = _create_solution(e2e_client, headers, slug=slug, global_repo_access=False)
         app_id = str(uuid.uuid4())
-        e2e_client.post(
-            f"/api/solutions/{sid}/deploy",
-            headers=headers,
-            json={
-                "python_files": {
-                    "workflows/main.py": (
-                        "from bifrost import workflow\n\n"
-                        "@workflow\n"
-                        "async def main():\n"
-                        f"    return {{'marker': '{marker}'}}\n"
-                    ),
-                },
-                "workflows": [{
-                    "id": str(uuid.uuid4()),
-                    "name": f"main_{slug}",
-                    "function_name": "main",
-                    "path": "workflows/main.py",
-                    "type": "workflow",
-                }],
-                "apps": [{
-                    "id": app_id,
-                    "slug": f"app-{slug}",
-                    "name": "App",
-                    "app_model": "standalone_v2",
-                    "dependencies": {},
-                    "access_level": "authenticated",
-                    "dist_files": {
-                        "index.html": '<!doctype html><div id="root"></div>',
-                    },
-                }],
+        _deploy(
+            e2e_client,
+            headers,
+            sid,
+            python_files={
+                "workflows/main.py": (
+                    "from bifrost import workflow\n\n"
+                    "@workflow\n"
+                    "async def main():\n"
+                    f"    return {{'marker': '{marker}'}}\n"
+                ),
             },
+            workflows=[{
+                "id": str(uuid.uuid4()),
+                "name": f"main_{slug}",
+                "function_name": "main",
+                "path": "workflows/main.py",
+                "type": "workflow",
+            }],
+            apps=[{
+                "id": app_id,
+                "slug": f"app-{slug}",
+                "name": "App",
+                "app_model": "standalone_v2",
+                "dependencies": {},
+                "access_level": "authenticated",
+                "dist_files": {
+                    "index.html": '<!doctype html><div id="root"></div>',
+                },
+            }],
         )
         # The app's DB id is the remapped uuid5(install, manifest_id).
         from src.services.solutions.deploy import solution_entity_id

--- a/api/tests/e2e/platform/test_solution_deploy_preflight_e2e.py
+++ b/api/tests/e2e/platform/test_solution_deploy_preflight_e2e.py
@@ -1,0 +1,106 @@
+"""End-to-end: the deploy workflow-name preflight refuses a bundle whose
+``function_name`` is not defined in the carried source.
+
+That bundle would persist a Workflow.name the execution engine can't resolve
+("Executable not found"). The deploy endpoint catches it up front and returns
+422 with actionable guidance. A manifest slug that merely differs from the
+decorated name is NOT a failure (import resolves to the decorated name), so
+that case deploys cleanly.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.e2e.platform.conftest import wait_for_deploy
+
+pytestmark = pytest.mark.e2e
+
+
+def _create_solution(e2e_client, headers, *, slug: str) -> str:
+    resp = e2e_client.post(
+        "/api/solutions",
+        headers=headers,
+        json={
+            "slug": slug,
+            "name": slug.upper(),
+            "scope": "global",
+            "global_repo_access": False,
+        },
+    )
+    assert resp.status_code in (200, 201), f"create failed: {resp.status_code} {resp.text}"
+    return resp.json()["id"]
+
+
+def test_deploy_rejects_missing_function(e2e_client, platform_admin):
+    """function_name points at a function the source does not define → 422."""
+    headers = platform_admin.headers
+    slug = f"sol-preflight-{uuid.uuid4().hex[:8]}"
+    sid = _create_solution(e2e_client, headers, slug=slug)
+
+    # Source defines `other`, but the bundle entry points at `main`.
+    source = (
+        "from bifrost import workflow\n\n"
+        '@workflow(name="Sandbox Ticket Snapshot")\n'
+        "async def other():\n"
+        "    return 1\n"
+    )
+    resp = e2e_client.post(
+        f"/api/solutions/{sid}/deploy",
+        headers=headers,
+        json={
+            "python_files": {"workflows/snap.py": source},
+            "workflows": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "hello",
+                    "function_name": "main",
+                    "path": "workflows/snap.py",
+                    "type": "workflow",
+                    "source": source,
+                }
+            ],
+        },
+    )
+    resp = wait_for_deploy(e2e_client, resp, headers)
+    assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text}"
+    detail = resp.json()["detail"]
+    assert "main" in detail
+    assert "workflows/snap.py" in detail
+
+
+def test_deploy_accepts_slug_differing_from_decorator(e2e_client, platform_admin):
+    """A manifest slug that differs from the decorated name still deploys —
+    import resolves to the decorated name, so preflight must not block it."""
+    headers = platform_admin.headers
+    slug = f"sol-preflight-ok-{uuid.uuid4().hex[:8]}"
+    sid = _create_solution(e2e_client, headers, slug=slug)
+
+    wf_name = f"Snap {slug}"
+    source = (
+        "from bifrost import workflow\n\n"
+        f'@workflow(name="{wf_name}")\n'
+        "async def main():\n"
+        "    return 1\n"
+    )
+    resp = e2e_client.post(
+        f"/api/solutions/{sid}/deploy",
+        headers=headers,
+        json={
+            "python_files": {"workflows/snap.py": source},
+            "workflows": [
+                {
+                    "id": str(uuid.uuid4()),
+                    # Slug diverges from the decorated name — legitimate, not blocked.
+                    "name": "hello-slug",
+                    "function_name": "main",
+                    "path": "workflows/snap.py",
+                    "type": "workflow",
+                    "source": source,
+                }
+            ],
+        },
+    )
+    resp = wait_for_deploy(e2e_client, resp, headers)
+    assert resp.status_code in (200, 201), f"deploy failed: {resp.status_code} {resp.text}"

--- a/api/tests/e2e/platform/test_solution_entities_endpoint.py
+++ b/api/tests/e2e/platform/test_solution_entities_endpoint.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import pytest
 
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -49,6 +50,7 @@ async def test_get_solution_entities_reports_config_status(e2e_client, platform_
             "required": True, "description": "needed", "position": 0,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
 
     r = e2e_client.get(f"/api/solutions/{sid}/entities", headers=headers)
@@ -124,6 +126,7 @@ async def test_get_solution_entities_includes_app_logo(e2e_client, platform_admi
             ]
         },
     )
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
     app = {"id": real_id}

--- a/api/tests/e2e/platform/test_solution_export_live.py
+++ b/api/tests/e2e/platform/test_solution_export_live.py
@@ -18,6 +18,7 @@ import uuid
 import zipfile
 
 import pytest
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -56,6 +57,7 @@ async def test_export_reflects_currently_owned_app(
             ]
         },
     )
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     assert dep.json()["apps_upserted"] == 1
 

--- a/api/tests/e2e/platform/test_solution_git_connected_e2e.py
+++ b/api/tests/e2e/platform/test_solution_git_connected_e2e.py
@@ -7,6 +7,8 @@ import uuid
 
 import pytest
 
+from tests.e2e.platform.conftest import wait_for_deploy
+
 pytestmark = pytest.mark.e2e
 
 
@@ -40,14 +42,17 @@ def test_disconnected_install_allows_deploy(e2e_client, platform_admin):
     dep = e2e_client.post(f"/api/solutions/{sid}/deploy", headers=headers, json={
         "python_files": {}, "workflows": [],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
 
 async def test_concurrent_deploy_to_same_install_is_refused(e2e_client, platform_admin):
-    """Codex #12: the deploy endpoint holds a per-install write lock across the
-    DB commit AND the S3 finalize, so a second concurrent deploy to the SAME
-    install is refused (409) rather than interleaving its finalize. Deterministic
-    repro: hold the lock out-of-band, then POST deploy → 409."""
+    """Codex #12: the deploy holds a per-install write lock across the DB commit
+    AND the S3 finalize, so a second concurrent deploy to the SAME install is
+    refused rather than interleaving its finalize. Under async deploy the lock is
+    held inside the background job, so a contended deploy reaches a FAILED job
+    with an "in progress" error (surfaced by ``wait_for_deploy`` as a 422 shim).
+    Deterministic repro: hold the lock out-of-band, then deploy → failed."""
     from uuid import UUID
 
     from src.services.solutions.write_lock import solution_write_lock
@@ -60,25 +65,28 @@ async def test_concurrent_deploy_to_same_install_is_refused(e2e_client, platform
     assert r.status_code in (200, 201), r.text
     sid = r.json()["id"]
 
-    # Simulate an in-flight deploy by holding the install's write lock.
+    # Simulate an in-flight deploy by holding the install's write lock. The POST
+    # is accepted (202) but the background job can't get the lock → fails.
     async with solution_write_lock(UUID(sid)):
         dep = e2e_client.post(f"/api/solutions/{sid}/deploy", headers=headers, json={
             "python_files": {}, "workflows": [],
         })
-    assert dep.status_code == 409, dep.text
+        dep = wait_for_deploy(e2e_client, dep, headers)
+    assert dep.status_code == 422, dep.text
     assert "in progress" in dep.text.lower()
 
     # Lock released → a subsequent deploy succeeds (not wedged).
     dep2 = e2e_client.post(f"/api/solutions/{sid}/deploy", headers=headers, json={
         "python_files": {}, "workflows": [],
     })
+    dep2 = wait_for_deploy(e2e_client, dep2, headers)
     assert dep2.status_code in (200, 201), dep2.text
 
 
-def test_invalid_bundle_returns_409_not_500(e2e_client, platform_admin):
+def test_invalid_bundle_fails_cleanly_not_500(e2e_client, platform_admin):
     """Codex #13: a deploy rejected by SolutionDeployConflict (here: an
-    inline_v1 app, which Solution deploy refuses) surfaces as a 409 with the
-    reason, NOT an unhandled 500."""
+    inline_v1 app, which Solution deploy refuses) surfaces as a clean job
+    failure with the reason, NOT an unhandled 500."""
     headers = platform_admin.headers
     slug = f"badbundle-{uuid.uuid4().hex[:8]}"
     r = e2e_client.post("/api/solutions", headers=headers, json={
@@ -93,5 +101,6 @@ def test_invalid_bundle_returns_409_not_500(e2e_client, platform_admin):
             "app_model": "inline_v1",
         }],
     })
-    assert dep.status_code == 409, f"expected 409, got {dep.status_code}: {dep.text}"
+    dep = wait_for_deploy(e2e_client, dep, headers)
+    assert dep.status_code == 422, f"expected failed job, got {dep.status_code}: {dep.text}"
     assert "standalone_v2" in dep.text

--- a/api/tests/e2e/platform/test_solution_id_in_responses.py
+++ b/api/tests/e2e/platform/test_solution_id_in_responses.py
@@ -14,6 +14,7 @@ from uuid import UUID
 import pytest
 
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -44,6 +45,7 @@ def test_solution_id_populated_on_workflow_and_agent(e2e_client, platform_admin)
             "system_prompt": "You are a helper.", "channels": ["chat"],
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
     # Deploy remaps each manifest id to uuid5(install_id, manifest_id).

--- a/api/tests/e2e/platform/test_solution_import_data.py
+++ b/api/tests/e2e/platform/test_solution_import_data.py
@@ -104,6 +104,8 @@ def make_solution_with_table_rows(e2e_client, platform_admin):
                 ],
             },
         )
+        from tests.e2e.platform.conftest import wait_for_deploy
+        dep = wait_for_deploy(e2e_client, dep, headers)
         assert dep.status_code in (200, 201), dep.text
 
         # Real deployed table id = uuid5(install_id, manifest_id).

--- a/api/tests/e2e/platform/test_solution_patch.py
+++ b/api/tests/e2e/platform/test_solution_patch.py
@@ -12,6 +12,7 @@ import pytest
 from sqlalchemy import select
 
 from src.models.orm.workflows import Workflow
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -78,6 +79,7 @@ async def test_patch_scope_restamps_owned_entities(e2e_client, platform_admin, d
             }],
         },
     )
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
 
     # The owned workflow currently sits on the global scope (org NULL).

--- a/api/tests/e2e/platform/test_solution_readonly.py
+++ b/api/tests/e2e/platform/test_solution_readonly.py
@@ -13,6 +13,7 @@ from uuid import UUID
 import pytest
 
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -40,6 +41,7 @@ def test_solution_workflow_is_read_only(e2e_client, platform_admin):
             "path": "workflows/w.py", "type": "workflow",
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
     # Deploy remaps the manifest id to uuid5(install_id, manifest_id); address by that.

--- a/api/tests/e2e/platform/test_solution_readonly_full.py
+++ b/api/tests/e2e/platform/test_solution_readonly_full.py
@@ -14,6 +14,7 @@ from uuid import UUID
 import pytest
 
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -44,6 +45,7 @@ def _deploy_workflow_and_app(e2e_client, headers, sid: str):
             "dist_files": {"index.html": "<html></html>"},
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     # Deploy remaps each manifest id to uuid5(install_id, manifest_id); the entity
     # is addressable only by the remapped id.
@@ -75,6 +77,7 @@ def test_solution_managed_trigger_is_locked(e2e_client, platform_admin):
             }],
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     real_es = str(solution_entity_id(UUID(sid), UUID(es_id)))
 
@@ -181,6 +184,7 @@ def test_remap_skips_managed_form_and_agent_tool(e2e_client, platform_admin):
             "system_prompt": "x", "tool_ids": [wf_id],
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
     real_wf = str(solution_entity_id(UUID(sid), UUID(wf_id)))
@@ -239,6 +243,7 @@ def test_delete_role_bound_to_managed_entity_is_refused(e2e_client, platform_adm
             "access_level": "role_based", "role_names": [role_name],
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
     # Deleting the role now would cascade-remove the managed binding → refuse.

--- a/api/tests/e2e/platform/test_solution_reattach.py
+++ b/api/tests/e2e/platform/test_solution_reattach.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from src.models.orm.config import Config
 from src.models.orm.tables import Document, Table
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -58,6 +59,7 @@ async def test_reinstall_reattaches_orphaned_table_with_data(
             "schema": {"columns": [{"name": "email"}]}, "policies": None,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
     real_tid_1 = solution_entity_id(UUID(sid1), UUID(bundle_tid))
 
@@ -94,6 +96,7 @@ async def test_reinstall_reattaches_orphaned_table_with_data(
             "schema": {"columns": [{"name": "email"}]}, "policies": None,
         }],
     })
+    dep2 = wait_for_deploy(e2e_client, dep2, headers)
     assert dep2.status_code == 200, dep2.text
 
     # ── Assert: the SAME table id was adopted (not recreated) ─────────────────
@@ -140,6 +143,7 @@ async def test_reinstall_reattaches_orphaned_config_value(
             "required": True, "description": "needed", "position": 0,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
     sc = e2e_client.post("/api/config", headers=headers, json={
         "key": key, "value": "sekret", "type": "string", "organization_id": None,
@@ -167,6 +171,7 @@ async def test_reinstall_reattaches_orphaned_config_value(
             "required": True, "description": "needed", "position": 0,
         }],
     })
+    dep2 = wait_for_deploy(e2e_client, dep2, headers)
     assert dep2.status_code == 200, dep2.text
 
     # The value is un-orphaned and intact.
@@ -198,6 +203,7 @@ async def test_fresh_install_no_orphan_creates_empty(
             "schema": {"columns": [{"name": "x"}]}, "policies": None,
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code == 200, dep.text
 
     db_session.expire_all()

--- a/api/tests/e2e/platform/test_solution_roundtrip.py
+++ b/api/tests/e2e/platform/test_solution_roundtrip.py
@@ -24,6 +24,7 @@ import base64
 import uuid
 
 import pytest
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -104,6 +105,7 @@ def _create_solution_with_app_and_workflow(
             ],
         },
     )
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     body = dep.json()
     assert body["apps_upserted"] == 1, f"expected 1 app, got: {body}"

--- a/api/tests/e2e/platform/test_solution_table_e2e.py
+++ b/api/tests/e2e/platform/test_solution_table_e2e.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import pytest
 
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -30,6 +31,7 @@ def test_table_deploy_preserves_rows_across_schema_change(e2e_client, platform_a
     dep = e2e_client.post(f"/api/solutions/{sid}/deploy", headers=headers, json={
         "tables": [{"id": tid, "name": f"people_{slug}", "schema": {"columns": [{"name": "email"}]}, "policies": None}],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     assert dep.json()["tables_upserted"] == 1
 
@@ -47,6 +49,7 @@ def test_table_deploy_preserves_rows_across_schema_change(e2e_client, platform_a
     dep2 = e2e_client.post(f"/api/solutions/{sid}/deploy", headers=headers, json={
         "tables": [{"id": tid, "name": f"people_{slug}", "schema": {"columns": [{"name": "email"}, {"name": "phone"}]}, "policies": None}],
     })
+    dep2 = wait_for_deploy(e2e_client, dep2, headers)
     assert dep2.status_code in (200, 201), dep2.text
 
     # Row survives the schema migration.
@@ -71,6 +74,7 @@ def test_repo_table_coexists_with_solution_table_same_name(e2e_client, platform_
     dep = e2e_client.post(f"/api/solutions/{sid}/deploy", headers=headers, json={
         "tables": [{"id": tid, "name": name, "schema": {"columns": [{"name": "email"}]}, "policies": None}],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     sol_table_id = str(solution_entity_id(UUID(sid), UUID(tid)))
 
@@ -110,6 +114,7 @@ def test_solution_table_coexists_with_existing_repo_table(e2e_client, platform_a
     dep = e2e_client.post(f"/api/solutions/{sid}/deploy", headers=headers, json={
         "tables": [{"id": tid, "name": name, "schema": {"columns": [{"name": "email"}]}, "policies": None}],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), f"solution deploy blocked by _repo row: {dep.text}"
     sol_table_id = str(solution_entity_id(UUID(sid), UUID(tid)))
 
@@ -135,6 +140,7 @@ def test_solution_app_resolves_its_table_by_name(e2e_client, platform_admin):
         "apps": [{"id": app_manifest_id, "slug": f"app-{slug}", "name": "App",
                   "app_model": "standalone_v2", "dist_files": {"index.html": "<html></html>"}}],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     app_id = str(solution_entity_id(UUID(sid), UUID(app_manifest_id)))
 
@@ -176,6 +182,7 @@ def test_solution_workflow_resolves_its_table_by_name(e2e_client, platform_admin
         "tables": [{"id": tid, "name": table_name,
                     "schema": {"columns": [{"name": "label"}]}, "policies": None}],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
     # WITHOUT the solution scope: name cascade excludes the solution table → 404.

--- a/api/tests/e2e/platform/test_solution_v2_app_e2e.py
+++ b/api/tests/e2e/platform/test_solution_v2_app_e2e.py
@@ -13,6 +13,7 @@ from uuid import UUID
 import pytest
 
 from src.services.solutions.deploy import solution_entity_id
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -66,6 +67,7 @@ def test_v2_app_deploys_builds_dist_and_reports_model(e2e_client, platform_admin
             ]
         },
     )
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     assert dep.json()["apps_upserted"] == 1
 
@@ -130,6 +132,7 @@ def test_redeploy_without_app_removes_it_for_this_install(e2e_client, platform_a
             ]
         },
     )
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
     assert e2e_client.get(f"/api/applications/{app_slug}", headers=headers).status_code == 200
 
@@ -137,6 +140,7 @@ def test_redeploy_without_app_removes_it_for_this_install(e2e_client, platform_a
     dep2 = e2e_client.post(
         f"/api/solutions/{sid}/deploy", headers=headers, json={"apps": []}
     )
+    dep2 = wait_for_deploy(e2e_client, dep2, headers)
     assert dep2.status_code in (200, 201), dep2.text
     assert dep2.json()["apps_deleted"] == 1
     assert e2e_client.get(f"/api/applications/{app_slug}", headers=headers).status_code == 404

--- a/api/tests/e2e/platform/test_solution_vendoring_e2e.py
+++ b/api/tests/e2e/platform/test_solution_vendoring_e2e.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from tests.e2e.platform.conftest import wait_for_deploy
 
 pytestmark = pytest.mark.e2e
 
@@ -66,6 +67,7 @@ def test_vendored_shared_dep_resolves_without_global_repo_access(e2e_client, pla
             "path": "workflows/uses_shared.py", "type": "workflow",
         }],
     })
+    dep = wait_for_deploy(e2e_client, dep, headers)
     assert dep.status_code in (200, 201), dep.text
 
     # The vendored shared.* import resolves even with global_repo_access OFF.

--- a/api/tests/unit/routers/test_solution_deploy_jobs.py
+++ b/api/tests/unit/routers/test_solution_deploy_jobs.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.models.orm.solution_deploy_jobs import SolutionDeployJob
+from src.models.orm.solutions import Solution
+from src.routers.solutions import reconcile_orphaned_deploy_jobs
+
+
+@pytest.mark.asyncio
+async def test_reconcile_orphaned_deploy_jobs_fails_stale_non_terminal_jobs(db_session):
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    sol = Solution(slug="demo", name="Demo")
+    db_session.add(sol)
+    await db_session.flush()
+
+    stale_queued = SolutionDeployJob(
+        install_id=sol.id,
+        status="queued",
+        created_at=now - timedelta(minutes=30),
+        updated_at=now - timedelta(minutes=30),
+    )
+    stale_running = SolutionDeployJob(
+        install_id=sol.id,
+        status="running",
+        created_at=now - timedelta(minutes=30),
+        updated_at=now - timedelta(minutes=30),
+    )
+    fresh_queued = SolutionDeployJob(
+        install_id=sol.id,
+        status="queued",
+        created_at=now,
+        updated_at=now,
+    )
+    succeeded = SolutionDeployJob(
+        install_id=sol.id,
+        status="succeeded",
+        created_at=now - timedelta(minutes=30),
+        updated_at=now - timedelta(minutes=30),
+    )
+    db_session.add_all([stale_queued, stale_running, fresh_queued, succeeded])
+    await db_session.flush()
+
+    changed = await reconcile_orphaned_deploy_jobs(
+        db_session,
+        older_than=timedelta(minutes=10),
+        now=now,
+    )
+
+    assert changed == 2
+    assert stale_queued.status == "failed"
+    assert stale_running.status == "failed"
+    assert "API restarted" in (stale_queued.error or "")
+    assert "API restarted" in (stale_running.error or "")
+    assert fresh_queued.status == "queued"
+    assert fresh_queued.error is None
+    assert succeeded.status == "succeeded"

--- a/api/tests/unit/routers/test_solution_deploy_jobs.py
+++ b/api/tests/unit/routers/test_solution_deploy_jobs.py
@@ -10,7 +10,7 @@ from src.routers.solutions import reconcile_orphaned_deploy_jobs
 
 
 @pytest.mark.asyncio
-async def test_reconcile_orphaned_deploy_jobs_fails_stale_non_terminal_jobs(db_session):
+async def test_reconcile_orphaned_deploy_jobs_fails_non_terminal_jobs(db_session):
     now = datetime(2026, 1, 1, tzinfo=timezone.utc)
     sol = Solution(slug="demo", name="Demo")
     db_session.add(sol)
@@ -43,17 +43,13 @@ async def test_reconcile_orphaned_deploy_jobs_fails_stale_non_terminal_jobs(db_s
     db_session.add_all([stale_queued, stale_running, fresh_queued, succeeded])
     await db_session.flush()
 
-    changed = await reconcile_orphaned_deploy_jobs(
-        db_session,
-        older_than=timedelta(minutes=10),
-        now=now,
-    )
+    changed = await reconcile_orphaned_deploy_jobs(db_session, now=now)
 
-    assert changed == 2
+    assert changed == 3
     assert stale_queued.status == "failed"
     assert stale_running.status == "failed"
+    assert fresh_queued.status == "failed"
     assert "API restarted" in (stale_queued.error or "")
     assert "API restarted" in (stale_running.error or "")
-    assert fresh_queued.status == "queued"
-    assert fresh_queued.error is None
+    assert "API restarted" in (fresh_queued.error or "")
     assert succeeded.status == "succeeded"

--- a/api/tests/unit/test_cli_push.py
+++ b/api/tests/unit/test_cli_push.py
@@ -1,0 +1,151 @@
+import pytest
+
+from bifrost import cli
+
+
+def test_push_accepts_single_file(tmp_path, monkeypatch):
+    f = tmp_path / "mod.py"
+    f.write_text("x = 1\n")
+    captured = {}
+
+    async def fake_sync(local_path, *, mirror, validate, force, client, single_file=None, one_way=False):
+        captured["single_file"] = single_file
+        captured["local_path"] = local_path
+        captured["one_way"] = one_way
+        return 0
+
+    monkeypatch.setattr(cli, "_sync_files", fake_sync)
+    monkeypatch.setattr(cli.BifrostClient, "get_instance", lambda **k: object())
+    rc = cli.handle_push([str(f)])
+    assert rc == 0
+    assert captured["single_file"] == str(f)
+
+
+def test_push_rejects_missing_path(tmp_path):
+    rc = cli.handle_push([str(tmp_path / "does-not-exist.py")])
+    assert rc == 1
+
+
+def test_collect_push_files_single_file_root(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("x = 1\n")
+    files, skipped = cli._collect_push_files(tmp_path, "", single_file=str(f))
+    assert skipped == 0
+    assert set(files.keys()) == {"mod.py"}
+
+
+def test_collect_push_files_single_file_nested_with_prefix(tmp_path):
+    sub = tmp_path / "apps" / "x"
+    sub.mkdir(parents=True)
+    f = sub / "main.tsx"
+    f.write_text("const a = 1;\n")
+    files, skipped = cli._collect_push_files(tmp_path, "repo", single_file=str(f))
+    assert skipped == 0
+    assert set(files.keys()) == {"repo/apps/x/main.tsx"}
+
+
+def test_collect_push_files_single_file_honors_ignore_filter(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("BIFROST_ACCESS_TOKEN=secret\n")
+
+    files, skipped = cli._collect_push_files(tmp_path, "", single_file=str(f))
+
+    assert files == {}
+    assert skipped == 1
+
+
+@pytest.mark.asyncio
+async def test_plain_push_with_tty_does_not_open_tui(tmp_path, monkeypatch):
+    f = tmp_path / "mod.py"
+    f.write_text("x = 1\n")
+
+    # Pretend we are on an interactive TTY.
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)
+    monkeypatch.delenv("BIFROST_NONINTERACTIVE", raising=False)
+
+    def _boom(*a, **k):
+        raise AssertionError("plain push must not open the interactive TUI")
+
+    import bifrost.tui.sync_app as sync_app
+
+    monkeypatch.setattr(sync_app, "interactive_sync", _boom)
+
+    class FakeResp:
+        def __init__(self, status_code, payload=None):
+            self.status_code = status_code
+            self._payload = payload or {}
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        async def post(self, url, *a, **k):
+            if url == "/api/files/list":
+                return FakeResp(200, {"files_metadata": []})
+            if url == "/api/files/write":
+                return FakeResp(204)
+            return FakeResp(200, {})
+
+    rc = await cli._sync_files(
+        str(tmp_path),
+        mirror=False,
+        force=False,
+        client=FakeClient(),
+        single_file=str(f),
+    )
+    assert rc == 0
+
+
+@pytest.mark.asyncio
+async def test_push_only_drops_pull_items_before_auto_accept(tmp_path, monkeypatch, capsys):
+    local = tmp_path / "local.py"
+    local.write_text("x = 1\n")
+
+    monkeypatch.setattr(cli, "_resolve_is_tty", lambda: False)
+
+    class FakeResp:
+        def __init__(self, status_code, payload=None):
+            self.status_code = status_code
+            self._payload = payload or {}
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        async def post(self, url, *a, **k):
+            self.calls.append((url, k.get("json")))
+            if url == "/api/files/list":
+                return FakeResp(200, {
+                    "files_metadata": [
+                        {
+                            "path": "remote.py",
+                            "etag": "server-md5",
+                            "last_modified": "2026-01-01T00:00:00+00:00",
+                            "updated_by": "server",
+                        }
+                    ]
+                })
+            if url == "/api/files/write":
+                return FakeResp(204)
+            if url == "/api/files/read":
+                raise AssertionError("push-only sync must not pull server files")
+            return FakeResp(200, {})
+
+    client = FakeClient()
+    rc = await cli._sync_files(
+        str(tmp_path),
+        mirror=False,
+        force=False,
+        client=client,
+        one_way=True,
+    )
+
+    assert rc == 0
+    assert [payload["path"] for url, payload in client.calls if url == "/api/files/write"] == ["local.py"]
+    assert not (tmp_path / "remote.py").exists()
+    out = capsys.readouterr().out
+    assert "to pull" not in out

--- a/api/tests/unit/test_cli_push_progress.py
+++ b/api/tests/unit/test_cli_push_progress.py
@@ -1,0 +1,58 @@
+"""Non-TTY push prints line-oriented progress so large pushes don't look hung."""
+import asyncio
+
+from bifrost import cli
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    """Stub BifrostClient: server has no files, writes succeed."""
+
+    async def post(self, url: str, json: dict | None = None):  # noqa: A002
+        if url == "/api/files/list":
+            return _FakeResp(200, {"files_metadata": []})
+        if url == "/api/files/write":
+            return _FakeResp(204)
+        return _FakeResp(200, {})
+
+    async def get(self, url: str):
+        return _FakeResp(404)
+
+
+def test_non_tty_push_prints_progress(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(cli, "_is_tty", False)
+
+    # Three local files to push; server has none (FakeClient returns empty list).
+    def _fake_collect(path, repo_prefix, single_file=None):
+        import base64
+
+        files = {
+            f"app/file{i}.txt": base64.b64encode(f"content {i}".encode()).decode()
+            for i in range(1, 4)
+        }
+        return files, 0
+
+    monkeypatch.setattr(cli, "_collect_push_files", _fake_collect)
+
+    rc = asyncio.run(
+        cli._sync_files(
+            str(tmp_path),
+            repo_prefix="app",
+            client=_FakeClient(),
+            one_way=True,
+        )
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Scanning files..." in out
+    assert "Uploading 1/3" in out
+    assert out.strip().endswith("Done: 3 pushed, 0 unchanged, 0 skipped, 0 failed")

--- a/api/tests/unit/test_cli_solution_deploy_phases.py
+++ b/api/tests/unit/test_cli_solution_deploy_phases.py
@@ -1,0 +1,108 @@
+"""`bifrost solution deploy` — the progress phases the CLI prints.
+
+Deploy used to go quiet between collecting files and the bundle summary, with
+the network-bound vendoring step hidden. These tests pin the visible phases so
+that gap stays instrumented:
+
+  Scanning solution files...  ->  found N ... file(s)
+  Vendoring shared dependencies...  ->  (vendored M | no shared dependencies)
+  Bundle: ...
+  Uploading bundle...  ->  Deploying install ...
+
+BifrostClient is mocked so no network/DB is touched. Deploying with --global and
+the default (vendoring-on) descriptor drives the no-shared-deps branch: the
+mocked /api/files/read returns nothing, so vendoring resolves to zero files.
+"""
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+import yaml
+from click.testing import CliRunner
+
+from bifrost.commands.solution import solution_group
+from bifrost.solution_descriptor import DESCRIPTOR_FILENAME
+
+INSTALL_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _resp(payload, status=200):
+    r = mock.MagicMock()
+    r.status_code = status
+    r.json.return_value = payload
+    r.text = str(payload)
+    return r
+
+
+def _client():
+    async def get(path, **_kwargs):  # type: ignore[no-untyped-def]
+        if path == "/api/solutions":
+            return _resp({"solutions": []})
+        if "/deploy-jobs/" in path:
+            return _resp({"status": "succeeded", "error": None, "install_id": INSTALL_ID})
+        return _resp({}, status=404)
+
+    async def post(path, json=None, **_kwargs):  # type: ignore[no-untyped-def]  # noqa: ARG001
+        if path == "/api/solutions":
+            return _resp({"id": INSTALL_ID}, status=201)
+        if path == "/api/files/read":
+            # Nothing resolvable in _repo/ -> nothing to vendor.
+            return _resp({"content": None}, status=404)
+        if path.endswith("/deploy"):
+            return _resp({"deploy_job_id": "job-1"}, status=202)
+        return _resp({}, status=404)
+
+    c = mock.AsyncMock()
+    c.get = get
+    c.post = post
+    c.organization = {"id": "00000000-0000-0000-0000-000000000000"}
+    return c
+
+
+def _scaffold(tmp_path: pathlib.Path) -> pathlib.Path:
+    ws = tmp_path / "sol"
+    ws.mkdir()
+    (ws / DESCRIPTOR_FILENAME).write_text(
+        yaml.safe_dump(
+            {
+                "slug": "demo",
+                "name": "Demo",
+                "version": "0.1.0",
+                "global_repo_access": False,
+            },
+            sort_keys=False,
+        )
+    )
+    (ws / "workflows").mkdir()
+    (ws / "workflows" / "hello.py").write_text("def run():\n    return 1\n")
+    return ws
+
+
+def _invoke(ws: pathlib.Path):
+    with mock.patch(
+        "bifrost.client.BifrostClient.get_instance", return_value=_client()
+    ):
+        return CliRunner().invoke(
+            solution_group, ["deploy", str(ws), "--global"], catch_exceptions=False
+        )
+
+
+def test_deploy_prints_each_phase(tmp_path) -> None:
+    result = _invoke(_scaffold(tmp_path))
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Each phase is announced before its (possibly slow) work runs.
+    assert "Scanning solution files..." in out
+    assert "found" in out and "python file(s)" in out
+    assert "Vendoring shared dependencies..." in out
+    assert "Bundle:" in out
+    assert "Uploading bundle..." in out
+    assert "Deploying install" in out
+
+
+def test_deploy_reports_when_nothing_to_vendor(tmp_path) -> None:
+    result = _invoke(_scaffold(tmp_path))
+    assert result.exit_code == 0, result.output
+    # The vendoring announcement always resolves to a result line, even at zero.
+    assert "no shared dependencies to vendor." in result.output

--- a/api/tests/unit/test_cli_watch.py
+++ b/api/tests/unit/test_cli_watch.py
@@ -339,3 +339,63 @@ def test_watch_handler_dropped_events_do_not_call_post(tmp_path, monkeypatch):
     # The batch push layer only posts drained work; empty sets mean zero calls.
     assert not changes
     assert not deletes
+
+    # If a caller naively iterated drained sets and posted per file, no posts
+    # would happen because both sets are empty. This documents the contract.
+    posted: list[tuple[str, dict]] = []
+
+    async def fake_post(url, json=None, **kwargs):  # type: ignore[no-untyped-def]
+        posted.append((url, json or {}))
+
+        class _Resp:
+            status_code = 204
+
+        return _Resp()
+
+    # Iterate as the watch batch would (no asyncio needed since we never await)
+    for _ in changes:
+        # Would have called fake_post; we never get here.
+        pass
+    for _ in deletes:
+        pass
+
+    assert posted == []
+
+
+def test_watch_refuses_in_solution_workspace(tmp_path, capsys):
+    """`bifrost watch` must refuse inside a Solution workspace (D1): watch only
+    syncs to the global _repo/, so running it where a bifrost.solution.yaml is
+    present would silently push the developer's apps/ and workflows/ to the
+    wrong place. It must hard-fail (SystemExit) before doing any work via the
+    unified solution-workspace guard."""
+    import pytest
+
+    from bifrost.cli import handle_watch
+
+    # A directory that IS a Solution workspace (descriptor present).
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: demo\nname: Demo\n")
+
+    with pytest.raises(SystemExit):
+        handle_watch([str(tmp_path)])
+
+    err = capsys.readouterr().err
+    assert "Solution workspace" in err
+    assert "solution deploy" in err
+
+
+def test_watch_allowed_in_plain_repo_workspace(tmp_path):
+    """A plain (non-Solution) workspace must NOT be refused by the solution
+    guard — watch proceeds past the check (it fails later on auth/lock in this
+    unit context, but NOT with the solution-workspace refusal)."""
+    from bifrost.cli import handle_watch
+
+    # No bifrost.solution.yaml here. Watch should pass the solution guard and
+    # fail later (no auth) — we only assert it is NOT the solution refusal.
+    with patch("bifrost.cli.WorkspaceLock") as mock_lock:
+        mock_lock.return_value.__enter__ = MagicMock(
+            side_effect=RuntimeError("stop-after-guard")
+        )
+        try:
+            handle_watch([str(tmp_path)])
+        except RuntimeError as e:
+            assert str(e) == "stop-after-guard"

--- a/api/tests/unit/test_contract_version.py
+++ b/api/tests/unit/test_contract_version.py
@@ -158,7 +158,7 @@ EXPECTED_CONTRACT_FINGERPRINT = (
     # Solution deploy now returns 202 + deploy_job_id and the CLI polls
     # SolutionDeployJobStatus for the prior summary shape (2026-06-17).
     # CONTRACT_VERSION bumped to 5.
-    "4d84dfc7b2ae64d8be2aba15ca782467b5b92de256507bcbc4228fb36a336ec3"
+    "a799468f53c14a67556701f44e0d2e40bc09f9055369c4eb3a2c2b9a18597514"
 )
 
 

--- a/api/tests/unit/test_contract_version.py
+++ b/api/tests/unit/test_contract_version.py
@@ -61,6 +61,11 @@ from src.models.contracts.organizations import (  # noqa: E402
     OrganizationCreate,
     OrganizationUpdate,
 )
+from src.models.contracts.solutions import (  # noqa: E402
+    SolutionDeployEnqueued,
+    SolutionDeployJobStatus,
+    SolutionDeployRequest,
+)
 from src.models.contracts.tables import TableCreate, TableUpdate  # noqa: E402
 from src.models.contracts.users import RoleCreate, RoleUpdate  # noqa: E402
 from src.models.contracts.workflows import WorkflowUpdateRequest  # noqa: E402
@@ -104,6 +109,9 @@ _COMMAND_DTOS: list[type] = [
     EventSourceUpdate,
     EventSubscriptionCreate,
     EventSubscriptionUpdate,
+    SolutionDeployRequest,
+    SolutionDeployEnqueued,
+    SolutionDeployJobStatus,
 ]
 
 #: Every request/response DTO the in-workflow SDK sends/parses against
@@ -146,7 +154,11 @@ EXPECTED_CONTRACT_FINGERPRINT = (
     # RequiredConnectionUnset escalation). ADDITIVE — an old CLI simply omits the
     # field and keeps silent-None behavior, so no CONTRACT_VERSION bump; fingerprint
     # refreshed only.
-    "b6d4cc23a983f8c71ab07b44bb7ffec7616846e1330f4be369310821eb7c4b6b"
+    #
+    # Solution deploy now returns 202 + deploy_job_id and the CLI polls
+    # SolutionDeployJobStatus for the prior summary shape (2026-06-17).
+    # CONTRACT_VERSION bumped to 5.
+    "4d84dfc7b2ae64d8be2aba15ca782467b5b92de256507bcbc4228fb36a336ec3"
 )
 
 

--- a/api/tests/unit/test_deploy_bundle_introspection.py
+++ b/api/tests/unit/test_deploy_bundle_introspection.py
@@ -1,0 +1,24 @@
+from bifrost.commands.solution import summarize_bundle
+
+
+def test_summary_counts_and_warns():
+    summary = summarize_bundle(
+        python_files={f"m/{i}.py": "x" for i in range(613)},
+        apps=[],
+        vendored_count=613,
+    )
+    assert summary.file_count == 613
+    assert summary.warn is True
+    assert "vendored" in summary.message.lower()
+
+
+def test_summary_no_warn_counts_apps():
+    summary = summarize_bundle(
+        python_files={"a.py": "xx", "b.py": "yyy"},
+        apps=[{"src_files": {"index.tsx": "code"}, "bin_files": {"logo.png": "AAAA"}}],
+        vendored_count=0,
+    )
+    # 2 python + 1 src + 1 bin = 4 files
+    assert summary.file_count == 4
+    assert summary.warn is False
+    assert "Bundle:" in summary.message

--- a/api/tests/unit/test_deploy_cli_poll.py
+++ b/api/tests/unit/test_deploy_cli_poll.py
@@ -1,0 +1,63 @@
+"""Unit: the CLI deploy poll loop prints a heartbeat + terminal status.
+
+The deploy endpoint is async (Task 7) — the CLI POSTs, gets a job id, then
+polls ``GET /api/solutions/deploy-jobs/{id}`` until a terminal status. While the
+job is still running it prints ``Still deploying... Ns``; on success it prints
+``Deploy complete``; on failure it surfaces the server-captured error.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from bifrost.commands.solution import _poll_deploy_job
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self.status_code = 200
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    """Returns ``running`` for the first N status polls, then a terminal state."""
+
+    def __init__(self, terminal: dict, running_count: int = 2) -> None:
+        self._terminal = terminal
+        self._running_left = running_count
+        self.calls = 0
+
+    async def get(self, path: str, **kwargs):  # noqa: ANN003
+        self.calls += 1
+        if self._running_left > 0:
+            self._running_left -= 1
+            return _FakeResponse({"status": "running", "error": None})
+        return _FakeResponse(self._terminal)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_poll_prints_heartbeat_and_result(capsys):
+    client = _FakeClient(
+        {"status": "succeeded", "error": None, "install_id": "abc"}
+    )
+    rc = _run(_poll_deploy_job(client, "job-1", interval=0.0))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Still deploying..." in out
+    assert "Deploy complete" in out
+
+
+def test_poll_surfaces_failure(capsys):
+    client = _FakeClient(
+        {"status": "failed", "error": "manifest entry `diverged` mismatch"}
+    )
+    rc = _run(_poll_deploy_job(client, "job-2", interval=0.0))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "diverged" in (captured.out + captured.err)

--- a/api/tests/unit/test_deploy_preflight.py
+++ b/api/tests/unit/test_deploy_preflight.py
@@ -1,0 +1,86 @@
+"""Unit tests for the solution-deploy workflow preflight.
+
+``preflight_workflows`` flags only the genuinely execution-breaking case: a
+bundle entry whose ``function_name`` is not defined anywhere in the carried
+source (the "Executable not found" class). A manifest ``name`` that differs from
+the decorated or function name is NOT an error — execution resolves a workflow
+by its ``function_name`` (service.py / module_loader.py), so the DB ``name`` is
+identity/display only.
+"""
+from src.services.solution_deploy_preflight import preflight_workflows
+
+
+def test_no_errors_when_function_exists():
+    wfs = [
+        {
+            "name": "Sandbox Ticket Snapshot",
+            "function_name": "main",
+            "path": "workflows/snap.py",
+            "source": '@workflow(name="Sandbox Ticket Snapshot")\ndef main():\n    pass\n',
+        }
+    ]
+    assert preflight_workflows(wfs) == []
+
+
+def test_slug_differs_from_decorator_is_not_an_error():
+    # Manifest slug "hello" diverges from the decorated name — import resolves
+    # this to the decorated name, so preflight must NOT block it.
+    wfs = [
+        {
+            "name": "hello",
+            "function_name": "main",
+            "path": "workflows/snap.py",
+            "source": '@workflow(name="Sandbox Ticket Snapshot")\ndef main():\n    pass\n',
+        }
+    ]
+    assert preflight_workflows(wfs) == []
+
+
+def test_slug_differs_from_bare_function_is_not_an_error():
+    # Bare function (no @workflow decorator), slug "main" != function "run".
+    # The function exists, so this is a legitimate, non-blocking bundle.
+    wfs = [
+        {
+            "name": "main",
+            "function_name": "run",
+            "path": "workflows/main.py",
+            "source": "def run(sdk):\n    return 'ok'\n",
+        }
+    ]
+    assert preflight_workflows(wfs) == []
+
+
+def test_reports_missing_function_with_guidance():
+    wfs = [
+        {
+            "name": "hello",
+            "function_name": "main",
+            "path": "workflows/snap.py",
+            # Source defines `other`, not `main`.
+            "source": '@workflow(name="X")\ndef other():\n    pass\n',
+        }
+    ]
+    errors = preflight_workflows(wfs)
+    assert len(errors) == 1
+    msg = errors[0]
+    assert "main" in msg
+    assert "workflows/snap.py" in msg
+    assert "hello" in msg
+
+
+def test_no_source_is_skipped():
+    wfs = [{"name": "hello", "function_name": "main", "path": "workflows/snap.py"}]
+    assert preflight_workflows(wfs) == []
+
+
+def test_unparseable_source_is_not_blocked():
+    # Static verification is impossible; preflight defers to the engine.
+    wfs = [
+        {
+            "name": "hello",
+            "function_name": "main",
+            "path": "workflows/snap.py",
+            "source": "def def (:::",
+        }
+    ]
+    assert preflight_workflows(wfs) == []

--- a/api/tests/unit/test_deploy_preflight.py
+++ b/api/tests/unit/test_deploy_preflight.py
@@ -73,6 +73,38 @@ def test_no_source_is_skipped():
     assert preflight_workflows(wfs) == []
 
 
+def test_empty_source_reports_missing_function():
+    wfs = [
+        {
+            "name": "hello",
+            "function_name": "main",
+            "path": "workflows/snap.py",
+            "source": "",
+        }
+    ]
+
+    errors = preflight_workflows(wfs)
+
+    assert len(errors) == 1
+    assert "main" in errors[0]
+
+
+def test_nested_function_does_not_satisfy_preflight():
+    wfs = [
+        {
+            "name": "hello",
+            "function_name": "main",
+            "path": "workflows/snap.py",
+            "source": "def wrapper():\n    def main():\n        return {}\n",
+        }
+    ]
+
+    errors = preflight_workflows(wfs)
+
+    assert len(errors) == 1
+    assert "main" in errors[0]
+
+
 def test_unparseable_source_is_not_blocked():
     # Static verification is impossible; preflight defers to the engine.
     wfs = [

--- a/api/tests/unit/test_solution_collect_workflows.py
+++ b/api/tests/unit/test_solution_collect_workflows.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 import pathlib
 import sys
 
+import click
+import pytest
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
 from bifrost.commands.solution import _collect_workflows  # noqa: E402
@@ -57,3 +60,21 @@ def test_collect_workflows_preserves_full_metadata(tmp_path) -> None:
 
 def test_collect_workflows_empty_when_no_manifest(tmp_path) -> None:
     assert _collect_workflows(tmp_path) == []
+
+
+@pytest.mark.parametrize("wf_path", ["../outside.py", "/tmp/outside.py"])
+def test_collect_workflows_rejects_manifest_path_outside_workspace(
+    tmp_path: pathlib.Path,
+    wf_path: str,
+) -> None:
+    ws = _ws(
+        tmp_path,
+        "workflows:\n"
+        "  11111111-1111-1111-1111-111111111111:\n"
+        "    name: Escape\n"
+        "    function_name: run\n"
+        f"    path: {wf_path}\n",
+    )
+
+    with pytest.raises(click.ClickException, match="escapes the workspace"):
+        _collect_workflows(ws)

--- a/api/tests/unit/test_solution_deploy_reconcile.py
+++ b/api/tests/unit/test_solution_deploy_reconcile.py
@@ -145,13 +145,16 @@ class TestSolutionDeployReconcile:
         w1, w2 = str(uuid4()), str(uuid4())
         await deployer.deploy(SolutionBundle(
             solution=sol,
-            python_files={"workflows/w1.py": "x", "workflows/w2.py": "y"},
+            python_files={
+                "workflows/w1.py": "def run():\n    return 1\n",
+                "workflows/w2.py": "def run():\n    return 2\n",
+            },
             workflows=[_wf_entry(w1, "w1"), _wf_entry(w2, "w2")],
         ))
         await db.flush()
         await deployer.deploy(SolutionBundle(
             solution=sol,
-            python_files={"workflows/w1.py": "x"},
+            python_files={"workflows/w1.py": "def run():\n    return 1\n"},
             workflows=[_wf_entry(w1, "w1")],
         ))
         await db.flush()
@@ -183,7 +186,7 @@ class TestSolutionDeployReconcile:
         w1 = str(uuid4())
         await deployer.deploy(SolutionBundle(
             solution=org_install,
-            python_files={"workflows/w1.py": "x"},
+            python_files={"workflows/w1.py": "def run():\n    return 1\n"},
             workflows=[_wf_entry(w1, "w1")],
         ))
         await db.flush()
@@ -359,7 +362,7 @@ class TestSolutionDeployReconcile:
 
         r1 = await deployer.deploy(SolutionBundle(
             solution=sol,
-            python_files={"workflows/w1.py": "VALUE = 1\n"},
+            python_files={"workflows/w1.py": "VALUE = 1\ndef run():\n    return VALUE\n"},
             workflows=[_wf_entry(w1, "w1")],
         ))
         await r1.finalize_s3()  # Python write is deferred to the S3 phase (P1-c).
@@ -369,7 +372,7 @@ class TestSolutionDeployReconcile:
         # Redeploy with changed bytes — cache must reflect the new content.
         r2 = await deployer.deploy(SolutionBundle(
             solution=sol,
-            python_files={"workflows/w1.py": "VALUE = 2\n"},
+            python_files={"workflows/w1.py": "VALUE = 2\ndef run():\n    return VALUE\n"},
             workflows=[_wf_entry(w1, "w1")],
         ))
         await r2.finalize_s3()

--- a/api/tests/unit/test_solution_guard.py
+++ b/api/tests/unit/test_solution_guard.py
@@ -162,7 +162,7 @@ class TestBeforeFlushBackstop:
         wf_id = str(uuid.uuid4())
         await SolutionDeployer(db).deploy(SolutionBundle(
             solution=sol,
-            python_files={"workflows/w.py": "x"},
+            python_files={"workflows/w.py": "def run():\n    return 1\n"},
             workflows=[{"id": wf_id, "name": "bfd_w", "function_name": "run", "path": "workflows/w.py", "type": "workflow"}],
         ))
         await db.flush()  # must not raise

--- a/api/tests/unit/test_solution_resolve_install.py
+++ b/api/tests/unit/test_solution_resolve_install.py
@@ -138,22 +138,49 @@ class _Resp:
 
 
 class _DeployFakeClient:
-    """Resolves the install by slug and records the deploy request body."""
+    """Resolves the install by slug and records the deploy request body.
+
+    Deploy is async: the POST returns 202 + a job id, then the CLI polls the
+    deploy-jobs status endpoint. ``deploy_resp`` overrides the POST response (to
+    exercise the synchronous 409 paths); the default POST enqueues and the poll
+    GET reports the job ``succeeded``.
+    """
 
     organization = {"id": "org-1"}
 
-    def __init__(self, deploy_resp: _Resp | None = None):
+    def __init__(
+        self,
+        deploy_resp: _Resp | None = None,
+        job_status: str = "succeeded",
+        job_error: str = "boom",
+    ):
         self.deploy_body: dict | None = None
         self._deploy_resp = deploy_resp or _Resp(
-            200, body={"workflows_upserted": 0, "workflows_deleted": 0}
+            202, body={"deploy_job_id": "job-1"}
         )
+        self._job_status = job_status
+        self._job_error = job_error
 
     async def get(self, path, **kwargs):
-        assert path == "/api/solutions"
-        return _Resp(
-            200,
-            body={"solutions": [{"id": "inst-1", "slug": "s", "organization_id": "org-1"}]},
-        )
+        if path == "/api/solutions":
+            return _Resp(
+                200,
+                body={
+                    "solutions": [
+                        {"id": "inst-1", "slug": "s", "organization_id": "org-1"}
+                    ]
+                },
+            )
+        if path == "/api/solutions/deploy-jobs/job-1":
+            return _Resp(
+                200,
+                body={
+                    "status": self._job_status,
+                    "error": self._job_error,
+                    "result": {},
+                },
+            )
+        raise AssertionError(f"unexpected GET {path}")
 
     async def post(self, path, **kwargs):
         if path == "/api/solutions/inst-1/deploy":
@@ -209,14 +236,14 @@ def test_deploy_no_descriptor_version_sends_null(tmp_path, monkeypatch):
     assert fake.deploy_body.get("version") is None
 
 
-def test_deploy_downgrade_409_prints_detail_and_force_hint(tmp_path, monkeypatch):
-    """The downgrade 409 (Task 20 gate) surfaces the server detail PLUS a
-    re-run-with---force hint."""
+def test_deploy_downgrade_prints_detail_and_force_hint(tmp_path, monkeypatch):
+    """The downgrade gate (Task 20) now surfaces as a FAILED deploy job; the CLI
+    re-attaches the re-run-with---force hint when polling sees the error."""
     detail = (
         "bundle version 0.9.0 is older than installed 1.0.0; "
         "re-run with force to downgrade"
     )
-    fake = _DeployFakeClient(deploy_resp=_Resp(409, body={"detail": detail}))
+    fake = _DeployFakeClient(job_status="failed", job_error=detail)
     runner, grp = _deploy_workspace(
         tmp_path, monkeypatch, fake, "slug: s\nname: S\nversion: 0.9.0\n"
     )

--- a/api/tests/unit/test_solution_workspace_guard.py
+++ b/api/tests/unit/test_solution_workspace_guard.py
@@ -1,0 +1,56 @@
+import pytest
+
+from bifrost._solution_workspace import (
+    assert_not_solution_workspace,
+    find_solution_root,
+)
+
+
+def test_find_solution_root_walks_up(tmp_path):
+    (tmp_path / "bifrost.solution.yaml").write_text("name: demo\n")
+    sub = tmp_path / "functions" / "deep"
+    sub.mkdir(parents=True)
+    assert find_solution_root(sub) == tmp_path
+
+
+def test_no_solution_root(tmp_path):
+    assert find_solution_root(tmp_path) is None
+
+
+def test_assert_blocks_with_message(tmp_path, capsys):
+    (tmp_path / "bifrost.solution.yaml").write_text("name: demo\n")
+    with pytest.raises(SystemExit):
+        assert_not_solution_workspace(str(tmp_path), "push")
+    err = capsys.readouterr().err
+    assert "Solution workspace" in err and "solution deploy" in err
+
+
+def test_assert_passes_outside_solution(tmp_path):
+    # No descriptor anywhere up the tree -> no raise, returns None.
+    assert assert_not_solution_workspace(str(tmp_path), "push") is None
+
+
+def test_assert_blocks_when_cwd_is_inside_solution_even_for_outside_target(
+    tmp_path,
+    monkeypatch,
+):
+    sol = tmp_path / "solution"
+    sol.mkdir()
+    (sol / "bifrost.solution.yaml").write_text("name: demo\n")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.chdir(sol)
+
+    with pytest.raises(SystemExit):
+        assert_not_solution_workspace(str(outside), "push")
+
+
+def test_handle_push_blocks_in_solution(tmp_path, monkeypatch):
+    (tmp_path / "bifrost.solution.yaml").write_text("name: demo\n")
+    f = tmp_path / "x.py"
+    f.write_text("x=1\n")
+    monkeypatch.chdir(tmp_path)
+    from bifrost import cli
+
+    with pytest.raises(SystemExit):
+        cli.handle_push(["x.py"])

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -3745,22 +3745,22 @@ export interface paths {
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        get: operations["execute_endpoint_api_endpoints__workflow_id__post"];
+        get: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        put: operations["execute_endpoint_api_endpoints__workflow_id__post"];
+        put: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        post: operations["execute_endpoint_api_endpoints__workflow_id__post"];
+        post: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        delete: operations["execute_endpoint_api_endpoints__workflow_id__post"];
+        delete: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         options?: never;
         head?: never;
         patch?: never;
@@ -7366,8 +7366,25 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Deploy a bundle to an install (full replace, non-interactive, admin only) */
+        /** Enqueue a deploy to an install (async, full replace, admin only) */
         post: operations["deploy_solution_api_solutions__solution_id__deploy_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/solutions/deploy-jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Poll the status of an async deploy job (admin only) */
+        get: operations["get_deploy_job_api_solutions_deploy_jobs__job_id__get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -20926,6 +20943,55 @@ export interface components {
             include_imports: boolean;
         };
         /**
+         * SolutionDeployEnqueued
+         * @description Returned by ``POST /{id}/deploy`` — the deploy runs as a background job;
+         *     the caller polls ``GET /deploy-jobs/{deploy_job_id}`` for the result.
+         */
+        SolutionDeployEnqueued: {
+            /**
+             * Deploy Job Id
+             * Format: uuid
+             */
+            deploy_job_id: string;
+        };
+        /**
+         * SolutionDeployJobStatus
+         * @description Current state of an async deploy job.
+         */
+        SolutionDeployJobStatus: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Install Id
+             * Format: uuid
+             */
+            install_id: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "succeeded" | "failed";
+            /** Error */
+            error?: string | null;
+            /** Result */
+            result?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /**
          * SolutionDeployRequest
          * @description Full-replace deploy bundle for one install.
          *
@@ -20989,81 +21055,6 @@ export interface components {
              * @default false
              */
             force: boolean;
-        };
-        /** SolutionDeployResponse */
-        SolutionDeployResponse: {
-            /**
-             * Solution Id
-             * Format: uuid
-             */
-            solution_id: string;
-            /**
-             * Workflows Upserted
-             * @default 0
-             */
-            workflows_upserted: number;
-            /**
-             * Workflows Deleted
-             * @default 0
-             */
-            workflows_deleted: number;
-            /**
-             * Tables Upserted
-             * @default 0
-             */
-            tables_upserted: number;
-            /**
-             * Tables Deleted
-             * @default 0
-             */
-            tables_deleted: number;
-            /**
-             * Apps Upserted
-             * @default 0
-             */
-            apps_upserted: number;
-            /**
-             * Apps Deleted
-             * @default 0
-             */
-            apps_deleted: number;
-            /**
-             * Forms Upserted
-             * @default 0
-             */
-            forms_upserted: number;
-            /**
-             * Forms Deleted
-             * @default 0
-             */
-            forms_deleted: number;
-            /**
-             * Agents Upserted
-             * @default 0
-             */
-            agents_upserted: number;
-            /**
-             * Agents Deleted
-             * @default 0
-             */
-            agents_deleted: number;
-            /**
-             * Claims Upserted
-             * @default 0
-             */
-            claims_upserted: number;
-            /**
-             * Claims Deleted
-             * @default 0
-             */
-            claims_deleted: number;
-            /**
-             * Integrations Shell Created
-             * @default 0
-             */
-            integrations_shell_created: number;
-            /** Roles Created */
-            roles_created?: string[];
         };
         /**
          * SolutionEntities
@@ -29651,7 +29642,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__post: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -29684,7 +29675,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__post: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -29717,7 +29708,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__post: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -29750,7 +29741,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__post: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -36252,12 +36243,43 @@ export interface operations {
         };
         responses: {
             /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SolutionDeployEnqueued"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_deploy_job_api_solutions_deploy_jobs__job_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SolutionDeployResponse"];
+                    "application/json": components["schemas"]["SolutionDeployJobStatus"];
                 };
             };
             /** @description Validation Error */

--- a/docs/superpowers/plans/2026-06-17-cli-solution-ux.md
+++ b/docs/superpowers/plans/2026-06-17-cli-solution-ux.md
@@ -1,0 +1,778 @@
+# CLI / Solution UX Improvement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Bifrost CLI repo sync (`push`/`pull`/`sync`/`watch`) and `solution deploy` predictable, observable, and hard to misuse — single-file push, non-interactive one-way push, solution-workspace guards, real progress output, async observable deploy, and correct workflow/app validation.
+
+**Architecture:** Eight cohesive changes on one branch (`worktree-cli-solution-ux`). CLI ergonomics live in `api/bifrost/` (argparse handlers in `cli.py`, click commands in `commands/solution.py`, auth in `credentials.py`/`client.py`). Server-side changes touch the solutions deploy router/job system and the applications validation router. The workflow-name fix is in manifest import. Each task is TDD with its own commit.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy, Pydantic, httpx, click + argparse (CLI), pytest, alembic.
+
+## Global Constraints
+
+- **Worktree only:** all work happens in `.claude/worktrees/cli-solution-ux`, never on `main`.
+- **CLI cannot import `src.*`:** `api/bifrost/commands/` and `api/bifrost/*.py` must never `import src.*` — the packaged CLI has no `src` on its path. Test with the installed CLI, not just in-repo.
+- **DTO parity:** if any `XxxCreate`/`XxxUpdate` DTO changes, run `./test.sh tests/unit/test_dto_flags.py` and reconcile CLI/MCP/manifest or add to `DTO_EXCLUDES`.
+- **Datetime:** `datetime.now(timezone.utc)` only; `DateTime(timezone=True)` columns; no `datetime.utcnow()`.
+- **Tests via `./test.sh`** (Dockerized stack), never bare pytest. JUnit XML at `/tmp/bifrost-<project>/test-results.xml`.
+- **Migrations** run by the init container: after creating one, restart `bifrost-debug-<project>-init-1` then `-api-1`.
+- **No dead code, no unrequested fallbacks.**
+- **#3 escape hatch:** HARD FAIL inside solution workspaces; NO `--global-repo` flag this branch.
+- **#7:** the `@workflow(name=...)` decorator name IS the execution identity by design — do NOT change the resolver. Fix the import that corrupts `Workflow.name`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|------|----------------|-------|
+| `api/bifrost/credentials.py` | `EnvBackend` token resolution from `.env`-loaded URL | 1 |
+| `api/bifrost/cli.py` | push/pull/sync/watch arg parsing, single-file support, solution-workspace guard, progress output | 2,3,4 |
+| `api/bifrost/_solution_workspace.py` (new) | upward walk for `bifrost.solution.yaml` | 3 |
+| `api/src/services/manifest_import.py` | derive `Workflow.name` from decorator, not manifest slug | 5 |
+| `api/src/services/solution_deploy_preflight.py` (new) | manifest/decorator mismatch preflight | 5 |
+| `api/src/models/orm/applications.py` + migration | `app_model` discriminator column | 6 |
+| `api/src/routers/applications.py` | branch validation on `app_model` | 6 |
+| `api/src/models/orm/solution_deploy_jobs.py` (new) + migration | async deploy job record | 7 |
+| `api/src/routers/solutions.py` | async deploy endpoint + status endpoint | 7 |
+| `api/bifrost/commands/solution.py` | deploy timeout, phases, heartbeat, poll, bundle introspection | 7,8 |
+
+---
+
+## Task 1: ~~Resolve `.env` tokens~~ — DROPPED (not a bug)
+
+**Reproduced live 2026-06-17 against the sandbox.** `apps list` and `solution deploy` both authenticate identically via the OS keychain (`KeyringBackend`), which holds a valid entry for `https://sandbox-bifrost.gocovi.app`. Auth was never the problem — `solution deploy` fails at an httpx **`ReadTimeout` after ~108s while the server completes successfully** (verified: the app's `updated_at` advanced). That is Task 7's bug, not an auth bug. **No Task 1 work.** Latent fragility noted for a future pass: keychain URL match is trailing-slash-exact, so a `/`-suffixed `.env` URL would silently miss — not fixed here, no evidence it bit anyone.
+
+## ~~Task 1 (original): Resolve `.env` tokens when only `BIFROST_API_URL` is set~~ (superseded above)
+
+**Root cause:** `EnvBackend.get()` returns `None` unless `BIFROST_API_URL` AND both tokens are in `os.environ`. A `.env` with only the URL (the sandbox case) plus an empty `~/.bifrost/credentials.json` → nothing resolves. `apps list` only worked when tokens happened to be exported. The `.env` IS loaded into `os.environ` at import (`client.py:133` `load_dotenv`), so tokens placed in `.env` ARE in `os.environ` — the bug is only that the guard treats a URL-only `.env` as unusable instead of looking for tokens it does have. The real failure is the user had no tokens in `.env` and none in the store; the fix makes the resolver's behavior honest: if the env has a URL but not tokens, fall through cleanly to the persistent backend (already happens), AND `bifrost login` writing to the persistent store must be the documented path. **The concrete code defect to fix:** `EnvBackend.get()` silently returns `None` with no signal, so a user who set only `BIFROST_API_URL` in `.env` gets the global-default behavior with zero diagnostics. Add a one-line diagnostic to `get_credentials()` when a URL resolves but no credentials back it.
+
+**Files:**
+- Modify: `api/bifrost/credentials.py` (`get_credentials`, ~line 395-435)
+- Test: `api/tests/unit/test_credentials.py`
+
+**Interfaces:**
+- Consumes: `EnvBackend`, `JsonBackend`, `_resolve_url` (existing).
+- Produces: `get_credentials(api_url=None)` unchanged signature; emits a stderr diagnostic when URL resolves but no creds found.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/unit/test_credentials.py
+import os
+from bifrost import credentials
+
+def test_url_only_env_emits_diagnostic(monkeypatch, capsys, tmp_path):
+    # Only URL in env, no tokens, empty persistent store.
+    monkeypatch.setenv("BIFROST_API_URL", "https://sandbox.example.app")
+    monkeypatch.delenv("BIFROST_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("BIFROST_REFRESH_TOKEN", raising=False)
+    monkeypatch.setattr(credentials, "get_persistent_backend", lambda: credentials.JsonBackend())
+    monkeypatch.setenv("HOME", str(tmp_path))  # empty creds file
+    result = credentials.get_credentials()
+    assert result is None
+    err = capsys.readouterr().err
+    assert "BIFROST_API_URL" in err and "sandbox.example.app" in err
+    assert "token" in err.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/test_credentials.py::test_url_only_env_emits_diagnostic -v`
+Expected: FAIL — no diagnostic on stderr.
+
+- [ ] **Step 3: Implement the diagnostic in `get_credentials`**
+
+In `api/bifrost/credentials.py`, after the persistent + legacy lookups return nothing, before `return None`:
+
+```python
+    # Diagnostic: a URL resolved (from .env or env) but nothing authenticates it.
+    # This is the URL-only-.env trap — the user set BIFROST_API_URL but no tokens,
+    # and the persistent store has no record for that URL.
+    if resolved and not os.environ.get("BIFROST_ACCESS_TOKEN"):
+        print(
+            f"No credentials for BIFROST_API_URL={resolved}. "
+            f"Your .env sets the URL but not tokens, and no saved login matches it. "
+            f"Run `bifrost login --url {resolved} ...` to store credentials.",
+            file=sys.stderr,
+        )
+    return None
+```
+
+Ensure `import sys` and `import os` are present at module top.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/unit/test_credentials.py::test_url_only_env_emits_diagnostic -v`
+Expected: PASS.
+
+- [ ] **Step 5: Regression test — full env still resolves silently**
+
+```python
+def test_full_env_resolves_no_diagnostic(monkeypatch, capsys):
+    monkeypatch.setenv("BIFROST_API_URL", "https://sandbox.example.app")
+    monkeypatch.setenv("BIFROST_ACCESS_TOKEN", "a")
+    monkeypatch.setenv("BIFROST_REFRESH_TOKEN", "r")
+    result = credentials.get_credentials()
+    assert result is not None
+    assert result["api_url"] == "https://sandbox.example.app"
+    assert capsys.readouterr().err == ""
+```
+
+Run: `./test.sh tests/unit/test_credentials.py -v` → both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/bifrost/credentials.py api/tests/unit/test_credentials.py
+git commit -m "fix(cli): diagnose URL-only .env with no resolvable tokens"
+```
+
+---
+
+## Task 2: Single-file push (and one-way non-interactive default)
+
+**Goal:** `bifrost push path/to/file.py` pushes exactly one file; directory and `.` still work. Push is one-way and non-interactive by default (no TUI for plain push); only `--mirror` confirms.
+
+**Files:**
+- Modify: `api/bifrost/cli.py` (`_parse_push_watch_args` ~1593, `handle_push` ~1617, `_collect_push_files` ~2797, `_sync_files` ~2829)
+- Test: `api/tests/unit/test_cli_push.py`
+
+**Interfaces:**
+- Consumes: `_sync_files(local_path, *, mirror, validate, force, client, single_file=None)`.
+- Produces: `handle_push` accepts a file path; `_collect_push_files(path, single_file)` returns the one file when `single_file` set.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/unit/test_cli_push.py
+import pathlib
+from bifrost import cli
+
+def test_push_accepts_single_file(tmp_path, monkeypatch):
+    f = tmp_path / "mod.py"
+    f.write_text("x = 1\n")
+    captured = {}
+    async def fake_sync(local_path, *, mirror, validate, force, client, single_file=None):
+        captured["single_file"] = single_file
+        captured["local_path"] = local_path
+        return 0
+    monkeypatch.setattr(cli, "_sync_files", fake_sync)
+    monkeypatch.setattr(cli.BifrostClient, "get_instance", lambda **k: object())
+    rc = cli.handle_push([str(f)])
+    assert rc == 0
+    assert captured["single_file"] == str(f)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./test.sh tests/unit/test_cli_push.py::test_push_accepts_single_file -v`
+Expected: FAIL — `handle_push` rejects non-directory at `cli.py:1665`.
+
+- [ ] **Step 3: Allow a file path in `handle_push`**
+
+Replace the directory check at `cli.py:1664-1667`:
+
+```python
+    resolved = pathlib.Path(parsed.local_path).resolve()
+    single_file: str | None = None
+    if resolved.is_file():
+        single_file = parsed.local_path
+        lock_target = resolved.parent
+    elif resolved.is_dir():
+        lock_target = resolved
+    else:
+        print(f"Error: {parsed.local_path} is not a valid file or directory", file=sys.stderr)
+        return 1
+```
+
+Update the `WorkspaceLock(resolved, "push")` call to use `lock_target`, and pass `single_file=single_file` into the `_sync_files(...)` call.
+
+- [ ] **Step 4: Thread `single_file` through `_sync_files`/`_collect_push_files`**
+
+In `_sync_files` signature add `single_file: str | None = None`. Where it calls `_collect_push_files(...)`, pass it. In `_collect_push_files(path, single_file=None)`:
+
+```python
+    if single_file is not None:
+        p = pathlib.Path(single_file).resolve()
+        repo_path = p.name if p.parent == pathlib.Path(path).resolve() else p.relative_to(pathlib.Path(path).resolve()).as_posix()
+        return {repo_path: p}  # match the existing return shape
+```
+
+(Confirm the real return shape of `_collect_push_files` at `cli.py:2797` and mirror it exactly — it currently maps repo-relative path → local Path.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `./test.sh tests/unit/test_cli_push.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Make plain push non-interactive (only `--mirror` confirms)**
+
+In `_sync_files`, the interactive TUI branch (`cli.py:3006-3029`) currently triggers when `not force and _is_tty`. Gate it so plain push never opens the per-file TUI; only `--mirror` (destructive) does:
+
+```python
+    interactive = (not force) and _is_tty and mirror  # only mirror is destructive enough to review
+    if interactive:
+        sync_result = await interactive_sync(...)
+    else:
+        # one-way: apply default actions (push) without prompting
+        ...
+```
+
+Add a test asserting a non-mirror push with a TTY does not call `interactive_sync` (monkeypatch it to raise).
+
+- [ ] **Step 7: Run + Commit**
+
+Run: `./test.sh tests/unit/test_cli_push.py -v` → PASS.
+
+```bash
+git add api/bifrost/cli.py api/tests/unit/test_cli_push.py
+git commit -m "feat(cli): single-file push; plain push is one-way non-interactive"
+```
+
+---
+
+## Task 3: Fail repo commands inside a Solution workspace
+
+**Goal:** `push`/`pull`/`sync`/`watch` hard-fail when cwd is inside a Solution workspace (upward walk finds `bifrost.solution.yaml`). Hard fail, no escape hatch.
+
+**Files:**
+- Create: `api/bifrost/_solution_workspace.py`
+- Modify: `api/bifrost/cli.py` (`handle_push`, `handle_pull`, `handle_sync`, `handle_watch`)
+- Test: `api/tests/unit/test_solution_workspace_guard.py`
+
+**Interfaces:**
+- Produces: `find_solution_root(start: pathlib.Path) -> pathlib.Path | None` and `assert_not_solution_workspace(path: str, command: str) -> None` (raises `SystemExit(1)` with the standard message after printing to stderr).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/unit/test_solution_workspace_guard.py
+import pathlib, pytest
+from bifrost._solution_workspace import find_solution_root, assert_not_solution_workspace
+
+def test_find_solution_root_walks_up(tmp_path):
+    (tmp_path / "bifrost.solution.yaml").write_text("name: demo\n")
+    sub = tmp_path / "functions" / "deep"
+    sub.mkdir(parents=True)
+    assert find_solution_root(sub) == tmp_path
+
+def test_no_solution_root(tmp_path):
+    assert find_solution_root(tmp_path) is None
+
+def test_assert_blocks_with_message(tmp_path, capsys):
+    (tmp_path / "bifrost.solution.yaml").write_text("name: demo\n")
+    with pytest.raises(SystemExit):
+        assert_not_solution_workspace(str(tmp_path), "push")
+    err = capsys.readouterr().err
+    assert "Solution workspace" in err and "solution deploy" in err
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./test.sh tests/unit/test_solution_workspace_guard.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the module**
+
+```python
+# api/bifrost/_solution_workspace.py
+"""Detect Solution workspaces so global _repo commands can refuse to run in them."""
+from __future__ import annotations
+import pathlib
+import sys
+
+DESCRIPTOR = "bifrost.solution.yaml"
+
+def find_solution_root(start: pathlib.Path) -> pathlib.Path | None:
+    cur = start.resolve()
+    for parent in [cur, *cur.parents]:
+        if (parent / DESCRIPTOR).is_file():
+            return parent
+    return None
+
+def assert_not_solution_workspace(path: str, command: str) -> None:
+    root = find_solution_root(pathlib.Path(path))
+    if root is not None:
+        print(
+            f"This is a Solution workspace ({root}). `bifrost {command}` targets the "
+            f"global _repo workspace and is disabled here.\nUse `bifrost solution deploy`.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./test.sh tests/unit/test_solution_workspace_guard.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the guard into all four handlers**
+
+In `cli.py`, at the top of `handle_push`, `handle_pull`, `handle_sync`, `handle_watch` — after the path is resolved and before the `WorkspaceLock` — add:
+
+```python
+    from bifrost._solution_workspace import assert_not_solution_workspace
+    assert_not_solution_workspace(parsed.local_path, "push")  # command name per handler
+```
+
+(Use `"pull"`, `"sync"`, `"watch"` in the respective handlers; `parsed.local_path` or the handler's local var.)
+
+- [ ] **Step 6: Integration test the wiring**
+
+```python
+def test_handle_push_blocks_in_solution(tmp_path, monkeypatch):
+    (tmp_path / "bifrost.solution.yaml").write_text("name: demo\n")
+    f = tmp_path / "x.py"; f.write_text("x=1\n")
+    monkeypatch.chdir(tmp_path)
+    import pytest
+    from bifrost import cli
+    with pytest.raises(SystemExit):
+        cli.handle_push(["x.py"])
+```
+
+Run: `./test.sh tests/unit/test_solution_workspace_guard.py tests/unit/test_cli_push.py -v` → PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/bifrost/_solution_workspace.py api/bifrost/cli.py api/tests/unit/test_solution_workspace_guard.py
+git commit -m "feat(cli): block push/pull/sync/watch inside a Solution workspace"
+```
+
+---
+
+## Task 4: Line-oriented push progress in non-TTY mode
+
+**Goal:** Non-TTY push prints local phases up front and per-file (throttled) upload lines, plus a final summary — so large pushes don't look hung.
+
+**Files:**
+- Modify: `api/bifrost/cli.py` (`_sync_files` progress section ~3108)
+- Test: `api/tests/unit/test_cli_push_progress.py`
+
+**Interfaces:**
+- Consumes: existing `_sync_files` push loop; `_is_tty` flag.
+- Produces: stderr/stdout lines: `Scanning files...`, `Scanned N files, M unchanged`, `Uploading i/N <path>`, `Done: N pushed, M unchanged, K skipped, F failed`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/unit/test_cli_push_progress.py
+import asyncio
+from bifrost import cli
+
+def test_non_tty_push_prints_progress(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(cli, "_is_tty", False)
+    # minimal fake: 3 files to push, server has none
+    # (stub _collect_push_files + client.post to no-op 200; assert lines)
+    ...
+    out = capsys.readouterr().out
+    assert "Scanning files..." in out
+    assert "Uploading 1/3" in out
+    assert out.strip().endswith("Done: 3 pushed, 0 unchanged, 0 skipped, 0 failed")
+```
+
+(Fill the stub bodies against the real `_sync_files` seam — see `cli.py:2829`. The implementer wires the fakes to whatever `_sync_files` actually calls.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./test.sh tests/unit/test_cli_push_progress.py -v`
+Expected: FAIL — no `Scanning files...` line today.
+
+- [ ] **Step 3: Add phase + per-file lines (non-TTY branch)**
+
+In `_sync_files`, guard a non-TTY progress path. Before scanning:
+
+```python
+    if not _is_tty:
+        print("Scanning files...", flush=True)
+```
+
+After collecting and diffing:
+
+```python
+    if not _is_tty:
+        print(f"Scanned {total} files, {unchanged} unchanged", flush=True)
+        print("Comparing remote state...", flush=True)
+```
+
+In the upload loop, throttle: every file when `total <= 50`, else every 25th file or once per second:
+
+```python
+    if not _is_tty and (total <= 50 or i % 25 == 0 or (now - last_print) >= 1.0):
+        print(f"Uploading {i}/{total} {repo_path}", flush=True)
+        last_print = now
+```
+
+Final summary:
+
+```python
+    if not _is_tty:
+        print(f"Done: {pushed} pushed, {unchanged} unchanged, {skipped} skipped, {failed} failed", flush=True)
+```
+
+Use `time.monotonic()` (avoid `Date.now`-style banned calls per project datetime rules — `monotonic` is fine).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./test.sh tests/unit/test_cli_push_progress.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/bifrost/cli.py api/tests/unit/test_cli_push_progress.py
+git commit -m "feat(cli): line-oriented push progress in non-TTY mode"
+```
+
+---
+
+## Task 5: Fix workflow name corruption in manifest import + deploy preflight
+
+**Goal:** Manifest import must write the **decorator** name into `Workflow.name`, never the manifest dict slug. Add a deploy preflight that catches a manifest/decorator mismatch with a clear error.
+
+**Root cause:** `manifest_import.py:976` does `self._resolve_workflow(mwf.name or key, mwf, cache)`; `ManifestWorkflow.name` defaults to `""`, so a workflow keyed by slug `hello` writes `Workflow.name="hello"` while the decorator says `Sandbox Ticket Snapshot` → execution (`service.py:284` matches `meta.name == workflow_record.name`) fails with "Executable 'hello' not found".
+
+**Files:**
+- Modify: `api/src/services/manifest_import.py` (~970-984, `_resolve_workflow`)
+- Create: `api/src/services/solution_deploy_preflight.py`
+- Modify: `api/bifrost/commands/solution.py` (`_collect_workflows`, deploy flow)
+- Test: `api/tests/unit/test_manifest_workflow_name.py`, `api/tests/unit/test_deploy_preflight.py`
+
+**Interfaces:**
+- Produces: `extract_workflow_name_from_source(source: str, function_name: str) -> str | None` (AST parse of `@workflow(name=...)`, default to `function_name`).
+- Produces: `preflight_workflows(workflows: list[dict]) -> list[str]` returning human-readable mismatch errors (empty = ok).
+
+- [ ] **Step 1: Write the failing test (import name)**
+
+```python
+# api/tests/unit/test_manifest_workflow_name.py
+from src.services.solution_deploy_preflight import extract_workflow_name_from_source
+
+def test_extracts_decorator_name():
+    src = '@workflow(name="Sandbox Ticket Snapshot")\ndef main():\n    pass\n'
+    assert extract_workflow_name_from_source(src, "main") == "Sandbox Ticket Snapshot"
+
+def test_defaults_to_function_name():
+    src = '@workflow()\ndef main():\n    pass\n'
+    assert extract_workflow_name_from_source(src, "main") == "main"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./test.sh tests/unit/test_manifest_workflow_name.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the AST extractor**
+
+```python
+# api/src/services/solution_deploy_preflight.py
+"""Preflight + name extraction so the decorator name stays the execution identity."""
+from __future__ import annotations
+import ast
+
+def extract_workflow_name_from_source(source: str, function_name: str) -> str | None:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            for dec in node.decorator_list:
+                if isinstance(dec, ast.Call) and _is_workflow_dec(dec.func):
+                    for kw in dec.keywords:
+                        if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                            return str(kw.value.value)
+                    return function_name  # @workflow() with no name → function name
+                if _is_workflow_dec(dec):  # bare @workflow
+                    return function_name
+    return function_name
+
+def _is_workflow_dec(node: ast.expr) -> bool:
+    return (isinstance(node, ast.Name) and node.id == "workflow") or (
+        isinstance(node, ast.Attribute) and node.attr == "workflow"
+    )
+
+def preflight_workflows(workflows: list[dict]) -> list[str]:
+    """workflows: deploy bundle entries with keys: name, function_name, path, source."""
+    errors: list[str] = []
+    for wf in workflows:
+        src = wf.get("source")
+        if not src:
+            continue
+        actual = extract_workflow_name_from_source(src, wf.get("function_name", ""))
+        declared = wf.get("name")
+        if actual and declared and actual != declared:
+            errors.append(
+                f"Workflow manifest entry `{declared}` points to {wf.get('path')}::"
+                f"{wf.get('function_name')}, but the decorated name is `{actual}`. "
+                f"Use @workflow(name=\"{declared}\") or update the manifest."
+            )
+    return errors
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./test.sh tests/unit/test_manifest_workflow_name.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Fix the import to use the decorator name (failing test first)**
+
+```python
+# add to test_manifest_workflow_name.py
+import pytest
+from src.services.manifest_import import ManifestImporter  # adjust to real class
+
+@pytest.mark.asyncio
+async def test_import_uses_decorator_name_not_slug(importer_with_file):
+    # manifest entry keyed "hello", name="", path points at a file whose
+    # decorator is @workflow(name="Sandbox Ticket Snapshot")
+    ops = importer_with_file._resolve_workflow_name_for("hello", mwf_with_empty_name, source)
+    assert ops == "Sandbox Ticket Snapshot"
+```
+
+Then in `manifest_import.py`, replace the name argument at line 976. Read the workflow source (import already gated on `_file_exists(mwf.path)`), extract the decorator name, and pass THAT instead of `mwf.name or key`:
+
+```python
+            if await _file_exists(mwf.path):
+                source = await _read_file(mwf.path)  # use the same read used elsewhere
+                from src.services.solution_deploy_preflight import extract_workflow_name_from_source
+                exec_name = extract_workflow_name_from_source(source or "", mwf.function_name) \
+                    or mwf.name or key
+                await _prog(f"Importing workflow: {exec_name}")
+                wf_ops = self._resolve_workflow(exec_name, mwf, cache)
+```
+
+(Confirm the file-read helper available in `manifest_import.py`; reuse it — do not invent a new reader.)
+
+- [ ] **Step 6: Wire preflight into deploy (server side)**
+
+In the `/api/solutions/{id}/deploy` handler (`api/src/routers/solutions.py`), before upserting workflows, call `preflight_workflows(workflows)`; if it returns errors, return `422` with the joined messages. Requires the deploy bundle to carry `source` per workflow — update `_collect_workflows` in `commands/solution.py` to include the `.py` source text. Add an e2e test in `tests/e2e/platform/` asserting a mismatched bundle returns 422 with the guidance string.
+
+- [ ] **Step 7: Run + Commit**
+
+Run: `./test.sh tests/unit/test_manifest_workflow_name.py tests/unit/test_deploy_preflight.py -v` → PASS.
+
+```bash
+git add api/src/services/solution_deploy_preflight.py api/src/services/manifest_import.py api/bifrost/commands/solution.py api/src/routers/solutions.py api/tests/unit/test_manifest_workflow_name.py api/tests/unit/test_deploy_preflight.py
+git commit -m "fix(solutions): keep decorator name as workflow execution identity; deploy preflight"
+```
+
+---
+
+## Task 6: v2-aware app validation (column ALREADY EXISTS)
+
+**Verified live 2026-06-17:** `app_model` is ALREADY an ORM column (`applications.py:75`) and the ORM already branches on `standalone_v2` (lines 123, 135). The live API returns `app_model: 'standalone_v2'`. **NO migration, NO column work.** The ONLY gap: the validate endpoint (`applications.py:707-714`) still requires `_layout.tsx` unconditionally and does not branch on `app_model`. This task is just that branch.
+
+**Goal:** `/applications/{id}/validate` must not run v1 `_layout.tsx` checks against `standalone_v2` apps.
+
+**Files:**
+- Modify: `api/src/routers/applications.py` (validation, the `_layout.tsx` check at ~707-714 and the Outlet check at ~764)
+- Test: `api/tests/e2e/platform/test_app_validation.py`
+
+**Interfaces:**
+- Consumes: `application.app_model` (existing column, values `"legacy_v1"` / `"standalone_v2"`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# api/tests/e2e/platform/test_app_validation.py
+async def test_v2_app_skips_layout_check(client, make_app):
+    app = await make_app(app_model="standalone_v2", files={"index.tsx": "export default () => null"})
+    resp = await client.post(f"/api/applications/{app.id}/validate")
+    issues = resp.json()["issues"]
+    assert not any(i["file"] == "_layout.tsx" for i in issues)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./test.sh e2e tests/e2e/platform/test_app_validation.py`
+Expected: FAIL — validator requires `_layout.tsx` unconditionally; the error is present.
+
+- [ ] **Step 3: Branch the validator (no migration — column already exists)**
+
+In `applications.py` validation (the `_layout.tsx` check at ~707-714 and the Outlet check at ~764), guard the v1-only checks:
+
+```python
+    is_v2 = (app.app_model == "standalone_v2")
+    if not is_v2:
+        if layout_path not in files:
+            errors.append(AppValidationIssue(severity="error", file="_layout.tsx",
+                          message="Missing required _layout.tsx file"))
+        # ...other v1-only checks
+    else:
+        # v2: validate buildability / imports; do not require _layout.tsx
+        ...
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `./test.sh e2e tests/e2e/platform/test_app_validation.py`
+Expected: PASS. Then `cd client && npm run generate:types` (schema changed) and `npm run tsc`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/models/orm/applications.py api/alembic/versions/*app_model* api/src/routers/applications.py api/tests/e2e/platform/test_app_validation.py client/src/lib/v1.d.ts
+git commit -m "feat(apps): app_model discriminator; v2 apps skip v1 layout validation"
+```
+
+---
+
+## Task 7: Async, observable solution deploy
+
+**Goal:** Deploy becomes job-based: CLI POSTs → server returns `deploy_job_id` → CLI polls a status endpoint with a deploy-specific timeout and heartbeat; final status/errors are inspectable. Quick-fix phases/timeout land here too.
+
+**Files:**
+- Create: `api/src/models/orm/solution_deploy_jobs.py` + migration
+- Modify: `api/src/routers/solutions.py` (async deploy endpoint + `GET /api/solutions/deploy-jobs/{id}`)
+- Modify: `api/bifrost/commands/solution.py` (local phases, deploy-specific timeout, poll loop, heartbeat)
+- Modify: `api/bifrost/client.py` (per-request timeout override support if not present)
+- Test: `api/tests/e2e/platform/test_solution_deploy_async.py`, `api/tests/unit/test_deploy_cli_poll.py`
+
+**Interfaces:**
+- Produces: `SolutionDeployJob(id, install_id, status, error, created_at, updated_at)`; status in `{queued, running, succeeded, failed}`.
+- Produces: `POST /api/solutions/{id}/deploy` → `{deploy_job_id}`; `GET /api/solutions/deploy-jobs/{job_id}` → job record.
+- Consumes (CLI): `client.post(..., timeout=600)` and a poll loop printing `Still deploying... Ns`.
+
+- [ ] **Step 1: Failing e2e — deploy returns a job id and reaches succeeded**
+
+```python
+async def test_async_deploy_completes(client, make_solution_install):
+    install = await make_solution_install()
+    resp = await client.post(f"/api/solutions/{install.id}/deploy", json=MIN_BUNDLE)
+    job_id = resp.json()["deploy_job_id"]
+    # poll
+    for _ in range(50):
+        st = (await client.get(f"/api/solutions/deploy-jobs/{job_id}")).json()
+        if st["status"] in ("succeeded", "failed"):
+            break
+    assert st["status"] == "succeeded"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./test.sh e2e tests/e2e/platform/test_solution_deploy_async.py`
+Expected: FAIL — endpoint returns deploy summary, not `deploy_job_id`.
+
+- [ ] **Step 3: Add the job model + migration**
+
+`solution_deploy_jobs.py`: ORM with the fields above, tz-aware `DateTime(timezone=True)` defaults via `lambda: datetime.now(timezone.utc)`. Migration creates the table. Apply via init container.
+
+- [ ] **Step 4: Make the deploy endpoint enqueue + a status endpoint**
+
+In `solutions.py`: create a job row (`queued`), dispatch the existing deploy logic as a background task (FastAPI `BackgroundTasks` or the project's worker queue — match how other async jobs run; check `api/src/jobs/`), update job to `running`→`succeeded`/`failed` with captured error. Add `GET /api/solutions/deploy-jobs/{job_id}`. Run preflight (Task 5) inside the job; failures set `status=failed, error=...`.
+
+- [ ] **Step 5: CLI — phases, timeout, poll, heartbeat (unit test first)**
+
+```python
+# test_deploy_cli_poll.py — assert heartbeat + terminal status print
+def test_poll_prints_heartbeat_and_result(monkeypatch, capsys):
+    ...  # fake client returns running twice then succeeded
+    out = capsys.readouterr().out
+    assert "Still deploying..." in out
+    assert "Deploy complete" in out
+```
+
+In `commands/solution.py` deploy flow: before the POST print local phases (`collecting solution files`, `counting files`, `computing bundle size`, `vendoring shared dependencies`, `uploading bundle`). POST with `timeout=600`. Then poll `deploy-jobs/{id}` every 3s, printing `Still deploying... {elapsed}s` each tick; on terminal status print `Deploy complete` or the error. Use `time.monotonic()`.
+
+- [ ] **Step 6: Run + Commit**
+
+Run: `./test.sh e2e tests/e2e/platform/test_solution_deploy_async.py` and `./test.sh tests/unit/test_deploy_cli_poll.py -v` → PASS. `cd client && npm run generate:types && npm run tsc`.
+
+```bash
+git add api/src/models/orm/solution_deploy_jobs.py api/alembic/versions/*deploy_job* api/src/routers/solutions.py api/bifrost/commands/solution.py api/bifrost/client.py api/tests/e2e/platform/test_solution_deploy_async.py api/tests/unit/test_deploy_cli_poll.py client/src/lib/v1.d.ts
+git commit -m "feat(solutions): async observable deploy with job status + heartbeat"
+```
+
+---
+
+## Task 8: Deploy bundle introspection
+
+**Goal:** Deploy prints bundle file count + size, and warns loudly when a large vendored `modules/`/`shared/` tree is included. Reuses Task 7's phase output.
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py` (after bundle assembly, before POST)
+- Test: `api/tests/unit/test_deploy_bundle_introspection.py`
+
+**Interfaces:**
+- Consumes: the assembled `bundle_python`, `apps`, and `vendored` set from Task 7's flow.
+- Produces: printed `Bundle: N files, X.X MB`; a warning when vendored file count exceeds a threshold.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# test_deploy_bundle_introspection.py
+from bifrost.commands.solution import summarize_bundle
+
+def test_summary_counts_and_warns():
+    summary = summarize_bundle(python_files={f"m/{i}.py": "x" for i in range(613)},
+                               apps=[], vendored_count=613)
+    assert summary.file_count == 613
+    assert summary.warn is True
+    assert "vendored" in summary.message.lower()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./test.sh tests/unit/test_deploy_bundle_introspection.py -v`
+Expected: FAIL — `summarize_bundle` missing.
+
+- [ ] **Step 3: Implement `summarize_bundle`**
+
+```python
+import dataclasses
+
+@dataclasses.dataclass
+class BundleSummary:
+    file_count: int
+    size_mb: float
+    warn: bool
+    message: str
+
+def summarize_bundle(python_files: dict, apps: list, vendored_count: int) -> BundleSummary:
+    app_files = sum(len(a.get("src_files", {})) + len(a.get("bin_files", {})) for a in apps)
+    count = len(python_files) + app_files
+    size = sum(len(v.encode()) for v in python_files.values())
+    size += sum(len(s.encode()) for a in apps for s in a.get("src_files", {}).values())
+    mb = round(size / 1_000_000, 1)
+    warn = vendored_count > 200
+    msg = (f"This deploy includes {vendored_count} vendored files from modules/ and shared/. "
+           f"Bundle size: {mb} MB.") if warn else f"Bundle: {count} files, {mb} MB."
+    return BundleSummary(count, mb, warn, msg)
+```
+
+- [ ] **Step 4: Print it in the deploy flow**
+
+After assembling the bundle (Task 7), call `summarize_bundle(...)` and `click.echo(summary.message)` (use `err=True` when `summary.warn`).
+
+- [ ] **Step 5: Run + Commit**
+
+Run: `./test.sh tests/unit/test_deploy_bundle_introspection.py -v` → PASS.
+
+```bash
+git add api/bifrost/commands/solution.py api/tests/unit/test_deploy_bundle_introspection.py
+git commit -m "feat(solutions): deploy bundle size/count + large-vendor warning"
+```
+
+---
+
+## Final Verification (after all tasks)
+
+```bash
+cd api && pyright && ruff check .
+cd ../client && npm run generate:types && npm run tsc && npm run lint
+cd .. && ./test.sh all && ./test.sh client unit
+./test.sh tests/unit/test_dto_flags.py        # DTO parity (bundle/app_model touched DTOs)
+./test.sh tests/unit/test_mcp_thin_wrapper.py  # if any MCP tool touched
+```
+
+Then drive it live (see [[feedback_drive_dont_just_test]]) from `~/GitHub/bifrost-sandbox-solution-example`: single-file push, push blocked in solution dir, deploy with heartbeat, a deliberately-mismatched workflow name caught by preflight, a `standalone_v2` app validating clean.
+
+## Self-Review Notes
+
+- Spec coverage: items 1-8 of the Obsidian plan map to Tasks 1-8 (deploy quick-fix folded into Task 7 alongside async; bundle handling = Task 8).
+- #4 reframed to the real defect (URL-only `.env` diagnostic) — confirmed empirically against the sandbox workspace.
+- #7 keeps the decorator name as identity per Jack's correction; fixes the import slug bug + adds preflight.
+- #8 adds the missing `app_model` discriminator the validator needs to branch.
+- Order respects dependencies: semantics (2) before guard (3); discriminator before v2 validation (6); preflight extractor (5) reused by async deploy (7); Task 7's bundle assembly reused by Task 8.

--- a/docs/superpowers/plans/2026-06-17-cli-solution-ux.md
+++ b/docs/superpowers/plans/2026-06-17-cli-solution-ux.md
@@ -45,6 +45,8 @@
 
 ## ~~Task 1 (original): Resolve `.env` tokens when only `BIFROST_API_URL` is set~~ (superseded above)
 
+**Historical context only — do not implement.** This was the original hypothesis before the live reproduction above showed the timeout, not auth resolution, was the defect addressed by this plan.
+
 **Root cause:** `EnvBackend.get()` returns `None` unless `BIFROST_API_URL` AND both tokens are in `os.environ`. A `.env` with only the URL (the sandbox case) plus an empty `~/.bifrost/credentials.json` → nothing resolves. `apps list` only worked when tokens happened to be exported. The `.env` IS loaded into `os.environ` at import (`client.py:133` `load_dotenv`), so tokens placed in `.env` ARE in `os.environ` — the bug is only that the guard treats a URL-only `.env` as unusable instead of looking for tokens it does have. The real failure is the user had no tokens in `.env` and none in the store; the fix makes the resolver's behavior honest: if the env has a URL but not tokens, fall through cleanly to the persistent backend (already happens), AND `bifrost login` writing to the persistent store must be the documented path. **The concrete code defect to fix:** `EnvBackend.get()` silently returns `None` with no signal, so a user who set only `BIFROST_API_URL` in `.env` gets the global-default behavior with zero diagnostics. Add a one-line diagnostic to `get_credentials()` when a URL resolves but no credentials back it.
 
 **Files:**

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -396,6 +396,7 @@
 | POST | `/api/settings/oauth/{provider}/test` |
 | GET | `/api/solutions` |
 | POST | `/api/solutions` |
+| GET | `/api/solutions/deploy-jobs/{job_id}` |
 | POST | `/api/solutions/install` |
 | POST | `/api/solutions/install/from-repo` |
 | POST | `/api/solutions/install/preview` |


### PR DESCRIPTION
## Summary
- Sync the two upstream commits after the last MTG catch-up (`380bfc7b9..9a76c95cb`).
- Bring in async Solution deploy jobs, deploy preflight, CLI push/deploy hardening, generated API contract updates, and the new Solution deploy migration.
- Preserve MTG fork deployment boundaries; `deploy-dev` remains upstream-only for `gobifrost/bifrost`.

## Upstream commits
- `2ecca251f` Solution deploy UX: async deploy, workflow execution fix, CLI push hardening (#388)
- `9a76c95cb` CLI deploy polish: instrument deploy phases, mention files in push --help (#389)

## Database
- Adds Alembic migration `api/alembic/versions/20260617_solution_deploy_jobs.py` for `solution_deploy_jobs`.

## Verification
- `python api/scripts/check_mtg_ci_boundaries.py`
- `git diff --check origin/main..HEAD`
- `python -m compileall -q api/bifrost api/src api/tests/unit/test_cli_watch.py api/tests/unit/test_contract_version.py api/tests/unit/test_cli_push.py api/tests/unit/test_cli_push_progress.py api/tests/unit/test_cli_solution_deploy_phases.py api/tests/unit/test_deploy_cli_poll.py api/tests/unit/test_deploy_preflight.py api/tests/unit/routers/test_solution_deploy_jobs.py`

## Notes
- Focused pytest could not run on this Windows checkout because the local Python environment lacks `pytest_asyncio` and this worktree has no `.venv`; GitHub Actions is the platform verification lane for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Solution deploy orchestration (DB migration, background jobs, write lock) and workflow execution resolution; behavior changes are well-tested but deploy is a critical path.
> 
> **Overview**
> This PR syncs upstream deploy UX: **Solution deploy is now asynchronous** — `POST /api/solutions/{id}/deploy` returns **202** with `deploy_job_id`, work runs in a background task tracked in new `solution_deploy_jobs` (Alembic migration), and callers poll **`GET /api/solutions/deploy-jobs/{job_id}`** for status, errors, and upsert counts. API startup reconciles orphaned queued/running jobs after restarts. **CLI contract version bumps to 5** for this breaking shape.
> 
> **`bifrost solution deploy`** uploads the bundle (long timeout), then polls with heartbeats; it adds phased progress (scan, vendor, bundle summary/warnings, upload) and attaches workflow **source** to the bundle for server preflight, with path traversal blocked when collecting workflows.
> 
> **Deploy preflight** rejects bundles whose `function_name` is missing from carried source (`SolutionWorkflowNameMismatch` on the job). **Workflow execution** now matches decorated callables by **`function_name`** (Python def name), not DB/display `name`, fixing “Executable not found” when manifest names diverge.
> 
> **CLI `_repo` sync** hardening: `push`/`sync`/`watch`/`pull` refuse inside a Solution workspace (`bifrost.solution.yaml`); `push` accepts a **single file**, skips `.env` in filters, stays one-way/non-interactive (no selection TUI), and prints line progress on non-TTY. **`standalone_v2`** app validation skips v1 `_layout.tsx` / `<Outlet />` rules.
> 
> E2E/unit tests and OpenAPI/client types updated for async deploy and the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bbb5c85de7c1d9d527f078064399ae35c08809c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Solution deployments are now asynchronous with job tracking and polling for status updates
  * Single-file push support in CLI for more granular file synchronization
  * Solution workspace detection prevents accidental global commands from running inside solution directories

* **Improvements**
  * Enhanced workflow validation during deployment to catch naming mismatches upfront
  * App validation now correctly handles v2 applications
  * Better progress reporting for non-interactive CLI environments with line-oriented output

* **Bug Fixes**
  * Workflow execution now properly resolves by function name instead of display name

<!-- end of auto-generated comment: release notes by coderabbit.ai -->