### PR TITLE
Restore invite passkey backend safety

### DIFF
--- a/api/src/core/csrf.py
+++ b/api/src/core/csrf.py
@@ -40,6 +40,8 @@ CSRF_EXEMPT_PATHS = {
     "/auth/setup/passkey/options",  # First-time passkey setup (no auth)
     "/auth/setup/passkey/verify",  # First-time passkey setup (no auth)
     "/auth/register-from-invite",  # Invite-based registration (token-gated, no cookies yet)
+    "/auth/register-from-invite/passkey/options",  # Invite passkey setup (token-gated)
+    "/auth/register-from-invite/passkey/verify",  # Invite passkey setup (token-gated)
     "/auth/device/code",  # Device flow: request code (no auth)
     "/auth/device/token",  # Device flow: exchange code for token (no auth)
     "/auth/cli/start",  # Native CLI OAuth: start localhost callback flow (no auth)

--- a/api/src/routers/users.py
+++ b/api/src/routers/users.py
@@ -407,10 +407,11 @@ async def _generate_invite(
     ).scalar_one_or_none()
     if not target:
         raise HTTPException(status_code=404, detail="User not found")
-    if target.is_registered:
-        raise HTTPException(status_code=409, detail="User is already registered")
 
     svc = UserInviteService(db)
+    if await svc.status_for(target) == InviteStatus.ACTIVE:
+        raise HTTPException(status_code=409, detail="User is already registered")
+
     raw_token, invite = await svc.create_or_replace(
         user_id=user_id, created_by=actor.user_id
     )

--- a/api/tests/e2e/api/test_user_invites.py
+++ b/api/tests/e2e/api/test_user_invites.py
@@ -92,6 +92,12 @@ class TestUserInviteFlags:
         assert target["is_registered"] is False
         assert target["invite_status"] == "active"
 
+        regenerate = e2e_client.post(
+            f"/api/users/{body['id']}/invite/regenerate",
+            headers=platform_admin.headers,
+        )
+        assert regenerate.status_code == 409
+
         e2e_client.patch(
             f"/api/users/{body['id']}",
             headers=platform_admin.headers,


### PR DESCRIPTION
## Summary
- exempt invite passkey registration endpoints from CSRF middleware
- reject invite regeneration/resend for effectively active users via invite status, including OAuth-linked users
- extend invite e2e coverage for OAuth-linked active users blocking regenerate

## Validation
- `ruff check api/src/core/csrf.py api/src/routers/users.py api/tests/e2e/api/test_user_invites.py`
- `python -m pytest api/tests/e2e/api/test_user_invites.py -k "oauth_linked_user_invite_status_is_active or regenerate_for_registered_user_409" -q` (blocked locally: missing `pytest_asyncio` in this Windows environment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CSRF exemptions and invite issuance rules for auth-adjacent flows; behavior change blocks invites for OAuth-linked users who previously might have passed the `is_registered` check only.
> 
> **Overview**
> **Invite passkey registration** during accept-invite can call new token-gated `/auth/register-from-invite/passkey/*` routes without CSRF cookies; those paths are added to the CSRF exempt list alongside the existing register-from-invite flow.
> 
> **Invite regeneration/resend** no longer relies on `is_registered` alone. `_generate_invite` returns **409** when `UserInviteService.status_for` is **ACTIVE**, so OAuth-linked users who were never backfilled (`is_registered` false but linked SSO) cannot get a new invite link.
> 
> E2E coverage asserts that an OAuth-linked user lists as **active** and **regenerate** returns **409**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f77112c66a58d1c0e70d6f0798acad2a11114e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->