### PR TITLE
Trace worker execution boundary

### DIFF
--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -28,6 +28,8 @@ from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlunparse
 
+from opentelemetry import trace
+
 # Install virtual import hook IMMEDIATELY at module load time.
 # This must happen before any workspace imports (e.g., from shared import ...)
 # The hook intercepts imports and loads modules from Redis cache.
@@ -36,6 +38,7 @@ from src.services.execution.virtual_import import install_virtual_import_hook
 install_virtual_import_hook()
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 def _default_internal_api_url() -> str:
@@ -92,6 +95,19 @@ def _capture_metrics(start_rss: int, start_utime: float, start_stime: float) -> 
         cpu_system_seconds=round(cpu_system, 4),
         cpu_total_seconds=round(cpu_user + cpu_system, 4),
     )
+
+
+def _annotate_worker_span(span: Any, result: dict[str, Any]) -> None:
+    """Attach terminal worker execution facts to the active span."""
+    span.set_attribute("bifrost.worker.status", str(result.get("status") or ""))
+    span.set_attribute("bifrost.worker.duration_ms", int(result.get("duration_ms") or 0))
+    if result.get("error_type"):
+        span.set_attribute("bifrost.worker.error_type", str(result["error_type"]))
+
+    metrics = result.get("metrics") or {}
+    if metrics:
+        span.set_attribute("bifrost.worker.peak_memory_bytes", int(metrics.get("peak_memory_bytes") or 0))
+        span.set_attribute("bifrost.worker.cpu_total_seconds", float(metrics.get("cpu_total_seconds") or 0.0))
 
 
 def _setup_signal_handlers():
@@ -168,6 +184,19 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
             _exec_solution_id,
             global_repo_access=bool(context_data.get("solution_global_repo_access", False)),
         )
+
+    span_attributes = {
+        "bifrost.execution.id": execution_id,
+        "bifrost.workflow.name": str(context_data.get("name") or ""),
+        "bifrost.workflow.function": str(context_data.get("function_name") or ""),
+        "bifrost.execution.organization_id": str((context_data.get("organization") or {}).get("id") or ""),
+        "bifrost.worker.is_script": bool(context_data.get("code")),
+        "bifrost.worker.has_file_path": bool(context_data.get("file_path")),
+        "bifrost.worker.solution_id": str(context_data.get("solution_id") or ""),
+    }
+
+    span_context = tracer.start_as_current_span("bifrost.worker.execute", attributes=span_attributes)
+    span = span_context.__enter__()
 
     try:
         # Reconstruct Organization
@@ -257,7 +286,7 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
                 # Use the actual error if available, otherwise fall back to generic message
                 error_msg = load_error or f"Executable '{name}' not found"
                 error_type = "WorkflowLoadError" if load_error else "ExecutableNotFound"
-                return {
+                result = {
                     "status": ExecutionStatus.FAILED.value,
                     "error_message": error_msg,
                     "error_type": error_type,
@@ -272,6 +301,8 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
                         "cpu_total_seconds": metrics.cpu_total_seconds,
                     },
                 }
+                _annotate_worker_span(span, result)
+                return result
 
         # Reconstruct EventContext for event-triggered executions
         event_ctx = None
@@ -309,7 +340,7 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
         metrics = _capture_metrics(start_rss, start_utime, start_stime)
 
         # Convert result to dict for serialization
-        return {
+        result = {
             "status": exec_result.status.value,
             "result": exec_result.result,
             "duration_ms": exec_result.duration_ms,
@@ -329,6 +360,8 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
                 "cpu_total_seconds": metrics.cpu_total_seconds,
             },
         }
+        _annotate_worker_span(span, result)
+        return result
 
     except Exception as e:
         import traceback
@@ -338,7 +371,7 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
         # Still capture metrics even on failure
         metrics = _capture_metrics(start_rss, start_utime, start_stime)
 
-        return {
+        result = {
             "status": ExecutionStatus.FAILED.value,
             "error_message": str(e),
             "error_type": type(e).__name__,
@@ -354,11 +387,14 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
                 "cpu_total_seconds": metrics.cpu_total_seconds,
             },
         }
+        _annotate_worker_span(span, result)
+        return result
 
     finally:
         # Always clear the solution import root — a forked worker is reused for
         # later executions and must not inherit this one's root.
         clear_solution_context()
+        span_context.__exit__(*sys.exc_info())
 
 
 async def worker_main(execution_id: str):

