### PR TITLE
Trace workflow enqueue boundary

### DIFF
--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -18,6 +18,8 @@ import logging
 import uuid
 from typing import Any
 
+from opentelemetry import trace
+
 from src.core.constants import SYSTEM_USER_ID, SYSTEM_USER_EMAIL
 from src.core.log_safety import log_safe
 from src.core.redis_client import get_redis_client
@@ -26,6 +28,7 @@ from src.sdk.context import EventContext, ExecutionContext
 from src.services.execution.queue_tracker import add_to_queue
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 QUEUE_NAME = "workflow-executions"
 
@@ -54,41 +57,61 @@ async def _publish_pending(
     execution promoter. Callers are responsible for generating execution_id
     before calling this helper.
     """
-    redis_client = get_redis_client()
-
-    # Store pending execution in Redis (worker needs this for execution context)
-    await redis_client.set_pending_execution(
-        execution_id=execution_id,
-        workflow_id=workflow_id,
-        parameters=parameters,
-        org_id=org_id,
-        user_id=user_id,
-        user_name=user_name,
-        user_email=user_email,
-        form_id=form_id,
-        startup=startup,
-        api_key_id=api_key_id,
-        sync=sync,
-        is_platform_admin=is_platform_admin,
-        event=event,
-    )
-
-    # Add to queue tracking (publishes position updates to all queued executions)
-    await add_to_queue(execution_id)
-
-    # Prepare queue message (minimal - worker reads full context from Redis)
-    message: dict[str, Any] = {
-        "execution_id": execution_id,
-        "workflow_id": workflow_id,
-        "sync": sync,
+    span_attributes = {
+        "bifrost.execution.id": execution_id,
+        "bifrost.workflow.id": workflow_id or "",
+        "bifrost.execution.organization_id": org_id or "",
+        "bifrost.execution.sync": sync,
+        "bifrost.execution.is_platform_admin": is_platform_admin,
+        "bifrost.execution.has_file_path": bool(file_path),
+        "messaging.system": "rabbitmq",
+        "messaging.destination.name": QUEUE_NAME,
     }
+    if event:
+        span_attributes["bifrost.execution.event.source"] = str(event.get("source") or "")
 
-    # Include file_path for fast direct loading (avoids filesystem scan)
-    if file_path:
-        message["file_path"] = file_path
+    with tracer.start_as_current_span("bifrost.workflow.enqueue", attributes=span_attributes) as span:
+        try:
+            redis_client = get_redis_client()
 
-    # Enqueue message via RabbitMQ
-    await publish_message(QUEUE_NAME, message)
+            # Store pending execution in Redis (worker needs this for execution context)
+            await redis_client.set_pending_execution(
+                execution_id=execution_id,
+                workflow_id=workflow_id,
+                parameters=parameters,
+                org_id=org_id,
+                user_id=user_id,
+                user_name=user_name,
+                user_email=user_email,
+                form_id=form_id,
+                startup=startup,
+                api_key_id=api_key_id,
+                sync=sync,
+                is_platform_admin=is_platform_admin,
+                event=event,
+            )
+
+            # Add to queue tracking (publishes position updates to all queued executions)
+            await add_to_queue(execution_id)
+
+            # Prepare queue message (minimal - worker reads full context from Redis)
+            message: dict[str, Any] = {
+                "execution_id": execution_id,
+                "workflow_id": workflow_id,
+                "sync": sync,
+            }
+
+            # Include file_path for fast direct loading (avoids filesystem scan)
+            if file_path:
+                message["file_path"] = file_path
+
+            # Enqueue message via RabbitMQ
+            await publish_message(QUEUE_NAME, message)
+            span.set_attribute("bifrost.execution.enqueue.status", "queued")
+        except Exception as exc:
+            span.set_attribute("bifrost.execution.enqueue.status", "failed")
+            span.set_attribute("bifrost.execution.error_type", type(exc).__name__)
+            raise
 
 
 async def enqueue_workflow_execution(

--- a/api/tests/unit/services/execution/test_async_executor.py
+++ b/api/tests/unit/services/execution/test_async_executor.py
@@ -2,7 +2,33 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.services.execution import async_executor
 from src.services.execution.async_executor import _publish_pending
+
+
+class _FakeSpan:
+    def __init__(self, name: str, attributes: dict):
+        self.name = name
+        self.attributes = dict(attributes)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def set_attribute(self, key: str, value):
+        self.attributes[key] = value
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.spans: list[_FakeSpan] = []
+
+    def start_as_current_span(self, name: str, attributes: dict):
+        span = _FakeSpan(name, attributes)
+        self.spans.append(span)
+        return span
 
 
 @pytest.mark.asyncio
@@ -35,6 +61,77 @@ async def test_publish_pending_writes_redis_then_publishes():
     queue_name, message = pub.await_args.args
     assert queue_name == "workflow-executions"
     assert message == {"execution_id": "e1", "workflow_id": "wf", "sync": False}
+
+
+@pytest.mark.asyncio
+async def test_publish_pending_emits_enqueue_span(monkeypatch):
+    fake_tracer = _FakeTracer()
+    monkeypatch.setattr(async_executor, "tracer", fake_tracer)
+    redis = AsyncMock()
+    with (
+        patch("src.services.execution.async_executor.get_redis_client", return_value=redis),
+        patch("src.services.execution.async_executor.add_to_queue", new=AsyncMock()),
+        patch("src.services.execution.async_executor.publish_message", new=AsyncMock()),
+    ):
+        await _publish_pending(
+            execution_id="e1",
+            workflow_id="wf",
+            parameters={},
+            org_id="org",
+            user_id="u",
+            user_name="Name",
+            user_email="n@e",
+            form_id=None,
+            startup=None,
+            api_key_id=None,
+            sync=True,
+            is_platform_admin=False,
+            file_path="workflows/foo.py",
+            event={"source": "topic"},
+        )
+
+    assert len(fake_tracer.spans) == 1
+    span = fake_tracer.spans[0]
+    assert span.name == "bifrost.workflow.enqueue"
+    assert span.attributes["bifrost.execution.id"] == "e1"
+    assert span.attributes["bifrost.workflow.id"] == "wf"
+    assert span.attributes["bifrost.execution.organization_id"] == "org"
+    assert span.attributes["bifrost.execution.sync"] is True
+    assert span.attributes["bifrost.execution.has_file_path"] is True
+    assert span.attributes["bifrost.execution.event.source"] == "topic"
+    assert span.attributes["bifrost.execution.enqueue.status"] == "queued"
+
+
+@pytest.mark.asyncio
+async def test_publish_pending_marks_enqueue_span_failed(monkeypatch):
+    fake_tracer = _FakeTracer()
+    monkeypatch.setattr(async_executor, "tracer", fake_tracer)
+    redis = AsyncMock()
+    with (
+        patch("src.services.execution.async_executor.get_redis_client", return_value=redis),
+        patch("src.services.execution.async_executor.add_to_queue", new=AsyncMock(side_effect=RuntimeError("full"))),
+        patch("src.services.execution.async_executor.publish_message", new=AsyncMock()),
+    ):
+        with pytest.raises(RuntimeError):
+            await _publish_pending(
+                execution_id="e1",
+                workflow_id="wf",
+                parameters={},
+                org_id="org",
+                user_id="u",
+                user_name="Name",
+                user_email="n@e",
+                form_id=None,
+                startup=None,
+                api_key_id=None,
+                sync=False,
+                is_platform_admin=False,
+                file_path=None,
+            )
+
+    span = fake_tracer.spans[0]
+    assert span.attributes["bifrost.execution.enqueue.status"] == "failed"
+    assert span.attributes["bifrost.execution.error_type"] == "RuntimeError"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an OpenTelemetry span around the async workflow enqueue boundary
- tag the span with execution, workflow, org, queue, sync, file-path, and enqueue status attributes
- cover queued and failed enqueue span behavior with focused unit tests

## Verification
- uv run ruff check api/src/services/execution/async_executor.py api/tests/unit/services/execution/test_async_executor.py
- uv run python -m pytest api/tests/unit/services/execution/test_async_executor.py api/tests/unit/services/execution/test_engine_telemetry.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only wrapping of existing enqueue logic; no changes to Redis, RabbitMQ, or execution semantics.
> 
> **Overview**
> Adds **OpenTelemetry** instrumentation around `_publish_pending`, the shared path that writes pending executions to Redis, registers queue position, and publishes to RabbitMQ.
> 
> A span named `bifrost.workflow.enqueue` records execution/workflow/org IDs, sync and platform-admin flags, whether a `file_path` is present, RabbitMQ destination metadata, optional event source, and a final **`bifrost.execution.enqueue.status`** of `queued` or `failed` (with `error_type` on failure). Enqueue behavior is unchanged; only tracing wraps the existing try/except.
> 
> Unit tests use a fake tracer to assert span name, attributes on success, and failed status when `add_to_queue` raises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29494859a3eb739eeeb20adf68fa2470164593c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->