### PR TITLE
Make OAuth token scope replay provider-configurable

### DIFF
--- a/api/alembic/versions/20260702_oauth_provider_token_scope_metadata.py
+++ b/api/alembic/versions/20260702_oauth_provider_token_scope_metadata.py
@@ -1,0 +1,38 @@
+"""backfill OAuth provider token-scope replay metadata
+
+Revision ID: 20260702_oauth_scope_metadata
+Revises: 20260617_solution_deploy_jobs
+"""
+
+from alembic import op
+
+
+revision = "20260702_oauth_scope_metadata"
+down_revision = "20260617_solution_deploy_jobs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE oauth_providers
+        SET provider_metadata =
+            COALESCE(provider_metadata, '{}'::jsonb)
+            || '{"omit_token_exchange_scope": true}'::jsonb
+        WHERE lower(provider_name) IN ('gotoconnect', 'ninjaone')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE oauth_providers
+        SET provider_metadata =
+            COALESCE(provider_metadata, '{}'::jsonb)
+            - 'omit_token_exchange_scope'
+        WHERE lower(provider_name) IN ('gotoconnect', 'ninjaone')
+          AND provider_metadata ->> 'omit_token_exchange_scope' = 'true'
+        """
+    )

--- a/api/bifrost/manifest.py
+++ b/api/bifrost/manifest.py
@@ -603,6 +603,11 @@ class ManifestOAuthProvider(EntityCodec, BaseModel):
     token_url: str | None = Field(default=None, description="OAuth token endpoint", **classify(FieldClass.CONTENT))
     token_url_defaults: dict | None = Field(default=None, description="Default params for token request", **classify(FieldClass.CONTENT))
     scopes: list[str] = Field(default_factory=list, description="OAuth scopes", **classify(FieldClass.CONTENT))
+    provider_metadata: dict = Field(
+        default_factory=dict,
+        description="Provider-specific OAuth behavior flags and metadata",
+        **classify(FieldClass.CONTENT),
+    )
     redirect_uri: str | None = Field(default=None, description="OAuth redirect URI", **classify(FieldClass.CONTENT))
 
     @classmethod
@@ -620,6 +625,7 @@ class ManifestOAuthProvider(EntityCodec, BaseModel):
             token_url=op.token_url,
             token_url_defaults=op.token_url_defaults or None,
             scopes=op.scopes or [],
+            provider_metadata=op.provider_metadata or {},
             redirect_uri=op.redirect_uri,
         )
 

--- a/api/src/models/contracts/export_import.py
+++ b/api/src/models/contracts/export_import.py
@@ -101,6 +101,7 @@ class OAuthProviderExportItem(BaseModel):
     token_url_defaults: dict = Field(default_factory=dict)
     redirect_uri: str | None = None
     scopes: list[str] = Field(default_factory=list)
+    provider_metadata: dict[str, Any] = Field(default_factory=dict)
     organization_id: str | None = None
     organization_name: str | None = None
 

--- a/api/src/models/contracts/integrations.py
+++ b/api/src/models/contracts/integrations.py
@@ -403,6 +403,10 @@ class OAuthConfigSummary(BaseModel):
     authorization_url: str | None = Field(default=None, description="Authorization URL")
     token_url: str = Field(..., description="Token URL")
     scopes: list[str] = Field(default_factory=list, description="OAuth scopes")
+    provider_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific OAuth behavior flags and metadata",
+    )
 
     # Connection status
     status: str = Field(default="not_connected", description="Connection status")

--- a/api/src/models/contracts/oauth.py
+++ b/api/src/models/contracts/oauth.py
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
 
 OAuthFlowType = Literal["authorization_code", "client_credentials", "refresh_token"]
 OAuthStatus = Literal["not_connected", "waiting_callback", "testing", "connected", "completed", "failed"]
+PROVIDER_METADATA_DESCRIPTION = "Provider-specific OAuth behavior flags and metadata"
+
+
+def _validate_provider_metadata(v: dict[str, Any]) -> dict[str, Any]:
+    flag = v.get("omit_token_exchange_scope")
+    if flag is not None and not isinstance(flag, bool):
+        raise ValueError("provider_metadata.omit_token_exchange_scope must be a boolean")
+    return v
 
 
 # ==================== OAUTH CONNECTION MODELS ====================
@@ -73,7 +81,7 @@ class CreateOAuthConnectionRequest(BaseModel):
     )
     provider_metadata: dict[str, Any] = Field(
         default_factory=dict,
-        description="Provider-specific OAuth behavior flags and metadata",
+        description=PROVIDER_METADATA_DESCRIPTION,
     )
     redirect_uri: str | None = Field(
         None,
@@ -90,6 +98,11 @@ class CreateOAuthConnectionRequest(BaseModel):
             if data.get('authorization_url') == '':
                 data['authorization_url'] = None
         return data
+
+    @field_validator("provider_metadata")
+    @classmethod
+    def validate_provider_metadata(cls, v: dict[str, Any]) -> dict[str, Any]:
+        return _validate_provider_metadata(v)
 
     @model_validator(mode='after')
     def validate_flow_requirements(self) -> 'CreateOAuthConnectionRequest':
@@ -132,8 +145,15 @@ class UpdateOAuthConnectionRequest(BaseModel):
     )
     provider_metadata: dict[str, Any] | None = Field(
         default=None,
-        description="Provider-specific OAuth behavior flags and metadata",
+        description=PROVIDER_METADATA_DESCRIPTION,
     )
+
+    @field_validator("provider_metadata")
+    @classmethod
+    def validate_provider_metadata(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        if v is None:
+            return None
+        return _validate_provider_metadata(v)
 
     @field_validator('scopes', mode='before')
     @classmethod
@@ -210,7 +230,7 @@ class OAuthConnectionDetail(BaseModel):
     )
     provider_metadata: dict[str, Any] = Field(
         default_factory=dict,
-        description="Provider-specific OAuth behavior flags and metadata",
+        description=PROVIDER_METADATA_DESCRIPTION,
     )
 
     # Status information
@@ -280,7 +300,7 @@ class OAuthConnection(BaseModel):
     scopes: str = ""
     provider_metadata: dict[str, Any] = Field(
         default_factory=dict,
-        description="Provider-specific OAuth behavior flags and metadata",
+        description=PROVIDER_METADATA_DESCRIPTION,
     )
     redirect_uri: str = Field(
         ...,

--- a/api/src/models/contracts/oauth.py
+++ b/api/src/models/contracts/oauth.py
@@ -71,6 +71,10 @@ class CreateOAuthConnectionRequest(BaseModel):
         max_length=500,
         description="OAuth audience parameter - identifies the target API/resource for the token request (e.g., required by Pax8, Auth0)"
     )
+    provider_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific OAuth behavior flags and metadata",
+    )
     redirect_uri: str | None = Field(
         None,
         description="OAuth redirect URI (defaults to /oauth/callback/{connection_name})"
@@ -125,6 +129,10 @@ class UpdateOAuthConnectionRequest(BaseModel):
         default=None,
         max_length=500,
         description="OAuth audience parameter"
+    )
+    provider_metadata: dict[str, Any] | None = Field(
+        default=None,
+        description="Provider-specific OAuth behavior flags and metadata",
     )
 
     @field_validator('scopes', mode='before')
@@ -200,6 +208,10 @@ class OAuthConnectionDetail(BaseModel):
         default=None,
         description="OAuth audience parameter for token requests"
     )
+    provider_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific OAuth behavior flags and metadata",
+    )
 
     # Status information
     status: OAuthStatus
@@ -266,6 +278,10 @@ class OAuthConnection(BaseModel):
         description="Default values for token_url placeholders (e.g., {'entity_id': 'common'})"
     )
     scopes: str = ""
+    provider_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific OAuth behavior flags and metadata",
+    )
     redirect_uri: str = Field(
         ...,
         description="Callback URL: /api/oauth/callback/{connection_name}"
@@ -346,6 +362,7 @@ class OAuthConnection(BaseModel):
             authorization_url=self.authorization_url,
             token_url=self.token_url,
             scopes=self.scopes,
+            provider_metadata=self.provider_metadata,
             status=self.status,
             status_message=self.status_message,
             integration_id=self.integration_id,

--- a/api/src/repositories/oauth.py
+++ b/api/src/repositories/oauth.py
@@ -87,6 +87,7 @@ class OAuthProviderRepository(OrgScopedRepository[OAuthProvider]):
         token_url: str | None,
         scopes_csv: str | None,
         created_by: str,
+        provider_metadata: dict[str, Any] | None = None,
     ) -> OAuthProvider:
         """Create a new OAuth provider/connection in the current scope."""
         from src.core.security import encrypt_secret
@@ -106,6 +107,7 @@ class OAuthProviderRepository(OrgScopedRepository[OAuthProvider]):
             authorization_url=authorization_url,
             token_url=token_url,
             scopes=scopes_csv.split(",") if scopes_csv else [],
+            provider_metadata=provider_metadata or {},
             status="not_connected",
             created_by=created_by,
         )
@@ -126,6 +128,7 @@ class OAuthProviderRepository(OrgScopedRepository[OAuthProvider]):
         token_url: str | None = None,
         scopes: list[str] | None = None,
         audience: str | None = None,
+        provider_metadata: dict[str, Any] | None = None,
     ) -> OAuthProvider | None:
         """Update an OAuth provider in-place."""
         from src.core.security import encrypt_secret
@@ -150,6 +153,8 @@ class OAuthProviderRepository(OrgScopedRepository[OAuthProvider]):
             provider.scopes = scopes
         if audience is not None:
             provider.audience = audience
+        if provider_metadata is not None:
+            provider.provider_metadata = provider_metadata
 
         provider.updated_at = datetime.now(timezone.utc)
         await self.session.flush()
@@ -302,6 +307,7 @@ class OAuthProviderRepository(OrgScopedRepository[OAuthProvider]):
             token_url=provider.token_url or "",
             scopes=scopes_str,
             audience=provider.audience,
+            provider_metadata=provider.provider_metadata or {},
             status=status,
             status_message=provider.status_message,
             integration_id=(

--- a/api/src/routers/export_import.py
+++ b/api/src/routers/export_import.py
@@ -388,6 +388,7 @@ async def _build_integrations_export(
                 token_url_defaults=op.token_url_defaults or {},
                 redirect_uri=op.redirect_uri,
                 scopes=op.scopes or [],
+                provider_metadata=op.provider_metadata or {},
                 organization_id=str(op.organization_id) if op.organization_id else None,
                 organization_name=org_names.get(op.organization_id) if op.organization_id else None,
             )
@@ -1187,6 +1188,7 @@ async def _import_oauth_provider(
         op.token_url_defaults = oauth_item.token_url_defaults
         op.redirect_uri = oauth_item.redirect_uri
         op.scopes = oauth_item.scopes
+        op.provider_metadata = oauth_item.provider_metadata or {}
     else:
         # Create new
         db.add(OAuthProvider(
@@ -1200,6 +1202,7 @@ async def _import_oauth_provider(
             token_url_defaults=oauth_item.token_url_defaults,
             redirect_uri=oauth_item.redirect_uri,
             scopes=oauth_item.scopes,
+            provider_metadata=oauth_item.provider_metadata or {},
             organization_id=org_id,
             integration_id=integration.id,
         ))

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -765,6 +765,7 @@ async def get_integration(
             last_refresh_at=provider.last_token_refresh,
             has_refresh_token=token.encrypted_refresh_token is not None if token else False,
             entity_id_source=provider.entity_id_source,
+            provider_metadata=provider.provider_metadata or {},
         )
 
     # Build mapping responses with org-specific overrides only (not merged with defaults)

--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -199,6 +199,7 @@ async def create_connection(
         token_url=request.token_url,
         scopes=request.scopes.split(",") if request.scopes else [],
         audience=request.audience,
+        provider_metadata=request.provider_metadata,
         status="not_connected",
         created_by=ctx.user.email,
         integration_id=integration_id,
@@ -234,7 +235,18 @@ async def update_connection(
     org_id = ctx.org_id
     repo = OAuthProviderRepository(ctx.db, org_id=org_id, is_superuser=True)
 
-    provider = await repo.update_connection(connection_name, name=request.name, oauth_flow_type=request.oauth_flow_type, client_id=request.client_id, client_secret=request.client_secret, authorization_url=request.authorization_url, token_url=request.token_url, scopes=request.scopes, audience=request.audience)
+    provider = await repo.update_connection(
+        connection_name,
+        name=request.name,
+        oauth_flow_type=request.oauth_flow_type,
+        client_id=request.client_id,
+        client_secret=request.client_secret,
+        authorization_url=request.authorization_url,
+        token_url=request.token_url,
+        scopes=request.scopes,
+        audience=request.audience,
+        provider_metadata=request.provider_metadata,
+    )
 
     if not provider:
         raise HTTPException(

--- a/api/src/services/manifest_generator.py
+++ b/api/src/services/manifest_generator.py
@@ -211,6 +211,7 @@ def serialize_integration(
                 token_url=oauth_provider.token_url,
                 token_url_defaults=oauth_provider.token_url_defaults or None,
                 scopes=oauth_provider.scopes or [],
+                provider_metadata=oauth_provider.provider_metadata or {},
                 redirect_uri=oauth_provider.redirect_uri,
             )
             if oauth_provider else None

--- a/api/src/services/manifest_import.py
+++ b/api/src/services/manifest_import.py
@@ -2100,6 +2100,7 @@ class ManifestResolver:
                 token_url=op_data.token_url,
                 token_url_defaults=op_data.token_url_defaults or {},
                 scopes=op_data.scopes or [],
+                provider_metadata=op_data.provider_metadata or {},
                 redirect_uri=op_data.redirect_uri,
                 integration_id=integ_id,
             ).on_conflict_do_update(
@@ -2116,6 +2117,7 @@ class ManifestResolver:
                     "token_url": op_data.token_url,
                     "token_url_defaults": op_data.token_url_defaults or {},
                     "scopes": op_data.scopes or [],
+                    "provider_metadata": op_data.provider_metadata or {},
                     "redirect_uri": op_data.redirect_uri,
                     "updated_at": datetime.now(timezone.utc),
                 },

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -23,18 +23,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-PROVIDERS_OMIT_TOKEN_EXCHANGE_SCOPE = frozenset(
-    {
-        "gotoconnect",
-        "ninjaone",
-    }
-)
-
-
 def compute_token_exchange_scopes(provider: "OAuthProvider") -> str | None:
     """Return scopes to send during authorization-code token exchange."""
-    provider_name = provider.provider_name or ""
-    if provider_name.casefold() in PROVIDERS_OMIT_TOKEN_EXCHANGE_SCOPE:
+    provider_metadata = provider.provider_metadata or {}
+    if provider_metadata.get("omit_token_exchange_scope") is True:
         return None
 
     return " ".join(provider.scopes) if provider.scopes else None

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -23,13 +23,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-PROVIDER_NINJAONE = "NinjaOne"
+PROVIDERS_OMIT_TOKEN_EXCHANGE_SCOPE = frozenset(
+    {
+        "gotoconnect",
+        "ninjaone",
+    }
+)
 
 
 def compute_token_exchange_scopes(provider: "OAuthProvider") -> str | None:
     """Return scopes to send during authorization-code token exchange."""
     provider_name = provider.provider_name or ""
-    if provider_name.casefold() == PROVIDER_NINJAONE.casefold():
+    if provider_name.casefold() in PROVIDERS_OMIT_TOKEN_EXCHANGE_SCOPE:
         return None
 
     return " ".join(provider.scopes) if provider.scopes else None

--- a/api/tests/unit/golden/manifest_codec/integration_git_sync.json
+++ b/api/tests/unit/golden/manifest_codec/integration_git_sync.json
@@ -29,6 +29,7 @@
     "display_name": "RT Golden OAuth",
     "oauth_flow_type": "authorization_code",
     "provider_name": "rt-golden-oauth",
+    "provider_metadata": {},
     "redirect_uri": "https://app.example.com/callback",
     "scopes": [
       "openid",

--- a/api/tests/unit/routers/test_export_import.py
+++ b/api/tests/unit/routers/test_export_import.py
@@ -281,6 +281,17 @@ class TestOrganizationNameSerialization:
         data = json.loads(item.model_dump_json())
         assert data["organization_name"] == "Contoso"
 
+    def test_oauth_provider_includes_provider_metadata(self):
+        """OAuth provider export item carries provider behavior metadata."""
+        item = OAuthProviderExportItem(
+            provider_name="scope-sensitive",
+            client_id="c1",
+            encrypted_client_secret="secret",
+            provider_metadata={"omit_token_exchange_scope": True},
+        )
+        data = json.loads(item.model_dump_json())
+        assert data["provider_metadata"] == {"omit_token_exchange_scope": True}
+
     def test_knowledge_roundtrip_with_org_name(self):
         """Knowledge export with org_name survives serialization roundtrip."""
         export = KnowledgeExportFile(

--- a/api/tests/unit/routers/test_oauth_refresh.py
+++ b/api/tests/unit/routers/test_oauth_refresh.py
@@ -231,6 +231,7 @@ class TestOAuthRefreshClientCredentials:
 
         provider = MagicMock()
         provider.provider_name = "NinjaOne"
+        provider.provider_metadata = {"omit_token_exchange_scope": True}
         provider.token_url = "https://app.ninjarmm.com/oauth/token"
         provider.client_id = "test-client-id"
         provider.encrypted_client_secret = b"encrypted-secret"

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -24,23 +24,37 @@ def oauth_client():
 
 
 class TestTokenExchangeScopePolicy:
-    """Test provider-specific scope replay behavior for token exchange."""
+    """Test provider-configured scope replay behavior for token exchange."""
 
     def test_generic_provider_replays_authorized_scopes(self):
         """Generic OAuth providers should send configured scopes to token exchange."""
-        provider = SimpleNamespace(provider_name="Generic OAuth", scopes=["read", "write"])
+        provider = SimpleNamespace(
+            provider_metadata={},
+            provider_name="Generic OAuth",
+            scopes=["read", "write"],
+        )
 
         assert compute_token_exchange_scopes(provider) == "read write"
 
-    @pytest.mark.parametrize(
-        "provider_name",
-        ["NinjaOne", "ninjaone", "GoToConnect", "gotoconnect"],
-    )
-    def test_scope_sensitive_providers_omit_token_exchange_scopes(self, provider_name):
-        """Providers that reject scope replay should omit scope from token exchange."""
-        provider = SimpleNamespace(provider_name=provider_name, scopes=["read", "write"])
+    def test_provider_metadata_can_omit_token_exchange_scope(self):
+        """Providers that reject scope replay should opt out via metadata."""
+        provider = SimpleNamespace(
+            provider_metadata={"omit_token_exchange_scope": True},
+            provider_name="ScopeSensitiveProvider",
+            scopes=["read", "write"],
+        )
 
         assert compute_token_exchange_scopes(provider) is None
+
+    def test_provider_name_does_not_control_token_exchange_scope_policy(self):
+        """Provider-specific behavior should be data-driven, not name-driven."""
+        provider = SimpleNamespace(
+            provider_metadata={},
+            provider_name="NinjaOne",
+            scopes=["read", "write"],
+        )
+
+        assert compute_token_exchange_scopes(provider) == "read write"
 
 
 class TestOAuthProviderTokenExchange:

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -7,15 +7,40 @@ Mocks HTTP requests to OAuth providers.
 import pytest
 import asyncio
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from src.services.oauth_provider import OAuthProviderClient, append_query_params
+from src.services.oauth_provider import (
+    OAuthProviderClient,
+    append_query_params,
+    compute_token_exchange_scopes,
+)
 
 
 @pytest.fixture
 def oauth_client():
     """Create OAuth provider client with test defaults"""
     return OAuthProviderClient(timeout=10, max_retries=3)
+
+
+class TestTokenExchangeScopePolicy:
+    """Test provider-specific scope replay behavior for token exchange."""
+
+    def test_generic_provider_replays_authorized_scopes(self):
+        """Generic OAuth providers should send configured scopes to token exchange."""
+        provider = SimpleNamespace(provider_name="Generic OAuth", scopes=["read", "write"])
+
+        assert compute_token_exchange_scopes(provider) == "read write"
+
+    @pytest.mark.parametrize(
+        "provider_name",
+        ["NinjaOne", "ninjaone", "GoToConnect", "gotoconnect"],
+    )
+    def test_scope_sensitive_providers_omit_token_exchange_scopes(self, provider_name):
+        """Providers that reject scope replay should omit scope from token exchange."""
+        provider = SimpleNamespace(provider_name=provider_name, scopes=["read", "write"])
+
+        assert compute_token_exchange_scopes(provider) is None
 
 
 class TestOAuthProviderTokenExchange:

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -10,6 +10,9 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 
+from pydantic import ValidationError
+
+from src.models.contracts.oauth import CreateOAuthConnectionRequest, UpdateOAuthConnectionRequest
 from src.services.oauth_provider import (
     OAuthProviderClient,
     append_query_params,
@@ -55,6 +58,27 @@ class TestTokenExchangeScopePolicy:
         )
 
         assert compute_token_exchange_scopes(provider) == "read write"
+
+
+class TestProviderMetadataValidation:
+    """Test request validation for provider behavior metadata."""
+
+    def test_create_request_rejects_non_boolean_omit_scope_flag(self):
+        with pytest.raises(ValidationError, match="omit_token_exchange_scope must be a boolean"):
+            CreateOAuthConnectionRequest(
+                integration_id="integration-id",
+                oauth_flow_type="authorization_code",
+                client_id="client-id",
+                authorization_url="https://auth.example.com/oauth/authorize",
+                token_url="https://auth.example.com/oauth/token",
+                provider_metadata={"omit_token_exchange_scope": "true"},
+            )
+
+    def test_update_request_rejects_non_boolean_omit_scope_flag(self):
+        with pytest.raises(ValidationError, match="omit_token_exchange_scope must be a boolean"):
+            UpdateOAuthConnectionRequest(
+                provider_metadata={"omit_token_exchange_scope": 1},
+            )
 
 
 class TestOAuthProviderTokenExchange:

--- a/api/tests/unit/test_manifest_codec.py
+++ b/api/tests/unit/test_manifest_codec.py
@@ -1618,6 +1618,21 @@ def test_child_models_have_no_standalone_orm_path(dest):
             child.to_orm_values(dest)
 
 
+def test_oauth_provider_manifest_carries_provider_metadata():
+    """OAuth provider behavior flags should round-trip through manifest data."""
+    from bifrost.manifest import ManifestOAuthProvider
+    from bifrost.manifest_codec import Destination
+
+    provider = ManifestOAuthProvider(
+        provider_name="scope-sensitive",
+        provider_metadata={"omit_token_exchange_scope": True},
+    )
+
+    assert provider.view(Destination.GIT_SYNC)["provider_metadata"] == {
+        "omit_token_exchange_scope": True,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Structural guard against "Leak A": a field that to_orm_values(INSTALL) writes
 # from self.X but that view(INSTALL) drops will silently reconstitute to its

--- a/api/tests/unit/test_manifest_import.py
+++ b/api/tests/unit/test_manifest_import.py
@@ -315,6 +315,7 @@ class TestManifestDestructiveScope:
 
         assert _collect_removed_entity_ids(changes) == {}
 
+
     def test_scope_filter_limits_non_file_deletes_to_declared_org_scope(self):
         from src.services.manifest_import import (
             _collect_removed_entity_ids,
@@ -404,6 +405,71 @@ class TestManifestDestructiveScope:
         assert _manifest_access_level(None, ["role-id"]) == "role_based"
         assert _manifest_access_level(None, []) is None
         assert _manifest_access_level("authenticated", ["role-id"]) == "authenticated"
+
+
+class TestManifestIntegrationOAuthProviderImport:
+    """Pin OAuth provider metadata persistence through integration import."""
+
+    @pytest.mark.asyncio
+    async def test_oauth_provider_upsert_persists_provider_metadata(self, db_session):
+        import uuid
+
+        from sqlalchemy import select
+
+        from bifrost.manifest import ManifestIntegration, ManifestOAuthProvider
+        from src.models.orm.oauth import OAuthProvider
+        from src.services.manifest_import import ManifestResolver
+
+        integration_id = str(uuid.uuid4())
+        resolver = ManifestResolver(db_session)
+
+        await resolver._resolve_integration(
+            "scope-sensitive",
+            ManifestIntegration(
+                id=integration_id,
+                name="scope-sensitive",
+                oauth_provider=ManifestOAuthProvider(
+                    provider_name="scope-sensitive",
+                    client_id="client-one",
+                    token_url="https://auth.example.com/oauth/token",
+                    scopes=["read"],
+                    provider_metadata={"omit_token_exchange_scope": True},
+                ),
+            ),
+        )
+        await db_session.flush()
+
+        provider = (
+            await db_session.execute(
+                select(OAuthProvider).where(OAuthProvider.integration_id == uuid.UUID(integration_id))
+            )
+        ).scalar_one()
+        assert provider.provider_metadata == {"omit_token_exchange_scope": True}
+
+        await resolver._resolve_integration(
+            "scope-sensitive",
+            ManifestIntegration(
+                id=integration_id,
+                name="scope-sensitive",
+                oauth_provider=ManifestOAuthProvider(
+                    provider_name="scope-sensitive",
+                    client_id="client-two",
+                    token_url="https://auth.example.com/oauth/token",
+                    scopes=["read", "write"],
+                    provider_metadata={"omit_token_exchange_scope": False},
+                ),
+            ),
+        )
+        await db_session.flush()
+
+        provider = (
+            await db_session.execute(
+                select(OAuthProvider).where(OAuthProvider.integration_id == uuid.UUID(integration_id))
+            )
+        ).scalar_one()
+        assert provider.client_id == "client-two"
+        assert provider.scopes == ["read", "write"]
+        assert provider.provider_metadata == {"omit_token_exchange_scope": False}
 
 
 class TestManifestAppPathSafety:

--- a/api/tests/unit/test_manifest_import.py
+++ b/api/tests/unit/test_manifest_import.py
@@ -438,6 +438,7 @@ class TestManifestIntegrationOAuthProviderImport:
             ),
         )
         await db_session.flush()
+        db_session.expire_all()
 
         provider = (
             await db_session.execute(
@@ -461,6 +462,7 @@ class TestManifestIntegrationOAuthProviderImport:
             ),
         )
         await db_session.flush()
+        db_session.expire_all()
 
         provider = (
             await db_session.execute(


### PR DESCRIPTION
## Summary
- add `provider_metadata.omit_token_exchange_scope` so OAuth providers can opt out of replaying `scope` during authorization-code token exchange
- carry OAuth provider metadata through API contracts, repository writes, integration details, export/import, and manifest generation/import
- backfill existing NinjaOne and GoToConnect provider rows to preserve current reconnect behavior while keeping runtime policy data-driven
- validate the metadata flag on request models and cover manifest-import upsert persistence

## Context
Some OAuth providers require scopes on the authorization request but reject a repeated `scope` parameter during the token exchange. GoToConnect returns: `All the submitted scopes from the consent page must be in the original authorization request.`

NinjaOne had the same fork-local behavior previously. This version removes provider-name checks from token exchange logic and makes the behavior an explicit provider capability, which is the shape we can propose upstream.

Relates to #385.

## Verification
- GitHub CI on latest head `796d9abc14d77a153ee70b7e2466556c9f6624ad`: all required checks green, including Unit Tests and E2E Tests.
- Talos devcontainer focused run: https://github.com/MTG-Thomas/bifrost-infra/actions/runs/28606973968
- Talos command: `PYTHONPATH=api python -m pytest api/tests/unit/routers/test_oauth_refresh.py::TestOAuthRefreshClientCredentials::test_callback_omits_token_exchange_scope_for_ninjaone api/tests/unit/services/test_oauth_provider.py::TestTokenExchangeScopePolicy api/tests/unit/routers/test_export_import.py::TestOrganizationNameSerialization::test_oauth_provider_includes_provider_metadata api/tests/unit/test_manifest_codec.py::test_oauth_provider_manifest_carries_provider_metadata -q`
- Talos result: `6 passed in 6.28s`