--- a/api/tests/unit/services/execution/test_worker_telemetry.py
+++ b/api/tests/unit/services/execution/test_worker_telemetry.py
@@ -1,0 +1,98 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.models.enums import ExecutionStatus
+
+
+if "resource" not in sys.modules:
+    resource = ModuleType("resource")
+    resource.RUSAGE_SELF = 0
+    resource.getrusage = lambda _who: SimpleNamespace(ru_maxrss=123, ru_utime=1.0, ru_stime=0.5)
+    sys.modules["resource"] = resource
+
+from src.services.execution import worker  # noqa: E402
+
+
+class _FakeSpan:
+    def __init__(self, name: str, attributes: dict):
+        self.name = name
+        self.attributes = dict(attributes)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def set_attribute(self, key: str, value):
+        self.attributes[key] = value
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.spans: list[_FakeSpan] = []
+
+    def start_as_current_span(self, name: str, attributes: dict):
+        span = _FakeSpan(name, attributes)
+        self.spans.append(span)
+        return span
+
+
+@pytest.mark.asyncio
+async def test_run_execution_emits_worker_span(monkeypatch):
+    fake_tracer = _FakeTracer()
+    monkeypatch.setattr(worker, "tracer", fake_tracer)
+
+    result = SimpleNamespace(
+        status=ExecutionStatus.SUCCESS,
+        result={"ok": True},
+        duration_ms=42,
+        logs=[],
+        variables={},
+        integration_calls=[],
+        roi=None,
+        error_message=None,
+        error_type=None,
+        cached=False,
+        cache_expires_at=None,
+        execution_context={"execution_id": "exec-1"},
+    )
+
+    context_data = {
+        "code": "result = {'ok': True}",
+        "name": "script_one",
+        "caller": {"user_id": "user-1", "email": "user@example.test", "name": "User One"},
+        "organization": {"id": "org-1", "name": "Org One"},
+        "parameters": {"x": 1},
+        "tags": ["workflow"],
+        "timeout_seconds": 30,
+        "cache_ttl_seconds": 300,
+        "transient": False,
+        "no_cache": False,
+        "is_platform_admin": False,
+    }
+
+    with (
+        patch("bifrost.credentials.is_token_expired", return_value=False),
+        patch("src.core.module_cache_sync.set_solution_context"),
+        patch("src.core.module_cache_sync.clear_solution_context"),
+        patch("src.services.execution.engine.execute", new=AsyncMock(return_value=result)),
+    ):
+        payload = await worker._run_execution("exec-1", context_data)
+
+    assert payload["status"] == ExecutionStatus.SUCCESS.value
+    assert len(fake_tracer.spans) == 1
+    span = fake_tracer.spans[0]
+    assert span.name == "bifrost.worker.execute"
+    assert span.attributes["bifrost.execution.id"] == "exec-1"
+    assert span.attributes["bifrost.workflow.name"] == "script_one"
+    assert span.attributes["bifrost.execution.organization_id"] == "org-1"
+    assert span.attributes["bifrost.worker.is_script"] is True
+    assert span.attributes["bifrost.worker.has_file_path"] is False
+    assert span.attributes["bifrost.worker.status"] == ExecutionStatus.SUCCESS.value
+    assert span.attributes["bifrost.worker.duration_ms"] == 42
+    assert span.attributes["bifrost.worker.peak_memory_bytes"] >= 0
+    assert span.attributes["bifrost.worker.cpu_total_seconds"] >= 0

