### PR TITLE
Ignore local tool output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,12 @@ azurite/
 # PyCharm
 .idea/
 
+# Cursor local hook state
+.cursor/hooks/state/
+
+# Local code knowledge graph output
+graphify-out/
+
 # ==================== OS ====================
 
 # macOS


### PR DESCRIPTION
## Summary
- ignore Cursor local hook state under .cursor/hooks/state
- ignore generated graphify-out knowledge graph output

## Validation
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ignore rules with no runtime, API, or dependency impact.
> 
> **Overview**
> Adds two **`.gitignore`** entries so local tooling artifacts stay out of version control.
> 
> **`.cursor/hooks/state/`** — ignores Cursor’s local hook runtime state. **graphify-out/** — ignores generated code-knowledge-graph output from local graphify runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d098fef66eb65db6323695c0e66f123c8eb6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->