### PR TITLE
Emit OpenTelemetry workflow metrics

### DIFF
--- a/api/src/core/telemetry.py
+++ b/api/src/core/telemetry.py
@@ -9,7 +9,7 @@ _configured_services: set[str] = set()
 
 
 def configure_opentelemetry(service_name: str, *, span_processor: str = "batch") -> None:
-    """Configure OTLP trace export when an endpoint is provided."""
+    """Configure OTLP trace and metric export when an endpoint is provided."""
     endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     if not endpoint:
         return
@@ -18,24 +18,35 @@ def configure_opentelemetry(service_name: str, *, span_processor: str = "batch")
         return
 
     try:
+        from opentelemetry import metrics
         from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
     except ImportError as exc:
-        logger.warning("OpenTelemetry trace export unavailable for %s: %s", service_name, exc)
+        logger.warning("OpenTelemetry export unavailable for %s: %s", service_name, exc)
         return
 
     resource = Resource.create({"service.name": service_name})
-    provider = TracerProvider(resource=resource)
-    exporter = OTLPSpanExporter(endpoint=endpoint)
+    trace_provider = TracerProvider(resource=resource)
+    trace_exporter = OTLPSpanExporter(endpoint=endpoint)
 
     if span_processor == "simple":
-        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        trace_provider.add_span_processor(SimpleSpanProcessor(trace_exporter))
     else:
-        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace_provider.add_span_processor(BatchSpanProcessor(trace_exporter))
 
-    trace.set_tracer_provider(provider)
+    trace.set_tracer_provider(trace_provider)
+
+    metric_reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint=endpoint),
+        export_interval_millis=15_000,
+    )
+    metrics.set_meter_provider(MeterProvider(resource=resource, metric_readers=[metric_reader]))
+
     _configured_services.add(service_name)