--- a/docs/runbooks/otel-platform-observability.md
+++ b/docs/runbooks/otel-platform-observability.md
@@ -1,0 +1,98 @@
+# Bifrost OpenTelemetry Platform Observability
+
+This is the operating plan for using OpenTelemetry as Bifrost platform
+telemetry, not just trace decoration.
+
+## Goal
+
+Every workflow execution should answer these questions from one trace:
+
+- Did the API accept and enqueue the execution?
+- Did a worker pick it up?
+- Did worker setup, module/cache loading, or the workflow body consume the time?
+- Did it fail because of platform infrastructure, workflow code, or a dependency?
+- Which namespace, service, and image version produced the span?
+
+## Current Trace Shape
+
+The first useful trace path is:
+
+1. `bifrost.workflow.enqueue` from the API process.
+2. `bifrost.worker.execute` from the worker process.
+3. `bifrost.workflow.execute` from the execution engine.
+
+The shared join key is `bifrost.execution.id`. Use `bifrost.workflow.name`,
+`bifrost.workflow.function`, and `bifrost.execution.organization_id` for
+filtering, not for high-cardinality aggregation.
+
+## Consumption Model
+
+Keep the collector as the ingestion boundary and add a real trace backend behind
+it. The recommended progression is:
+
+1. **Debug exporter only** while proving span content in PoC.
+2. **Grafana Tempo** for durable trace storage once spans are useful.
+3. **Grafana dashboards** that link OpenCost namespace spend to trace examples.
+4. **Log correlation** by adding trace IDs to structured logs after the trace
+   shape is stable.
+
+Tempo is the right next backend because it is cheaper to operate than a heavy
+APM stack, works cleanly behind the OpenTelemetry Collector, and gives us a
+direct path to Grafana panels and trace search. Jaeger remains useful for local
+developer debugging, but it should not be the durable cluster store.
+
+## Day-To-Day Use
+
+For a failed or slow execution:
+
+1. Start with the execution ID from Bifrost history.
+2. Search traces by `bifrost.execution.id`.
+3. Compare span durations:
+   - API enqueue high: Redis/RabbitMQ publish path.
+   - Gap before worker span: queue depth, KEDA scale-out, or worker availability.
+   - Worker span high before workflow span: context read, module cache, auth, or
+     setup.
+   - Workflow span high: user workflow, SDK calls, integrations, or data
+     provider cache misses.
+4. If the trace points to platform capacity, compare with OpenCost namespace
+   allocation and worker scaling history.
+5. If the trace points to policy drift, check Kyverno reports for the namespace
+   before changing manifests.
+
+## Attribute Rules
+
+Allowed high-cardinality fields:
+
+- `bifrost.execution.id`
+- `bifrost.workflow.id`
+
+Allowed filter fields:
+
+- `bifrost.workflow.name`
+- `bifrost.workflow.function`
+- `bifrost.execution.organization_id`
+- `bifrost.execution.status`
+- `bifrost.execution.error_type`
+- `bifrost.worker.is_script`
+- `bifrost.worker.has_file_path`
+
+Do not emit secrets, parameters, request bodies, ticket content, log lines, or
+raw results as span attributes.
+
+## Next Instrumentation Slices
+
+1. Add queue wait timing by carrying an enqueue timestamp into the worker
+   context.
+2. Split worker setup into child spans for context read, module cache load, and
+   workflow function load.
+3. Add integration-call spans with provider, status, duration, and sanitized
+   error type.
+4. Add data-provider cache spans for hit/miss, load duration, and write duration.
+5. Add trace ID to execution logs so Bifrost history can deep-link to Tempo.
+
+## Maturity Gate
+
+Do not make OTel mandatory for production startup. Runtime behavior must remain
+unchanged when `OTEL_EXPORTER_OTLP_ENDPOINT` is absent. Treat telemetry export as
+best-effort until the collector, backend, retention, and dashboards are proven
+in the AKS lane.


### PR DESCRIPTION
## Summary
- add a worker-side OpenTelemetry span around _run_execution
- annotate worker spans with execution/workflow/org shape, script/file-path flags, status, duration, memory, and CPU facts
- document the Bifrost platform OTel plan and consumption model: enqueue -> worker -> workflow, collector now, Tempo/Grafana next

## Plan of action
1. Keep OTEL_EXPORTER_OTLP_ENDPOINT optional and treat export as best-effort.
2. Use ifrost.execution.id as the join key across API enqueue, worker execute, and workflow execute spans.
3. Add Tempo behind the collector for durable trace search once PoC span content is stable.
4. Add queue wait timing, child spans for worker setup/module loading, integration-call spans, and data-provider cache spans in later slices.
5. Link Bifrost execution history to traces once trace IDs are available in logs/results.

## Verification
- uv run ruff check api/src/services/execution/worker.py api/tests/unit/services/execution/test_worker_telemetry.py api/tests/unit/services/execution/test_async_executor.py api/tests/unit/services/execution/test_engine_telemetry.py
- uv run python -m pytest api/tests/unit/services/execution/test_worker_telemetry.py api/tests/unit/services/execution/test_async_executor.py api/tests/unit/services/execution/test_engine_telemetry.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes around existing execution paths; behavior is unchanged when OTLP is not configured, with unit tests covering span emission.
> 
> **Overview**
> Adds the **worker** leg of the execution trace so a single `bifrost.execution.id` can link API enqueue, worker pickup, and engine workflow spans.
> 
> **Worker (`_run_execution`)** opens a `bifrost.worker.execute` span with execution/workflow/org context and script vs file-path flags. On every exit path (success, load failure, or exception), `_annotate_worker_span` records status, duration, optional error type, and resource metrics (peak memory, CPU). The span is closed in `finally` alongside existing solution-context cleanup.
> 
> **Tests** assert span name and expected attributes for a scripted run.
> 
> **Docs** add `docs/runbooks/otel-platform-observability.md`: trace shape, Tempo/Grafana consumption path, attribute rules (no secrets/parameters in spans), and follow-up slices (queue wait, child spans, log correlation). OTel remains optional when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef44f5c4154521939f1aa24843d7bba817612ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->