### PR TITLE
Guard app draft subscription cleanup

### DIFF
--- a/client/src/components/jsx-app/BundledAppShell.tsx
+++ b/client/src/components/jsx-app/BundledAppShell.tsx
@@ -375,14 +375,16 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 		// never subscribe — we gate on the model the first load resolved.
 		let unsub: (() => void) | null = null;
 		const initialLoad = loadBundle();
+		let disposed = false;
 		if (isPreview) {
-			(async () => {
+			void (async () => {
 				try {
 					const model = await initialLoad;
 					if (model === "standalone_v2") return;
 					if (controller.signal.aborted) return;
 					await webSocketService.connectToAppDraft(appId);
-					unsub = webSocketService.onAppCodeFileUpdate(
+					if (disposed) return;
+					const nextUnsub = webSocketService.onAppCodeFileUpdate(
 						appId,
 						(update: AppCodeFileUpdate) => {
 							if (update.error && update.error.messages.length > 0) {
@@ -393,6 +395,11 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 							}
 						},
 					);
+					if (disposed) {
+						nextUnsub();
+						return;
+					}
+					unsub = nextUnsub;
 				} catch (e) {
 					console.warn("[Bifrost] Failed to subscribe to app updates:", e);
 				}
@@ -400,6 +407,7 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 		}
 
 		return () => {
+			disposed = true;
 			controller.abort();
 			if (unsub) unsub();
 		};


### PR DESCRIPTION
Publishes the remaining unique work from the cleaned linked worktree branch. The OAuth refresh scope and migration changes from the original branch are already present on main, so this rebased PR keeps only the app-shell cleanup guard that avoids retaining a draft WebSocket subscription if the preview component unmounts while subscription setup is in flight.\n\nValidation: not run locally; opening/rerunning repository CI for the rebased one-file diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in preview-only code with no auth or data-model changes; main risk is regressing hot-reload behavior if the guard is wrong.
> 
> **Overview**
> Fixes a **preview hot-reload subscription leak** in `BundledAppShell` when the shell unmounts (or the effect re-runs) while draft WebSocket setup is still in flight.
> 
> The effect cleanup could run before `onAppCodeFileUpdate` returned its unsubscribe handle, so the async path could still register a listener that was never torn down. A **`disposed` flag** is set in the effect cleanup; after `connectToAppDraft` and again after registering the listener, the async flow bails out and **immediately calls the new unsubscribe** if disposal already happened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b0e187f11e3eb18a5f193adf5a49982d5b99c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->