### PR TITLE
Merge branding terminology updates

### DIFF
--- a/api/src/repositories/branding.py
+++ b/api/src/repositories/branding.py
@@ -85,7 +85,12 @@ class BrandingRepository:
             if primary_color is not None:
                 existing.primary_color = primary_color
             if terminology is not None:
-                existing.terminology = terminology
+                merged_terminology = dict(existing.terminology or {})
+                for noun, terms in terminology.items():
+                    noun_terms = dict(merged_terminology.get(noun, {}))
+                    noun_terms.update(terms)
+                    merged_terminology[noun] = noun_terms
+                existing.terminology = merged_terminology
             if application_name is not _UNSET:
                 existing.application_name = application_name
 

--- a/api/src/repositories/branding.py
+++ b/api/src/repositories/branding.py
@@ -98,22 +98,21 @@ class BrandingRepository:
             await self.session.refresh(existing)
             logger.info("Global branding updated")
             return existing
-        else:
-            # Create new
-            branding = GlobalBranding(
-                square_logo_data=square_logo_data,
-                square_logo_content_type=square_logo_content_type,
-                rectangle_logo_data=rectangle_logo_data,
-                rectangle_logo_content_type=rectangle_logo_content_type,
-                primary_color=primary_color,
-                terminology=terminology,
-                application_name=None if application_name is _UNSET else application_name,
-            )
-            self.session.add(branding)
-            await self.session.flush()
-            await self.session.refresh(branding)
-            logger.info("Global branding created")
-            return branding
+        # Create new
+        branding = GlobalBranding(
+            square_logo_data=square_logo_data,
+            square_logo_content_type=square_logo_content_type,
+            rectangle_logo_data=rectangle_logo_data,
+            rectangle_logo_content_type=rectangle_logo_content_type,
+            primary_color=primary_color,
+            terminology=terminology,
+            application_name=None if application_name is _UNSET else application_name,
+        )
+        self.session.add(branding)
+        await self.session.flush()
+        await self.session.refresh(branding)
+        logger.info("Global branding created")
+        return branding
 
     async def delete_branding(self) -> bool:
         """


### PR DESCRIPTION
Publishes the remaining unique work from the cleaned linked worktree branch. The passkey transport normalization from the original branch is already present on main, so this rebased PR preserves the still-unique branding terminology merge behavior without replaying stale pre-squash platform history.\n\nValidation:\n- ruff check --fix api/src/repositories/branding.py\n- ruff format api/src/repositories/branding.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small repository-only change to merge semantics for branding JSON; no auth or critical infrastructure impact.
> 
> **Overview**
> Updates to **global branding** now **deep-merge** `terminology` instead of replacing the whole JSON blob. For each noun in the incoming payload, term keys are merged into any existing noun map so partial API updates do not wipe unrelated terminology.
> 
> The create path in `set_branding` is unchanged in behavior; only control flow is flattened after the early return on update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e059d2235085d7e511a28da7c55008b20d078e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->