### PR TITLE
Record workflow queue wait in OTel spans

### DIFF
--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -110,6 +110,19 @@ def _annotate_worker_span(span: Any, result: dict[str, Any]) -> None:
         span.set_attribute("bifrost.worker.cpu_total_seconds", float(metrics.get("cpu_total_seconds") or 0.0))
 
 
+def _queue_wait_ms(created_at: str | None, now: datetime | None = None) -> int | None:
+    if not created_at:
+        return None
+    try:
+        enqueued_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if enqueued_at.tzinfo is None:
+        enqueued_at = enqueued_at.replace(tzinfo=timezone.utc)
+    observed_at = now or datetime.now(timezone.utc)
+    return max(0, int((observed_at - enqueued_at).total_seconds() * 1000))
+
+
 def _setup_signal_handlers():
     """Set up signal handlers for graceful shutdown."""
     def handle_sigterm(signum, frame):
@@ -194,6 +207,9 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
         "bifrost.worker.has_file_path": bool(context_data.get("file_path")),
         "bifrost.worker.solution_id": str(context_data.get("solution_id") or ""),
     }
+    queue_wait_ms = _queue_wait_ms(context_data.get("created_at"))
+    if queue_wait_ms is not None:
+        span_attributes["bifrost.queue.wait_ms"] = queue_wait_ms
 
     span_context = tracer.start_as_current_span("bifrost.worker.execute", attributes=span_attributes)
     span = span_context.__enter__()

--- a/api/tests/unit/services/execution/test_worker_telemetry.py
+++ b/api/tests/unit/services/execution/test_worker_telemetry.py
@@ -67,6 +67,7 @@ async def test_run_execution_emits_worker_span(monkeypatch):
         "caller": {"user_id": "user-1", "email": "user@example.test", "name": "User One"},
         "organization": {"id": "org-1", "name": "Org One"},
         "parameters": {"x": 1},
+        "created_at": "2026-06-27T14:00:00+00:00",
         "tags": ["workflow"],
         "timeout_seconds": 30,
         "cache_ttl_seconds": 300,
@@ -94,5 +95,6 @@ async def test_run_execution_emits_worker_span(monkeypatch):
     assert span.attributes["bifrost.worker.has_file_path"] is False
     assert span.attributes["bifrost.worker.status"] == ExecutionStatus.SUCCESS.value
     assert span.attributes["bifrost.worker.duration_ms"] == 42
+    assert span.attributes["bifrost.queue.wait_ms"] >= 0
     assert span.attributes["bifrost.worker.peak_memory_bytes"] >= 0
     assert span.attributes["bifrost.worker.cpu_total_seconds"] >= 0

--- a/docs/runbooks/otel-platform-observability.md
+++ b/docs/runbooks/otel-platform-observability.md
@@ -18,7 +18,9 @@ Every workflow execution should answer these questions from one trace:
 The first useful trace path is:
 
 1. `bifrost.workflow.enqueue` from the API process.
-2. `bifrost.worker.execute` from the worker process.
+2. `bifrost.worker.execute` from the worker process, including
+   `bifrost.queue.wait_ms` when the pending execution context includes
+   `created_at`.
 3. `bifrost.workflow.execute` from the execution engine.
 
 The shared join key is `bifrost.execution.id`. Use `bifrost.workflow.name`,
@@ -30,10 +32,12 @@ filtering, not for high-cardinality aggregation.
 Keep the collector as the ingestion boundary and add a real trace backend behind
 it. The recommended progression is:
 
-1. **Debug exporter only** while proving span content in PoC.
-2. **Grafana Tempo** for durable trace storage once spans are useful.
+1. **Debug exporter** while proving span content in PoC.
+2. **Grafana Tempo** for durable trace storage with 3-7 day retention.
 3. **Grafana dashboards** that link OpenCost namespace spend to trace examples.
-4. **Log correlation** by adding trace IDs to structured logs after the trace
+4. **Bifrost UI links** from execution history into Grafana/Tempo once trace
+   IDs are available in logs or persisted execution metadata.
+5. **Log correlation** by adding trace IDs to structured logs after the trace
    shape is stable.
 
 Tempo is the right next backend because it is cheaper to operate than a heavy
@@ -75,20 +79,19 @@ Allowed filter fields:
 - `bifrost.execution.error_type`
 - `bifrost.worker.is_script`
 - `bifrost.worker.has_file_path`
+- `bifrost.queue.wait_ms`
 
 Do not emit secrets, parameters, request bodies, ticket content, log lines, or
 raw results as span attributes.
 
 ## Next Instrumentation Slices
 
-1. Add queue wait timing by carrying an enqueue timestamp into the worker
-   context.
-2. Split worker setup into child spans for context read, module cache load, and
+1. Split worker setup into child spans for context read, module cache load, and
    workflow function load.
-3. Add integration-call spans with provider, status, duration, and sanitized
+2. Add integration-call spans with provider, status, duration, and sanitized
    error type.
-4. Add data-provider cache spans for hit/miss, load duration, and write duration.
-5. Add trace ID to execution logs so Bifrost history can deep-link to Tempo.
+3. Add data-provider cache spans for hit/miss, load duration, and write duration.
+4. Add trace ID to execution logs so Bifrost history can deep-link to Tempo.
 
 ## Maturity Gate
 


### PR DESCRIPTION
## Summary
- derive queue wait from the pending execution created_at timestamp
- add ifrost.queue.wait_ms to worker execution spans when the timestamp is available
- update the Bifrost OTel runbook now that queue wait timing has landed

## Decisions encoded
- Backend: Grafana Tempo consumption downstream
- Sensitive data: only timing and execution metadata, no parameters, bodies, logs, secrets, ticket content, or results

## Verification
- uv run ruff check api/src/services/execution/worker.py api/tests/unit/services/execution/test_worker_telemetry.py
- uv run python -m pytest api/tests/unit/services/execution/test_worker_telemetry.py api/tests/unit/services/execution/test_async_executor.py api/tests/unit/services/execution/test_engine_telemetry.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only span attributes with no execution-path changes; optional when `created_at` is missing.
> 
> **Overview**
> Workers now expose **time spent waiting in the queue** on the `bifrost.worker.execute` OpenTelemetry span when the Redis execution context includes `created_at`.
> 
> A new `_queue_wait_ms` helper parses that enqueue timestamp (ISO, with `Z` or UTC handling) and sets **`bifrost.queue.wait_ms`** at span start—milliseconds from enqueue until the worker begins execution. Missing or invalid timestamps leave the attribute unset so behavior stays unchanged when `created_at` is absent.
> 
> The OTel runbook documents the new attribute, lists it as an allowed filter field, and drops queue-wait timing from the “next slices” list now that it is implemented. Consumption guidance is refreshed (Tempo retention, Bifrost UI deep-links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5a83307668f08cf6a0bdd0fbe7d517b10cfe81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->