### PR TITLE
Fix worker workflow metrics export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,12 @@ azurite/
 # PyCharm
 .idea/
 
+# Cursor local hook state
+.cursor/hooks/state/
+
+# Local code knowledge graph output
+graphify-out/
+
 # ==================== OS ====================
 
 # macOS

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -30,16 +30,29 @@ from src.core.secret_string import redact_secrets
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 meter = metrics.get_meter(__name__)
-workflow_execution_counter = meter.create_counter(
-    "bifrost.workflow.executions",
-    unit="1",
-    description="Workflow executions completed by status.",
-)
-workflow_execution_duration = meter.create_histogram(
-    "bifrost.workflow.execution.duration",
-    unit="ms",
-    description="Workflow execution duration in milliseconds.",
-)
+workflow_execution_counter = None
+workflow_execution_duration = None
+
+
+def _workflow_metric_instruments():
+    """Create workflow metric instruments after the process MeterProvider is configured."""
+    global workflow_execution_counter, workflow_execution_duration
+
+    if workflow_execution_counter is None:
+        workflow_execution_counter = metrics.get_meter(__name__).create_counter(
+            "bifrost.workflow.executions",
+            unit="1",
+            description="Workflow executions completed by status.",
+        )
+
+    if workflow_execution_duration is None:
+        workflow_execution_duration = metrics.get_meter(__name__).create_histogram(
+            "bifrost.workflow.execution.duration",
+            unit="ms",
+            description="Workflow execution duration in milliseconds.",
+        )
+
+    return workflow_execution_counter, workflow_execution_duration
 
 
 def _human_size(num_bytes: int) -> str:
@@ -1101,6 +1114,7 @@ async def _execute_workflow_with_trace(
                 "bifrost.execution.scope": execution_scope,
                 "bifrost.execution.is_platform_admin": context.is_platform_admin,
             }
+            workflow_counter, workflow_duration = _workflow_metric_instruments()
             start_time = time.perf_counter()
             with tracer.start_as_current_span(
                 "bifrost.workflow.execute",
@@ -1110,14 +1124,14 @@ async def _execute_workflow_with_trace(
                     # Run the workflow directly - isolation is provided by subprocess
                     result = await _run_workflow_async()
                     span.set_attribute("bifrost.execution.status", ExecutionStatus.SUCCESS.value)
-                    workflow_execution_counter.add(
+                    workflow_counter.add(
                         1,
                         attributes={
                             **metric_attributes,
                             "bifrost.execution.status": ExecutionStatus.SUCCESS.value,
                         },
                     )
-                    workflow_execution_duration.record(
+                    workflow_duration.record(
                         (time.perf_counter() - start_time) * 1000,
                         attributes={
                             **metric_attributes,
@@ -1127,14 +1141,14 @@ async def _execute_workflow_with_trace(
                 except asyncio.CancelledError:
                     span.set_attribute("bifrost.execution.status", ExecutionStatus.CANCELLED.value)
                     span.set_attribute("bifrost.execution.error_type", "CancelledError")
-                    workflow_execution_counter.add(
+                    workflow_counter.add(
                         1,
                         attributes={
                             **metric_attributes,
                             "bifrost.execution.status": ExecutionStatus.CANCELLED.value,
                         },
                     )
-                    workflow_execution_duration.record(
+                    workflow_duration.record(
                         (time.perf_counter() - start_time) * 1000,
                         attributes={
                             **metric_attributes,
@@ -1145,14 +1159,14 @@ async def _execute_workflow_with_trace(
                 except Exception as exc:
                     span.set_attribute("bifrost.execution.status", ExecutionStatus.FAILED.value)
                     span.set_attribute("bifrost.execution.error_type", type(exc).__name__)
-                    workflow_execution_counter.add(
+                    workflow_counter.add(
                         1,
                         attributes={
                             **metric_attributes,
                             "bifrost.execution.status": ExecutionStatus.FAILED.value,
                         },
                     )
-                    workflow_execution_duration.record(
+                    workflow_duration.record(
                         (time.perf_counter() - start_time) * 1000,
                         attributes={
                             **metric_attributes,

--- a/api/tests/unit/services/execution/test_engine_telemetry.py
+++ b/api/tests/unit/services/execution/test_engine_telemetry.py
@@ -50,6 +50,22 @@ class _FakeHistogram:
         self.calls.append((value, dict(attributes)))
 
 
+class _FakeMeter:
+    def __init__(self):
+        self.counter = _FakeCounter()
+        self.histogram = _FakeHistogram()
+        self.counter_names: list[str] = []
+        self.histogram_names: list[str] = []
+
+    def create_counter(self, name: str, **_kwargs):
+        self.counter_names.append(name)
+        return self.counter
+
+    def create_histogram(self, name: str, **_kwargs):
+        self.histogram_names.append(name)
+        return self.histogram
+
+
 def _context() -> ExecutionContext:
     return ExecutionContext(
         user_id="user-1",
@@ -122,6 +138,31 @@ async def test_workflow_execution_emits_success_span(monkeypatch):
     duration, attributes = fake_duration.calls[0]
     assert duration >= 0
     assert attributes["bifrost.execution.status"] == ExecutionStatus.SUCCESS.value
+
+
+@pytest.mark.asyncio
+async def test_workflow_execution_metrics_are_created_lazily(monkeypatch):
+    fake_tracer = _FakeTracer()
+    fake_meter = _FakeMeter()
+    monkeypatch.setattr(engine, "tracer", fake_tracer)
+    monkeypatch.setattr(engine, "workflow_execution_counter", None)
+    monkeypatch.setattr(engine, "workflow_execution_duration", None)
+    monkeypatch.setattr(engine.metrics, "get_meter", lambda _name: fake_meter)
+
+    async def workflow(context):
+        return {"ok": True}
+
+    await engine._execute_workflow_with_trace(
+        workflow,
+        _context(),
+        {},
+        execution_id="exec-1",
+    )
+
+    assert fake_meter.counter_names == ["bifrost.workflow.executions"]
+    assert fake_meter.histogram_names == ["bifrost.workflow.execution.duration"]
+    assert fake_meter.counter.calls[0][1]["bifrost.execution.status"] == ExecutionStatus.SUCCESS.value
+    assert fake_meter.histogram.calls[0][1]["bifrost.execution.status"] == ExecutionStatus.SUCCESS.value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- create worker workflow OTel metric instruments lazily after the process MeterProvider is configured
- keep existing execution status counter/duration attributes unchanged
- add regression coverage for import-before-provider initialization

## Verification
- ./.venv/Scripts/python.exe -m pytest api/tests/unit/services/execution/test_engine_telemetry.py -q
- ./.venv/Scripts/python.exe -m py_compile api/src/services/execution/engine.py api/tests/unit/services/execution/test_engine_telemetry.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability initialization timing only; metric semantics unchanged and covered by unit tests.
> 
> **Overview**
> Fixes **worker workflow metrics not exporting** when the execution engine is imported before the process `MeterProvider` is configured.
> 
> Workflow OTel counter and histogram are no longer created at **module import**; `_workflow_metric_instruments()` creates them on the first traced workflow run via `get_meter`, so instruments bind to the configured provider. Success, cancelled, and failed paths still emit the same metric names and attributes.
> 
> Adds regression test `test_workflow_execution_metrics_are_created_lazily`. Also ignores `.cursor/hooks/state/` and `graphify-out/` in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec675e1a9f20f41ee6209f10c0a4b474074da7fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow tracking so execution metrics are recorded reliably after the app is fully initialized.
  * Fixed local development files from being included in version control.

* **Tests**
  * Added coverage for workflow metric creation and recording behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->