### PR TITLE
Fix SDK mapping default secret disclosure

### DIFF
--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -1051,7 +1051,7 @@ async def sdk_integrations_list_mappings(
             config = await repo.get_config_for_mapping(
                 integration.id,
                 mapping.organization_id,
-                include_default_secrets=not is_external,
+                include_default_secrets=False,
                 external=is_external,
             )
             items.append({
@@ -1115,7 +1115,7 @@ async def sdk_integrations_get_mapping(
         config = await repo.get_config_for_mapping(
             integration.id,
             mapping.organization_id,
-            include_default_secrets=not is_external,
+            include_default_secrets=False,
             external=is_external,
         )
 

--- a/api/tests/e2e/api/test_integrations.py
+++ b/api/tests/e2e/api/test_integrations.py
@@ -1180,10 +1180,10 @@ class TestIntegrationConfigSecrets:
                 headers=platform_admin.headers,
             )
 
-    def test_sdk_get_mapping_includes_default_secrets_for_internal_users(
+    def test_sdk_get_mapping_omits_default_secrets_for_internal_users(
         self, e2e_client, platform_admin, integration_with_secret_schema, org1
     ):
-        """Internal mapping reads include integration-level default secrets."""
+        """Internal mapping reads do not disclose integration-level default secrets."""
         integration = integration_with_secret_schema
         default_secret = f"global-default-{uuid4().hex}"
 
@@ -1221,7 +1221,7 @@ class TestIntegrationConfigSecrets:
 
             assert data["id"] == mapping["id"]
             assert data["config"]["base_url"] == "https://api.default.com"
-            assert data["config"]["api_key"] == default_secret
+            assert "api_key" not in data["config"]
 
             response = e2e_client.post(
                 "/api/sdk/integrations/list_mappings",
@@ -1235,7 +1235,7 @@ class TestIntegrationConfigSecrets:
             ]
             assert len(listed) == 1
             assert listed[0]["config"]["base_url"] == "https://api.default.com"
-            assert listed[0]["config"]["api_key"] == default_secret
+            assert "api_key" not in listed[0]["config"]
         finally:
             e2e_client.delete(
                 f"/api/integrations/{integration['id']}/mappings/{mapping['id']}",

--- a/api/tests/e2e/platform/test_cli_integrations_external.py
+++ b/api/tests/e2e/platform/test_cli_integrations_external.py
@@ -15,8 +15,8 @@ include the global SECRET default). Then assert:
 
   - an EXTERNAL portal user gets NONE of the global SECRET/token back from ANY
     of get / list_mappings / get_mapping / upsert_mapping / refresh_token;
-  - a NORMAL org user (and the sentinel/engine path) still receives the global
-    tier — proving the restriction is external-specific, not a blanket break.
+  - a NORMAL org user still receives the global tier from the legacy get and
+    write echo paths, while mapping reads drop integration-level SECRET defaults.
 
 Engine/sentinel path is unchanged (a workflow legitimately uses its org's
 integrations including global defaults).
@@ -291,8 +291,8 @@ _CONFIG_ENDPOINTS = ["get", "list_mappings", "get_mapping", "upsert_mapping"]
 @pytest.mark.parametrize("endpoint", _CONFIG_ENDPOINTS)
 class TestExternalIntegrationsSurface:
     """NEW-G: EVERY config-returning /api/sdk/integrations/* endpoint must drop
-    the global SECRET default for an external caller, and keep it for a normal
-    org user."""
+    the global SECRET default for an external caller. Mapping read endpoints
+    also omit integration-level SECRET defaults for normal org users."""
 
     def test_external_never_sees_global_secret(
         self, e2e_client, external_user, global_integration, endpoint
@@ -316,12 +316,16 @@ class TestExternalIntegrationsSurface:
         resp = _call_endpoint(e2e_client, org1_user, endpoint, global_integration)
         assert resp.status_code in (200, 201), f"{endpoint}: {resp.status_code} {resp.text}"
         blob = _serialize(resp.json())
-        # The mapping-echo siblings (and get) merge the global SECRET default
-        # into the org mapping's config for a normal org user — proving the
-        # restriction is external-specific, not a blanket break.
-        assert GLOBAL_CONFIG_SECRET in blob, (
-            f"normal org user must still receive the global SECRET default via {endpoint}"
-        )
+        if endpoint in {"list_mappings", "get_mapping"}:
+            assert GLOBAL_CONFIG_SECRET not in blob, (
+                f"normal org user must not receive the global SECRET default via {endpoint}"
+            )
+        else:
+            # Legacy get and write echo paths still merge the global SECRET
+            # default into the org mapping's config for a normal org user.
+            assert GLOBAL_CONFIG_SECRET in blob, (
+                f"normal org user must still receive the global SECRET default via {endpoint}"
+            )
 
 
 class TestExternalIntegrationsRefreshToken:


### PR DESCRIPTION
## Summary
- stop SDK integration mapping reads from returning integration-level default secrets
- keep org-scoped mapping secret overrides available
- update focused e2e coverage for get_mapping and list_mappings

## Validation
- `ruff check api/src/routers/cli.py api/tests/e2e/api/test_integrations.py`
- `python -m pytest api/tests/e2e/api/test_integrations.py -k "sdk_get_mapping or sdk_mapping_endpoints" -q` (blocked locally: missing `pytest_asyncio` in this Windows environment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive change to what decrypted secrets SDK clients receive; workflows that relied on default secrets via mapping list/get may need org overrides or `integrations/get` instead. Upsert echo behavior is unchanged.
> 
> **Overview**
> **Stops leaking integration-level default secrets** on SDK mapping **read** paths: `list_mappings` and `get_mapping` now always call `get_config_for_mapping` with `include_default_secrets=False`, instead of exposing decrypted global defaults to internal users.
> 
> Non-secret defaults (e.g. `base_url`) still merge as before. **Org-specific secret overrides** on a mapping remain returned on direct mapping reads.
> 
> **E2E coverage** now expects internal callers to omit default `api_key` on `get_mapping` / `list_mappings`, while external-user parametrized tests distinguish mapping reads (no global secret) from legacy `get` and `upsert_mapping` echo paths (global secret still present for normal org users).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ae39e40f2c87d949cae268d4d09df1f5eb6d0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal integration mapping reads no longer return default secret values.
  * Both single-mapping and list-mapping responses now omit secret fields that should not be exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->