-    logger.info("OpenTelemetry trace export configured for %s", service_name)
+    logger.info("OpenTelemetry trace and metric export configured for %s", service_name)

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -3,6 +3,7 @@ Unified Execution Engine
 Single source of truth for all code execution (workflows, scripts, data providers)
 """
 
+import asyncio
 import inspect
 import json
 import logging
@@ -1085,18 +1086,19 @@ async def _execute_workflow_with_trace(
         # Set up trace function for variable capture
         sys.settrace(chained_trace_func if existing_trace else trace_func)
         try:
+            execution_scope = context.scope or "GLOBAL"
             span_attributes = {
                 "bifrost.execution.id": execution_id or context.execution_id,
                 "bifrost.workflow.name": context.workflow_name or func_name,
                 "bifrost.workflow.function": func_name,
-                "bifrost.execution.scope": context.scope,
+                "bifrost.execution.scope": execution_scope,
                 "bifrost.execution.organization_id": context.org_id or "",
                 "bifrost.execution.is_platform_admin": context.is_platform_admin,
             }
             metric_attributes = {
                 "bifrost.workflow.name": context.workflow_name or func_name,
                 "bifrost.workflow.function": func_name,
-                "bifrost.execution.scope": context.scope or "GLOBAL",
+                "bifrost.execution.scope": execution_scope,
                 "bifrost.execution.is_platform_admin": context.is_platform_admin,
             }
             start_time = time.perf_counter()
@@ -1122,6 +1124,24 @@ async def _execute_workflow_with_trace(
                             "bifrost.execution.status": ExecutionStatus.SUCCESS.value,
                         },
                     )
+                except asyncio.CancelledError:
+                    span.set_attribute("bifrost.execution.status", ExecutionStatus.CANCELLED.value)
+                    span.set_attribute("bifrost.execution.error_type", "CancelledError")
+                    workflow_execution_counter.add(
+                        1,
+                        attributes={
+                            **metric_attributes,
+                            "bifrost.execution.status": ExecutionStatus.CANCELLED.value,
+                        },
+                    )
+                    workflow_execution_duration.record(
+                        (time.perf_counter() - start_time) * 1000,
+                        attributes={
+                            **metric_attributes,
+                            "bifrost.execution.status": ExecutionStatus.CANCELLED.value,
+                        },
+                    )
+                    raise
                 except Exception as exc:
                     span.set_attribute("bifrost.execution.status", ExecutionStatus.FAILED.value)
                     span.set_attribute("bifrost.execution.error_type", type(exc).__name__)

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -1096,7 +1096,7 @@ async def _execute_workflow_with_trace(
             metric_attributes = {
                 "bifrost.workflow.name": context.workflow_name or func_name,
                 "bifrost.workflow.function": func_name,
-                "bifrost.execution.scope": context.scope,
+                "bifrost.execution.scope": context.scope or "GLOBAL",
                 "bifrost.execution.is_platform_admin": context.is_platform_admin,
             }
             start_time = time.perf_counter()

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import sys
+import time
 from contextlib import redirect_stdout, redirect_stderr
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -15,7 +16,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, get_type_hints, get_origin, get_args, Union
 
-from opentelemetry import trace
+from opentelemetry import metrics, trace
 from pydantic import BaseModel
 
 from src.sdk.context import Caller, ExecutionContext, Organization
@@ -27,6 +28,17 @@ from src.core.secret_string import redact_secrets
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+workflow_execution_counter = meter.create_counter(
+    "bifrost.workflow.executions",
+    unit="1",
+    description="Workflow executions completed by status.",
+)
+workflow_execution_duration = meter.create_histogram(
+    "bifrost.workflow.execution.duration",
+    unit="ms",
+    description="Workflow execution duration in milliseconds.",
+)
 
 
 def _human_size(num_bytes: int) -> str:
@@ -1081,6 +1093,13 @@ async def _execute_workflow_with_trace(
                 "bifrost.execution.organization_id": context.org_id or "",
                 "bifrost.execution.is_platform_admin": context.is_platform_admin,
             }
+            metric_attributes = {
+                "bifrost.workflow.name": context.workflow_name or func_name,
+                "bifrost.workflow.function": func_name,
+                "bifrost.execution.scope": context.scope,
+                "bifrost.execution.is_platform_admin": context.is_platform_admin,
+            }
+            start_time = time.perf_counter()
             with tracer.start_as_current_span(
                 "bifrost.workflow.execute",
                 attributes=span_attributes,
@@ -1089,9 +1108,37 @@ async def _execute_workflow_with_trace(
                     # Run the workflow directly - isolation is provided by subprocess
                     result = await _run_workflow_async()
                     span.set_attribute("bifrost.execution.status", ExecutionStatus.SUCCESS.value)
+                    workflow_execution_counter.add(
+                        1,
+                        attributes={
+                            **metric_attributes,
+                            "bifrost.execution.status": ExecutionStatus.SUCCESS.value,
+                        },
+                    )
+                    workflow_execution_duration.record(
+                        (time.perf_counter() - start_time) * 1000,
+                        attributes={
+                            **metric_attributes,
+                            "bifrost.execution.status": ExecutionStatus.SUCCESS.value,
+                        },
+                    )
                 except Exception as exc:
                     span.set_attribute("bifrost.execution.status", ExecutionStatus.FAILED.value)
                     span.set_attribute("bifrost.execution.error_type", type(exc).__name__)
+                    workflow_execution_counter.add(
+                        1,
+                        attributes={
+                            **metric_attributes,
+                            "bifrost.execution.status": ExecutionStatus.FAILED.value,
+                        },
+                    )
+                    workflow_execution_duration.record(
+                        (time.perf_counter() - start_time) * 1000,
+                        attributes={
+                            **metric_attributes,
+                            "bifrost.execution.status": ExecutionStatus.FAILED.value,
+                        },
+                    )
                     raise
         finally:
             # Clear trace function

--- a/api/tests/unit/services/execution/test_engine_telemetry.py
+++ b/api/tests/unit/services/execution/test_engine_telemetry.py
@@ -62,6 +62,20 @@ def _context() -> ExecutionContext:
     )
 
 
+def _global_context() -> ExecutionContext:
+    return ExecutionContext(
+        user_id="user-1",
+        email="user@example.com",
+        name="User One",
+        scope=None,
+        organization=None,
+        is_platform_admin=True,
+        is_function_key=False,
+        execution_id="exec-1",
+        workflow_name="status_snapshot",
+    )
+
+
 @pytest.mark.asyncio
 async def test_workflow_execution_emits_success_span(monkeypatch):
     fake_tracer = _FakeTracer()
@@ -106,6 +120,29 @@ async def test_workflow_execution_emits_success_span(monkeypatch):
     duration, attributes = fake_duration.calls[0]
     assert duration >= 0
     assert attributes["bifrost.execution.status"] == ExecutionStatus.SUCCESS.value
+
+
+@pytest.mark.asyncio
+async def test_workflow_execution_metrics_use_global_scope_for_missing_scope(monkeypatch):
+    fake_tracer = _FakeTracer()
+    fake_counter = _FakeCounter()
+    fake_duration = _FakeHistogram()
+    monkeypatch.setattr(engine, "tracer", fake_tracer)
+    monkeypatch.setattr(engine, "workflow_execution_counter", fake_counter)
+    monkeypatch.setattr(engine, "workflow_execution_duration", fake_duration)
+
+    async def workflow(context):
+        return {"ok": True}
+
+    await engine._execute_workflow_with_trace(
+        workflow,
+        _global_context(),
+        {},
+        execution_id="exec-1",
+    )
+
+    assert fake_counter.calls[0][1]["bifrost.execution.scope"] == "GLOBAL"
+    assert fake_duration.calls[0][1]["bifrost.execution.scope"] == "GLOBAL"
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/execution/test_engine_telemetry.py
+++ b/api/tests/unit/services/execution/test_engine_telemetry.py
@@ -32,6 +32,22 @@ class _FakeTracer:
         return span
 
 
+class _FakeCounter:
+    def __init__(self):
+        self.calls: list[tuple[int, dict]] = []
+
+    def add(self, value: int, *, attributes: dict):
+        self.calls.append((value, dict(attributes)))
+
+
+class _FakeHistogram:
+    def __init__(self):
+        self.calls: list[tuple[float, dict]] = []
+
+    def record(self, value: float, *, attributes: dict):
+        self.calls.append((value, dict(attributes)))
+
+
 def _context() -> ExecutionContext:
     return ExecutionContext(
         user_id="user-1",
@@ -49,7 +65,11 @@ def _context() -> ExecutionContext:
 @pytest.mark.asyncio
 async def test_workflow_execution_emits_success_span(monkeypatch):
     fake_tracer = _FakeTracer()
+    fake_counter = _FakeCounter()
+    fake_duration = _FakeHistogram()
     monkeypatch.setattr(engine, "tracer", fake_tracer)
+    monkeypatch.setattr(engine, "workflow_execution_counter", fake_counter)
+    monkeypatch.setattr(engine, "workflow_execution_duration", fake_duration)
 
     async def workflow(context):
         return {"ok": True}
@@ -70,12 +90,32 @@ async def test_workflow_execution_emits_success_span(monkeypatch):
     assert span.attributes["bifrost.workflow.function"] == "workflow"
     assert span.attributes["bifrost.execution.organization_id"] == "org-1"
     assert span.attributes["bifrost.execution.status"] == ExecutionStatus.SUCCESS.value
+    assert fake_counter.calls == [
+        (
+            1,
+            {
+                "bifrost.workflow.name": "status_snapshot",
+                "bifrost.workflow.function": "workflow",
+                "bifrost.execution.scope": "org-1",
+                "bifrost.execution.is_platform_admin": False,
+                "bifrost.execution.status": ExecutionStatus.SUCCESS.value,
+            },
+        )
+    ]
+    assert len(fake_duration.calls) == 1
+    duration, attributes = fake_duration.calls[0]
+    assert duration >= 0
+    assert attributes["bifrost.execution.status"] == ExecutionStatus.SUCCESS.value
 
 
 @pytest.mark.asyncio
 async def test_workflow_execution_emits_failed_span(monkeypatch):
     fake_tracer = _FakeTracer()
+    fake_counter = _FakeCounter()
+    fake_duration = _FakeHistogram()
     monkeypatch.setattr(engine, "tracer", fake_tracer)
+    monkeypatch.setattr(engine, "workflow_execution_counter", fake_counter)
+    monkeypatch.setattr(engine, "workflow_execution_duration", fake_duration)
 
     async def workflow(context):
         raise RuntimeError("boom")
@@ -92,3 +132,19 @@ async def test_workflow_execution_emits_failed_span(monkeypatch):
     assert span.attributes["bifrost.execution.id"] == "exec-1"
     assert span.attributes["bifrost.execution.status"] == ExecutionStatus.FAILED.value
     assert span.attributes["bifrost.execution.error_type"] == "RuntimeError"
+    assert fake_counter.calls == [
+        (
+            1,
+            {
+                "bifrost.workflow.name": "status_snapshot",
+                "bifrost.workflow.function": "workflow",
+                "bifrost.execution.scope": "org-1",
+                "bifrost.execution.is_platform_admin": False,
+                "bifrost.execution.status": ExecutionStatus.FAILED.value,
+            },
+        )
+    ]
+    assert len(fake_duration.calls) == 1
+    duration, attributes = fake_duration.calls[0]
+    assert duration >= 0
+    assert attributes["bifrost.execution.status"] == ExecutionStatus.FAILED.value

--- a/api/tests/unit/services/execution/test_engine_telemetry.py
+++ b/api/tests/unit/services/execution/test_engine_telemetry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from src.models.enums import ExecutionStatus
@@ -143,6 +145,48 @@ async def test_workflow_execution_metrics_use_global_scope_for_missing_scope(mon
 
     assert fake_counter.calls[0][1]["bifrost.execution.scope"] == "GLOBAL"
     assert fake_duration.calls[0][1]["bifrost.execution.scope"] == "GLOBAL"
+    assert fake_tracer.spans[0].attributes["bifrost.execution.scope"] == "GLOBAL"
+
+
+@pytest.mark.asyncio
+async def test_workflow_execution_emits_cancelled_metrics(monkeypatch):
+    fake_tracer = _FakeTracer()
+    fake_counter = _FakeCounter()
+    fake_duration = _FakeHistogram()
+    monkeypatch.setattr(engine, "tracer", fake_tracer)
+    monkeypatch.setattr(engine, "workflow_execution_counter", fake_counter)
+    monkeypatch.setattr(engine, "workflow_execution_duration", fake_duration)
+
+    async def workflow(context):
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await engine._execute_workflow_with_trace(
+            workflow,
+            _context(),
+            {},
+        )
+
+    assert len(fake_tracer.spans) == 1
+    span = fake_tracer.spans[0]
+    assert span.attributes["bifrost.execution.status"] == ExecutionStatus.CANCELLED.value
+    assert span.attributes["bifrost.execution.error_type"] == "CancelledError"
+    assert fake_counter.calls == [
+        (
+            1,
+            {
+                "bifrost.workflow.name": "status_snapshot",
+                "bifrost.workflow.function": "workflow",
+                "bifrost.execution.scope": "org-1",
+                "bifrost.execution.is_platform_admin": False,
+                "bifrost.execution.status": ExecutionStatus.CANCELLED.value,
+            },
+        )
+    ]
+    assert len(fake_duration.calls) == 1
+    duration, attributes = fake_duration.calls[0]
+    assert duration >= 0
+    assert attributes["bifrost.execution.status"] == ExecutionStatus.CANCELLED.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to observability wiring and do not alter execution outcomes; risk is mainly missing OTel metric packages at runtime or added export volume when OTLP is enabled.
> 
> **Overview**
> When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, **`configure_opentelemetry`** now registers **OTLP metric export** (15s periodic reader) in addition to traces, so API and worker processes can ship both signal types to the same endpoint.
> 
> The execution engine records **`bifrost.workflow.executions`** (counter) and **`bifrost.workflow.execution.duration`** (histogram, ms) inside `_execute_workflow_with_trace`, aligned with existing `bifrost.workflow.execute` spans. Metrics are labeled with workflow name/function, scope (defaulting missing scope to **`GLOBAL`**), platform-admin flag, and terminal status (**success**, **failed**, or **cancelled**). **`asyncio.CancelledError`** is handled explicitly so cancellations update span attributes and metrics before re-raise.
> 
> Unit tests mock the new instruments and assert counter/histogram payloads for success, failure, cancellation, and GLOBAL scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542ec0d88b088e1d9d23654594584ca2ad692939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry metrics alongside tracing for service telemetry.
  * Workflow executions now emit a status counter and execution-duration histogram for both success and failure cases.

* **Bug Fixes**
  * Telemetry setup now initializes trace and metric export together when configured, with clearer messaging when export support isn’t available.

* **Tests**
  * Expanded coverage to verify telemetry metrics are recorded correctly for successful and failed workflow runs, including GLOBAL scope behavior when scope is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->