### PR TITLE
Trace workflow executions with OpenTelemetry

### DIFF
--- a/api/src/core/telemetry.py
+++ b/api/src/core/telemetry.py
@@ -1,0 +1,41 @@
+"""OpenTelemetry configuration helpers."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_configured_services: set[str] = set()
+
+
+def configure_opentelemetry(service_name: str, *, span_processor: str = "batch") -> None:
+    """Configure OTLP trace export when an endpoint is provided."""
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        return
+
+    if service_name in _configured_services:
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+    except ImportError as exc:
+        logger.warning("OpenTelemetry trace export unavailable for %s: %s", service_name, exc)
+        return
+
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=endpoint)
+
+    if span_processor == "simple":
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+    else:
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+
+    trace.set_tracer_provider(provider)
+    _configured_services.add(service_name)
+    logger.info("OpenTelemetry trace export configured for %s", service_name)

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -17,6 +17,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound, OperationalError
 
 from src.config import get_settings
 from src.core.sentry import configure_sentry
+from src.core.telemetry import configure_opentelemetry
 from src.models.contracts.common import ErrorResponse
 from src.core.csrf import CSRFMiddleware
 from src.core.embed_middleware import EmbedScopeMiddleware
@@ -125,6 +126,7 @@ async def app_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Startup
     logger.info("Starting Bifrost API...")
     settings = get_settings()
+    configure_opentelemetry("bifrost-api")
 
     # Initialize database
     logger.info("Initializing database connection...")

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -15,6 +15,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, get_type_hints, get_origin, get_args, Union
 
+from opentelemetry import trace
 from pydantic import BaseModel
 
 from src.sdk.context import Caller, ExecutionContext, Organization
@@ -25,6 +26,7 @@ from src.core.cache import get_cached_data_provider, cache_data_provider_result
 from src.core.secret_string import redact_secrets
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 def _human_size(num_bytes: int) -> str:
@@ -1071,8 +1073,26 @@ async def _execute_workflow_with_trace(
         # Set up trace function for variable capture
         sys.settrace(chained_trace_func if existing_trace else trace_func)
         try:
-            # Run the workflow directly - isolation is provided by subprocess
-            result = await _run_workflow_async()
+            span_attributes = {
+                "bifrost.execution.id": execution_id or context.execution_id,
+                "bifrost.workflow.name": context.workflow_name or func_name,
+                "bifrost.workflow.function": func_name,
+                "bifrost.execution.scope": context.scope,
+                "bifrost.execution.organization_id": context.org_id or "",
+                "bifrost.execution.is_platform_admin": context.is_platform_admin,
+            }
+            with tracer.start_as_current_span(
+                "bifrost.workflow.execute",
+                attributes=span_attributes,
+            ) as span:
+                try:
+                    # Run the workflow directly - isolation is provided by subprocess
+                    result = await _run_workflow_async()
+                    span.set_attribute("bifrost.execution.status", ExecutionStatus.SUCCESS.value)
+                except Exception as exc:
+                    span.set_attribute("bifrost.execution.status", ExecutionStatus.FAILED.value)
+                    span.set_attribute("bifrost.execution.error_type", type(exc).__name__)
+                    raise
         finally:
             # Clear trace function
             sys.settrace(None)

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -313,6 +313,10 @@ def _execute_sync(execution_id: str, worker_id: str) -> dict[str, Any]:
     Returns:
         Result dict with success, result, error, duration_ms, etc.
     """
+    from src.core.telemetry import configure_opentelemetry
+
+    configure_opentelemetry("bifrost-worker", span_processor="simple")
+
     try:
         result = asyncio.run(_execute_async(execution_id, worker_id))
         return result

--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -447,5 +447,9 @@ def run_in_worker(execution_id: str):
         format=f"[Worker:{execution_id[:8]}] %(levelname)s - %(message)s"
     )
 
+    from src.core.telemetry import configure_opentelemetry
+
+    configure_opentelemetry("bifrost-worker", span_processor="simple")
+
     # Run the async worker
     asyncio.run(worker_main(execution_id))

--- a/api/tests/unit/services/execution/test_engine_telemetry.py
+++ b/api/tests/unit/services/execution/test_engine_telemetry.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from src.models.enums import ExecutionStatus
+from src.sdk.context import ExecutionContext, Organization
+from src.services.execution import engine
+
+
+class _FakeSpan:
+    def __init__(self, name: str, attributes: dict):
+        self.name = name
+        self.attributes = dict(attributes)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def set_attribute(self, key: str, value):
+        self.attributes[key] = value
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.spans: list[_FakeSpan] = []
+
+    def start_as_current_span(self, name: str, attributes: dict):
+        span = _FakeSpan(name, attributes)
+        self.spans.append(span)
+        return span
+
+
+def _context() -> ExecutionContext:
+    return ExecutionContext(
+        user_id="user-1",
+        email="user@example.com",
+        name="User One",
+        scope="org-1",
+        organization=Organization(id="org-1", name="Org One"),
+        is_platform_admin=False,
+        is_function_key=False,
+        execution_id="exec-1",
+        workflow_name="status_snapshot",
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_execution_emits_success_span(monkeypatch):
+    fake_tracer = _FakeTracer()
+    monkeypatch.setattr(engine, "tracer", fake_tracer)
+
+    async def workflow(context):
+        return {"ok": True}
+
+    result, _, _ = await engine._execute_workflow_with_trace(
+        workflow,
+        _context(),
+        {},
+        execution_id="exec-1",
+    )
+
+    assert result == {"ok": True}
+    assert len(fake_tracer.spans) == 1
+    span = fake_tracer.spans[0]
+    assert span.name == "bifrost.workflow.execute"
+    assert span.attributes["bifrost.execution.id"] == "exec-1"
+    assert span.attributes["bifrost.workflow.name"] == "status_snapshot"
+    assert span.attributes["bifrost.workflow.function"] == "workflow"
+    assert span.attributes["bifrost.execution.organization_id"] == "org-1"
+    assert span.attributes["bifrost.execution.status"] == ExecutionStatus.SUCCESS.value
+
+
+@pytest.mark.asyncio
+async def test_workflow_execution_emits_failed_span(monkeypatch):
+    fake_tracer = _FakeTracer()
+    monkeypatch.setattr(engine, "tracer", fake_tracer)
+
+    async def workflow(context):
+        raise RuntimeError("boom")
+
+    with pytest.raises(Exception):
+        await engine._execute_workflow_with_trace(
+            workflow,
+            _context(),
+            {},
+        )
+
+    assert len(fake_tracer.spans) == 1
+    span = fake_tracer.spans[0]
+    assert span.attributes["bifrost.execution.id"] == "exec-1"
+    assert span.attributes["bifrost.execution.status"] == ExecutionStatus.FAILED.value
+    assert span.attributes["bifrost.execution.error_type"] == "RuntimeError"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,8 @@ dependencies = [
     "python-json-logger",
     "structlog",
     "sentry-sdk[fastapi]",
+    "opentelemetry-sdk==1.41.1",
+    "opentelemetry-exporter-otlp-proto-grpc==1.41.1",
     "psutil",  # Process monitoring for worker heartbeats
 
     # =========================================================================

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,6 +12,10 @@ aiofile==3.9.0 \
     --hash=sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa \
     --hash=sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b
     # via py-key-value-aio
+aiofiles==25.1.0 \
+    --hash=sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2 \
+    --hash=sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695
+    # via bifrost-api (pyproject.toml)
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
     --hash=sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8
@@ -884,6 +888,50 @@ docutils==0.22.4 \
     --hash=sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968 \
     --hash=sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de
     # via rich-rst
+dulwich==1.2.0 \
+    --hash=sha256:001a523ce152b1ec78868192f72abbbad79c3576bb29f506586f57e71c2a0d7f \
+    --hash=sha256:007a28a1ea80e09e352f5d856748b7d68507ba35d9b371870f2e3dd9a966c611 \
+    --hash=sha256:01445379a257f2b4efc5b052a78c36f548cc89c9118328959222cb3bec6299ed \
+    --hash=sha256:03c5d1f437dcd61d94f9feba0123eac3b69e7b4635cc2d093686b1b6dbe885ec \
+    --hash=sha256:0939506a171a4f940643d6707746663aab38f2aa5e92c9dd2adcf37050aeeb10 \
+    --hash=sha256:20abb86f848c1b9834d5db157236dfcce1e201edf051779c9c85a72250861558 \
+    --hash=sha256:24782814579f47377fb424d70f23e3879f3a3a2fd2c37cbf21154465ac0cc9f3 \
+    --hash=sha256:24d14a7e4cf6a0cfa8ac389f768b541ef4a0ea63d557369015346bdeb097f89f \
+    --hash=sha256:27e996f17e27902156510f4c25de668dadb18b584bdf62bbe576c66e20087060 \
+    --hash=sha256:28b66382d3eb641716b8309fca710735a81d817dd64184f3882d919da16511b7 \
+    --hash=sha256:34a753d8f1a180a4ae360788707d2bd6b885affd542b40f90d678870c99a0756 \
+    --hash=sha256:34eb006da077173d17cbed78f66213ca66ed5c8fe53e19d721a49fe448d04584 \
+    --hash=sha256:36e2031b95b925c777de259441d7c7a9cd9665c584b7ddffaacaa7643124956f \
+    --hash=sha256:3c5f0e8f3bb617b827840280b0382e53b24aea35de2a22d8f40a07dd9a8b0ec5 \
+    --hash=sha256:42c30d97175324d6066070ecbbf27e624202b3377f8ede03088ef3d42cf4c2db \
+    --hash=sha256:47d1207e3585024772d798a683f79bd862c878a726817a1ce8e16ff1d2f4ffb8 \
+    --hash=sha256:49963c23f93601b8b43c3e9ee204bd2f8f25b4fcd22aaadfe21fa79f394107d8 \
+    --hash=sha256:57eba7939f0579b98feae6efc7adcc8ba34592a30b018a4922fe745373c976cb \
+    --hash=sha256:5948faa66b0e9185c9f07602dbe5ba0cd92fdda397e5303964fb53aada7746fe \
+    --hash=sha256:5dedff29bab8a74152cf780f6e9d33b3955a8dd8696eee48e8418a25fd3c9bf1 \
+    --hash=sha256:6024cf63f7d57d2ad6c6bdf3a156a9b6bc079a9536dfe3fae52862b000c38f31 \
+    --hash=sha256:62bfcd5cab75b2241d7180aa2fd1782d615f1dfd6c0191561509b124064cc619 \
+    --hash=sha256:64ed5080c88dad6da70aa9a2e6a48dd2e9b0aa06c9eefc25e5d24e4e32bc4c00 \
+    --hash=sha256:75934f4b61508cf3f81fb1f059f7d3b6d8d770e471999fc37c40c633f5d427e1 \
+    --hash=sha256:7eca8c569f950d9c9fbc4ffdeceae01fed923d7a0b06922c93f7ce08a0b54c0c \
+    --hash=sha256:944a9c5e0533cdd6d16085b932f11bf440ff1bfc0c4684ada3b60070d3df656b \
+    --hash=sha256:9b3d1c49004080aabcad4cef982e678887c6c2f178cc681f03094aba791f4cfe \
+    --hash=sha256:ad453f45cf941e768a8e4868220e80c5e91fca4f50b662d2be60fe5467d81aed \
+    --hash=sha256:b3c3dd4bb99961cbdb9311c1fd9b03e3cf17d26d8b68e984561896a003452328 \
+    --hash=sha256:c11f7578e29545d0d0308f56f1d3da741e11db2494c6126792aee5e121d659af \
+    --hash=sha256:c97f67baac9cac70e1b4b55cf31b0bf0d42ef7361197637a5e5658cd23699326 \
+    --hash=sha256:d28ee76464f750248a2eea1f859d654f8b23c64e712fb6bdfbd23de73e56dff8 \
+    --hash=sha256:db600dae670f2b6402c2a6f201dcd9f54893a18d33262f51815de5efd99ba97e \
+    --hash=sha256:dfe3abf0364b260c593978830bc320e8dd99250260efa6476888f9479f367691 \
+    --hash=sha256:dfe6b4dcfb9ac83d6861e18343c9d1fae98288f9ec685bffb0d4dcfea1d9cfce \
+    --hash=sha256:e86ad1d93ef5046a7286458dd29e64e51a8e6199cc312209dc2dda3d67dd62ae \
+    --hash=sha256:e9513b59b7c6244dbe9bc1136e41171ba58a87ffd1298e55fcd284eabb1870be \
+    --hash=sha256:e9d0a318473776dc1e134eb3c48ea77ef6a0f5c4648677abc85dfe717a2b238e \
+    --hash=sha256:ec9c0cad2971e4a64e482c54aac0f413401f8c221123766e8e97b258d61ac8a6 \
+    --hash=sha256:ecd807308820425ec5456fb3a0d092f0391c116aea8bc2c4c7bf813a81387984 \
+    --hash=sha256:ee454672b74c9c281377515a024962942fd558748bb116ea3574e633d75e3bab \
+    --hash=sha256:fd650a9568ff02c0c3bc2582502a07b58c09c5dcb41b385ae1789b1558b44a4c
+    # via bifrost-api (pyproject.toml)
 email-validator==2.3.0 \
     --hash=sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4 \
     --hash=sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426
@@ -1046,6 +1094,10 @@ gitpython==3.1.50 \
     --hash=sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc \
     --hash=sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9
     # via bifrost-api (pyproject.toml)
+googleapis-common-protos==1.75.0 \
+    --hash=sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd \
+    --hash=sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed
+    # via opentelemetry-exporter-otlp-proto-grpc
 greenlet==3.4.0 \
     --hash=sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267 \
     --hash=sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2 \
@@ -1113,6 +1165,59 @@ griffelib==2.0.2 \
     --hash=sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e \
     --hash=sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1
     # via fastmcp
+grpcio==1.81.1 \
+    --hash=sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854 \
+    --hash=sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2 \
+    --hash=sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3 \
+    --hash=sha256:15641444eca4a29358107b3dceb74c1c6305c55c822fd199b458aaea4068a7fb \
+    --hash=sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad \
+    --hash=sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2 \
+    --hash=sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0 \
+    --hash=sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7 \
+    --hash=sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79 \
+    --hash=sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821 \
+    --hash=sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94 \
+    --hash=sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6 \
+    --hash=sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5 \
+    --hash=sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b \
+    --hash=sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7 \
+    --hash=sha256:592b5fee597faa91cce2dd294dd7d9a1c83d76c4dbf877e33ec1adb866b2fbed \
+    --hash=sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f \
+    --hash=sha256:62481553b1793a27e9b9c3cf9e5bd483ef045ca72462592074b46d42b0c4d9b9 \
+    --hash=sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416 \
+    --hash=sha256:69ef28e54fc85397f91b8c19592b8ef3d81952080366914823bd8572a2958120 \
+    --hash=sha256:6f9a0c9c1cc15c112d1c053064fd032b64917062292c3d70aea280e02ae10b77 \
+    --hash=sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b \
+    --hash=sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0 \
+    --hash=sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42 \
+    --hash=sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e \
+    --hash=sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf \
+    --hash=sha256:88268ca418cacea64cecb0d1d600d3c6b3a8038fcba02e1e205178c5b1f47661 \
+    --hash=sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115 \
+    --hash=sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c \
+    --hash=sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5 \
+    --hash=sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6 \
+    --hash=sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70 \
+    --hash=sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a \
+    --hash=sha256:aa2ba7d2ad6df4d80127cea65e5b8d5e2c3adbf153ff4804452836328aca7c54 \
+    --hash=sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe \
+    --hash=sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137 \
+    --hash=sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3 \
+    --hash=sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190 \
+    --hash=sha256:bb693b1e3d9a2f3fd228e2110daf4b5aeedb36761ca1e4282f74725f6d89f611 \
+    --hash=sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb \
+    --hash=sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0 \
+    --hash=sha256:ca1cc11d82677b9662082e5478b7528e2b7db7beaa6bdff42bd62789d81be399 \
+    --hash=sha256:d4b2dddfc219f54f956ccd53cf76a1d338ffe68fc7f2849ec9c7feb9927ff692 \
+    --hash=sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f \
+    --hash=sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e \
+    --hash=sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27 \
+    --hash=sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5 \
+    --hash=sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae \
+    --hash=sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14 \
+    --hash=sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60 \
+    --hash=sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49
+    # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
@@ -1813,7 +1918,35 @@ openapi-pydantic==0.5.1 \
 opentelemetry-api==1.41.1 \
     --hash=sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621 \
     --hash=sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f
-    # via fastmcp
+    # via
+    #   fastmcp
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1 \
+    --hash=sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb \
+    --hash=sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9
+    # via opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-exporter-otlp-proto-grpc==1.41.1 \
+    --hash=sha256:537926dcef951136992479af1d9cd88f25e33d56c530e9f020ed57774dca2f94 \
+    --hash=sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b
+    # via bifrost-api (pyproject.toml)
+opentelemetry-proto==1.41.1 \
+    --hash=sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720 \
+    --hash=sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-sdk==1.41.1 \
+    --hash=sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6 \
+    --hash=sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d
+    # via
+    #   bifrost-api (pyproject.toml)
+    #   opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-semantic-conventions==0.62b1 \
+    --hash=sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802 \
+    --hash=sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c
+    # via opentelemetry-sdk
 packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
     --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
@@ -1974,6 +2107,20 @@ propcache==0.4.1 \
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6 \
+    --hash=sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326 \
+    --hash=sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901 \
+    --hash=sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3 \
+    --hash=sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a \
+    --hash=sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135 \
+    --hash=sha256:bd56799fb262994b2c2faa1799693c95cc2e22c62f56fb43af311cae45d26f0e \
+    --hash=sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3 \
+    --hash=sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2 \
+    --hash=sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593 \
+    --hash=sha256:f443a394af5ed23672bc6c486be138628fbe5c651ccbc536873d7da23d1868cf
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2 \
     --hash=sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372 \
     --hash=sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9 \
@@ -2801,6 +2948,10 @@ starlette==1.0.0 \
     #   fastapi
     #   mcp
     #   sse-starlette
+structlog==25.5.0 \
+    --hash=sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98 \
+    --hash=sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f
+    # via bifrost-api (pyproject.toml)
 textual==8.2.4 \
     --hash=sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba \
     --hash=sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4
@@ -2833,9 +2984,13 @@ typing-extensions==4.15.0 \
     #   azure-identity
     #   azure-storage-blob
     #   fastapi
+    #   grpcio
     #   mcp
     #   openai
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   py-key-value-aio
     #   pydantic
     #   pydantic-core
@@ -2869,6 +3024,7 @@ urllib3==2.7.0 \
     # via
     #   bifrost-api (pyproject.toml)
     #   botocore
+    #   dulwich
     #   pygithub
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
## Summary
- configure OTLP trace export for API and worker processes when OTEL_EXPORTER_OTLP_ENDPOINT is set
- add workflow execution spans around engine execution with execution/workflow/status attributes
- add targeted unit coverage for success and failure span attributes
- add pinned OpenTelemetry SDK/exporter dependencies to pyproject.toml and requirements.lock

## Verification
- uv run python -m pytest api/tests/unit/services/execution/test_engine_telemetry.py api/tests/unit/services/execution/test_service.py
- uv run ruff check api/src/core/telemetry.py api/src/main.py api/src/services/execution/engine.py api/src/services/execution/worker.py api/src/services/execution/simple_worker.py api/tests/unit/services/execution/test_engine_telemetry.py
- live proof from earlier proof image: collector logged trace 82615b1775a7ddf21876210f3fa46951 for execution df0231c2-0b8c-4086-9d11-bc28b0655284 workflow handle_ninjaone_alert status Success

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only path gated on an env var; execution logic is unchanged aside from span wrapping, with graceful no-op if OTEL packages or endpoint are missing.
> 
> **Overview**
> Adds **optional OpenTelemetry trace export** when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, without changing behavior when it is unset.
> 
> A shared helper in `telemetry.py` wires a gRPC OTLP exporter with batch processing for the API (`bifrost-api` at lifespan startup) and **simple** processors in worker entry points (`bifrost-worker` in `worker.py` and `simple_worker.py`). Each service name is configured once per process.
> 
> Workflow runs in the execution engine are wrapped in a **`bifrost.workflow.execute`** span with `bifrost.*` attributes (execution id, workflow name/function, org scope, success/failure status, error type). Dependencies are pinned in `pyproject.toml` / `requirements.lock`, with unit tests asserting success and failure span attributes via a fake tracer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e63ca9d514f6c61ae702dc0ac4adda3f41e4d38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application tracing support for better visibility into startup and workflow activity.
  * Enabled telemetry collection in background worker runs for more complete monitoring.

* **Bug Fixes**
  * Improved tracing reliability so execution status and errors are captured consistently during workflow runs.

* **Tests**
  * Added coverage for successful and failed traced executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->