### PR TITLE
Fix Sonar quality gate findings

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse, urlsplit, urlunsplit
 
 if TYPE_CHECKING:
     import pathspec
@@ -2844,6 +2844,19 @@ async def _auto_validate_app(
                 print(f"  [{ts}] \u26a0 Auto-validate '{slug}' failed: {e}", flush=True)
 
 
+def _file_activity_ws_url(api_url: str) -> str:
+    """Build the file-activity WebSocket URL, allowing cleartext only for local dev."""
+    parsed = urlsplit(api_url.rstrip("/"))
+    if parsed.scheme == "https":
+        scheme = "wss"
+    elif parsed.scheme == "http" and parsed.hostname in {"localhost", "127.0.0.1", "::1"}:
+        scheme = "ws"
+    else:
+        raise ValueError("file-activity WebSocket requires HTTPS unless the API URL is localhost")
+
+    return urlunsplit((scheme, parsed.netloc, "/ws/connect", "channels=file-activity", ""))
+
+
 async def _ws_listener(state: _WatchState, client: "BifrostClient") -> None:
     """Listen for file-activity WebSocket events from other sessions."""
     try:
@@ -2853,8 +2866,7 @@ async def _ws_listener(state: _WatchState, client: "BifrostClient") -> None:
         print("  Reinstall CLI: pipx install --force <url>", flush=True)
         return
 
-    ws_url = client.api_url.replace("https://", "wss://").replace("http://", "ws://")
-    ws_url += "/ws/connect?channels=file-activity"
+    ws_url = _file_activity_ws_url(client.api_url)
     backoff = 1.0
     connected_once = False
 

--- a/api/scripts/check_mtg_ci_boundaries.py
+++ b/api/scripts/check_mtg_ci_boundaries.py
@@ -15,6 +15,24 @@ EXPECTED_DEPLOY_DEV_IF = (
 )
 
 
+def _repo_root() -> Path:
+    path = Path(__file__).resolve()
+    root = path.parents[2]
+    if root == root.parent:
+        # The API test container mounts api/ at /app, so api/scripts becomes
+        # /app/scripts and parents[2] is the filesystem root.
+        return path.parents[1]
+    return root
+
+
+def _resolve_workflow_path(path: Path) -> Path:
+    root = _repo_root()
+    resolved = (root / path).resolve() if not path.is_absolute() else path.resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError(f"{path}: workflow path must stay within {root}")
+    return resolved
+
+
 def _job_block(lines: list[str], job_name: str) -> tuple[int, list[str]] | None:
     marker = f"  {job_name}:"
     for index, line in enumerate(lines):
@@ -73,7 +91,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    violations = check_ci_workflow(args.workflow)
+    try:
+        workflow = _resolve_workflow_path(args.workflow)
+    except ValueError as exc:
+        print(f"MTG CI boundary check failed: {exc}", file=sys.stderr)
+        return 2
+
+    violations = check_ci_workflow(workflow)
     if not violations:
         print("MTG CI boundary checks passed.")
         return 0

--- a/api/src/services/file_storage/diagnostics.py
+++ b/api/src/services/file_storage/diagnostics.py
@@ -18,6 +18,7 @@ from src.models.contracts.notifications import (
     NotificationCategory,
     NotificationStatus,
 )
+from src.core.log_safety import log_safe
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class DiagnosticsService:
             category=NotificationCategory.SYSTEM,
         )
         if existing:
-            logger.debug(f"SDK notification already exists for {path}")
+            logger.debug("SDK notification already exists for %s", log_safe(path))
             return
 
         # Build description with first few issues
@@ -116,7 +117,11 @@ class DiagnosticsService:
             initial_status=NotificationStatus.AWAITING_ACTION,
         )
 
-        logger.info(f"Created SDK issues notification for {path}: {len(issues)} issues")
+        logger.info(
+            "Created SDK issues notification for %s: %s issues",
+            log_safe(path),
+            len(issues),
+        )
 
     async def clear_sdk_issues_notification(self, path: str) -> None:
         """
@@ -140,7 +145,7 @@ class DiagnosticsService:
         )
         if existing:
             await service.dismiss_notification(existing.id, user_id="system")
-            logger.info(f"Cleared SDK issues notification for {path}")
+            logger.info("Cleared SDK issues notification for %s", log_safe(path))
 
     async def create_diagnostic_notification(
         self, path: str, diagnostics: list[FileDiagnosticInfo]
@@ -171,7 +176,7 @@ class DiagnosticsService:
             category=NotificationCategory.SYSTEM,
         )
         if existing:
-            logger.debug(f"Diagnostic notification already exists for {path}")
+            logger.debug("Diagnostic notification already exists for %s", log_safe(path))
             return
 
         # Build description from first few errors
@@ -206,7 +211,11 @@ class DiagnosticsService:
             initial_status=NotificationStatus.AWAITING_ACTION,
         )
 
-        logger.info(f"Created diagnostic notification for {path}: {len(errors)} errors")
+        logger.info(
+            "Created diagnostic notification for %s: %s errors",
+            log_safe(path),
+            len(errors),
+        )
 
     async def clear_diagnostic_notification(self, path: str) -> None:
         """
@@ -230,7 +239,7 @@ class DiagnosticsService:
         )
         if existing:
             await service.dismiss_notification(existing.id, user_id="system")
-            logger.info(f"Cleared diagnostic notification for {path}")
+            logger.info("Cleared diagnostic notification for %s", log_safe(path))
 
     async def scan_for_unresolved_refs(
         self,
@@ -266,7 +275,7 @@ class DiagnosticsService:
             category=NotificationCategory.SYSTEM,
         )
         if existing:
-            logger.debug(f"Unresolved refs notification already exists for {path}")
+            logger.debug("Unresolved refs notification already exists for %s", log_safe(path))
             return
 
         # Build description with first few refs
@@ -292,7 +301,11 @@ class DiagnosticsService:
             initial_status=NotificationStatus.AWAITING_ACTION,
         )
 
-        logger.info(f"Created unresolved refs notification for {path}: {len(unresolved_refs)} refs")
+        logger.info(
+            "Created unresolved refs notification for %s: %s refs",
+            log_safe(path),
+            len(unresolved_refs),
+        )
 
     async def clear_unresolved_refs_notification(self, path: str) -> None:
         """
@@ -316,4 +329,4 @@ class DiagnosticsService:
         )
         if existing:
             await service.dismiss_notification(existing.id, user_id="system")
-            logger.info(f"Cleared unresolved refs notification for {path}")
+            logger.info("Cleared unresolved refs notification for %s", log_safe(path))

--- a/api/src/services/openapi_endpoints.py
+++ b/api/src/services/openapi_endpoints.py
@@ -204,7 +204,7 @@ def register_workflow_endpoint(app: FastAPI, workflow: Workflow) -> None:
 
     # Check if route already exists and remove it
     path = f"/api/endpoints/{workflow_name}"
-    app.routes = [r for r in app.routes if getattr(r, "path", None) != path]
+    app.router.routes = [r for r in app.router.routes if getattr(r, "path", None) != path]
 
     # Create the route handler
     # We use api_route to support multiple methods
@@ -224,7 +224,7 @@ def register_workflow_endpoint(app: FastAPI, workflow: Workflow) -> None:
     ) -> EndpointExecuteResponse:
         # Delegate to the main execute_endpoint function
         return await execute_endpoint(
-            workflow_name=workflow_name,
+            workflow_id=workflow_name,
             request=request,
             x_bifrost_key=x_bifrost_key,
         )

--- a/api/src/services/sdk_reference_scanner.py
+++ b/api/src/services/sdk_reference_scanner.py
@@ -18,6 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.orm import Config, Integration, IntegrationMapping
+from src.core.log_safety import log_safe
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +191,12 @@ class SDKReferenceScanner:
                     issue_type="config",
                     key=key,
                 ))
-                logger.debug(f"Missing config reference: {key} at {path}:{line_num}")
+                logger.debug(
+                    "Missing config reference: %s at %s:%s",
+                    log_safe(key),
+                    log_safe(path),
+                    line_num,
+                )
 
         # Validate integration references
         if integration_refs:
@@ -204,10 +210,15 @@ class SDKReferenceScanner:
                     issue_type="integration",
                     key=name,
                 ))
-                logger.debug(f"Missing integration reference: {name} at {path}:{line_num}")
+                logger.debug(
+                    "Missing integration reference: %s at %s:%s",
+                    log_safe(name),
+                    log_safe(path),
+                    line_num,
+                )
 
         if issues:
-            logger.info(f"Found {len(issues)} SDK issue(s) in {path}")
+            logger.info("Found %s SDK issue(s) in %s", len(issues), log_safe(path))
 
         return issues
 
@@ -224,7 +235,7 @@ class SDKReferenceScanner:
         all_issues: list[SDKIssue] = []
 
         if not workspace_path.exists():
-            logger.warning(f"Workspace path does not exist: {workspace_path}")
+            logger.warning("Workspace path does not exist: %s", log_safe(workspace_path))
             return all_issues
 
         # Find all Python files, excluding __pycache__ and hidden dirs
@@ -237,14 +248,15 @@ class SDKReferenceScanner:
 
             try:
                 content = py_file.read_text(encoding='utf-8')
-                relative_path = str(py_file.relative_to(workspace_path))
+                relative_path = py_file.relative_to(workspace_path).as_posix()
                 issues = await self.scan_file(relative_path, content)
                 all_issues.extend(issues)
             except (OSError, UnicodeDecodeError) as e:
-                logger.warning(f"Failed to read {py_file}: {e}")
+                logger.warning("Failed to read %s: %s", log_safe(py_file), log_safe(e))
 
         logger.info(
-            f"Workspace scan complete: scanned {workspace_path}, "
-            f"found {len(all_issues)} issue(s)"
+            "Workspace scan complete: scanned %s, found %s issue(s)",
+            log_safe(workspace_path),
+            len(all_issues),
         )
         return all_issues

--- a/api/tests/unit/scripts/test_check_mtg_ci_boundaries.py
+++ b/api/tests/unit/scripts/test_check_mtg_ci_boundaries.py
@@ -1,0 +1,14 @@
+import pytest
+
+from scripts.check_mtg_ci_boundaries import _repo_root, _resolve_workflow_path
+
+
+def test_resolve_workflow_path_rejects_paths_outside_repo():
+    outside = _repo_root().parent / "outside.yml"
+    with pytest.raises(ValueError, match="must stay within"):
+        _resolve_workflow_path(outside)
+
+
+def test_repo_root_never_resolves_to_filesystem_root():
+    root = _repo_root()
+    assert root != root.parent

--- a/api/tests/unit/services/test_diagnostics_unresolved_refs.py
+++ b/api/tests/unit/services/test_diagnostics_unresolved_refs.py
@@ -95,6 +95,33 @@ class TestUnresolvedRefNotifications:
             )
 
     @pytest.mark.asyncio
+    async def test_clearing_notification_logs_sanitized_path(
+        self, diagnostics_service, caplog
+    ):
+        """User-controlled paths are escaped before they enter log records."""
+        with patch(
+            "src.services.file_storage.diagnostics.get_notification_service"
+        ) as mock_get_service:
+            mock_notification = MagicMock()
+            mock_notification.id = "notif-123"
+
+            mock_service = MagicMock()
+            mock_service.find_admin_notification_by_title = AsyncMock(
+                return_value=mock_notification
+            )
+            mock_service.dismiss_notification = AsyncMock()
+            mock_get_service.return_value = mock_service
+
+            with caplog.at_level("INFO", logger="src.services.file_storage.diagnostics"):
+                await diagnostics_service.clear_unresolved_refs_notification(
+                    path="apps/my-app/pages/index.tsx\nforged=true"
+                )
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("index.tsx\\nforged=true" in message for message in messages)
+        assert all("index.tsx\nforged=true" not in message for message in messages)
+
+    @pytest.mark.asyncio
     async def test_skips_duplicate_notification(self, diagnostics_service):
         """Does not create duplicate notification if one already exists."""
         unresolved = ["workflows/missing.py::func"]

--- a/api/tests/unit/services/test_openapi_endpoints.py
+++ b/api/tests/unit/services/test_openapi_endpoints.py
@@ -8,12 +8,17 @@ including parameter mapping, method handling, and schema structure.
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 from src.services.openapi_endpoints import (
     generate_workflow_openapi_schema,
     _param_to_openapi_schema,
     get_endpoint_enabled_workflows,
+    register_workflow_endpoint,
     TYPE_TO_OPENAPI,
 )
+from src.routers.endpoints import EndpointExecuteResponse
 
 
 class TestParamToOpenAPISchema:
@@ -258,6 +263,43 @@ class TestGetEndpointEnabledWorkflows:
 
             assert result == []
             mock_db.execute.assert_called_once()
+
+
+class TestRegisterWorkflowEndpoint:
+    """Tests for dynamic route registration."""
+
+    def test_registered_route_delegates_with_workflow_id(self):
+        """Dynamic route passes the registered workflow name as workflow_id."""
+        app = FastAPI()
+        workflow = MagicMock()
+        workflow.name = "dynamic_workflow"
+        workflow.description = "Dynamic workflow"
+        workflow.allowed_methods = ["POST"]
+        workflow.parameters_schema = []
+
+        async def fake_execute_endpoint(workflow_id, request, x_bifrost_key):
+            return EndpointExecuteResponse(
+                execution_id=f"exec-{workflow_id}",
+                status="queued",
+                message=x_bifrost_key,
+            )
+
+        with patch(
+            "src.routers.endpoints.execute_endpoint",
+            side_effect=fake_execute_endpoint,
+        ) as mock_execute:
+            register_workflow_endpoint(app, workflow)
+            response = TestClient(app).post(
+                "/api/endpoints/dynamic_workflow",
+                headers={"X-Bifrost-Key": "test-key"},
+                json={},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["execution_id"] == "exec-dynamic_workflow"
+        mock_execute.assert_called_once()
+        assert mock_execute.call_args.kwargs["workflow_id"] == "dynamic_workflow"
+        assert mock_execute.call_args.kwargs["x_bifrost_key"] == "test-key"
 
 
 class TestTypeMapping:

--- a/api/tests/unit/services/test_sdk_reference_scanner.py
+++ b/api/tests/unit/services/test_sdk_reference_scanner.py
@@ -172,6 +172,23 @@ class TestScanFile:
         assert issues[0].file_path == "test.py"
 
     @pytest.mark.asyncio
+    async def test_missing_config_log_escapes_user_controlled_values(
+        self, async_scanner, caplog
+    ):
+        code = 'key = await config.get("missing\\nkey")'
+        async_scanner.get_all_config_keys = AsyncMock(return_value=set())
+        async_scanner.get_all_mapped_integrations = AsyncMock(return_value=set())
+
+        with caplog.at_level("DEBUG", logger="src.services.sdk_reference_scanner"):
+            await async_scanner.scan_file("wf.py\nforged=true", code)
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("missing\\nkey" in message for message in messages)
+        assert any("wf.py\\nforged=true" in message for message in messages)
+        assert all("missing\nkey" not in message for message in messages)
+        assert all("wf.py\nforged=true" not in message for message in messages)
+
+    @pytest.mark.asyncio
     async def test_missing_integration(self, async_scanner):
         code = 'halo = await integrations.get("Unknown")'
         async_scanner.get_all_config_keys = AsyncMock(return_value=set())

--- a/api/tests/unit/test_cli_watch.py
+++ b/api/tests/unit/test_cli_watch.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from bifrost.cli import _WatchChangeHandler, _WatchState
+from bifrost.cli import _WatchChangeHandler, _WatchState, _file_activity_ws_url
 
 
 def test_read_only_events_are_ignored():
@@ -160,7 +160,7 @@ def test_deletion_computes_correct_repo_path():
     repo_prefix = "my-org/my-repo"
 
     rel = abs_path.relative_to(base)
-    repo_path = f"{repo_prefix}/{rel}" if repo_prefix else str(rel)
+    repo_path = f"{repo_prefix}/{rel.as_posix()}" if repo_prefix else rel.as_posix()
 
     assert repo_path == "my-org/my-repo/apps/my-app/old-file.tsx"
 
@@ -172,7 +172,7 @@ def test_deletion_computes_repo_path_without_prefix():
     repo_prefix = ""
 
     rel = abs_path.relative_to(base)
-    repo_path = f"{repo_prefix}/{rel}" if repo_prefix else str(rel)
+    repo_path = f"{repo_prefix}/{rel.as_posix()}" if repo_prefix else rel.as_posix()
 
     assert repo_path == "apps/my-app/old-file.tsx"
 
@@ -318,6 +318,25 @@ def test_watch_handler_respects_root_gitignore_for_subdirectory_watch(tmp_path):
     assert str(generated) not in state.pending_changes
     assert str(local_config) not in state.pending_changes
     assert str(real_path) in state.pending_changes
+
+
+def test_file_activity_ws_url_uses_wss_for_https():
+    assert (
+        _file_activity_ws_url("https://dev.bifrost.example")
+        == "wss://dev.bifrost.example/ws/connect?channels=file-activity"
+    )
+
+
+def test_file_activity_ws_url_allows_localhost_cleartext_dev():
+    assert (
+        _file_activity_ws_url("http://localhost:8000")
+        == "ws://localhost:8000/ws/connect?channels=file-activity"
+    )
+
+
+def test_file_activity_ws_url_rejects_remote_cleartext():
+    with pytest.raises(ValueError, match="requires HTTPS"):
+        _file_activity_ws_url("http://bifrost.example")
 
 
 def test_watch_handler_dropped_events_do_not_call_post(tmp_path, monkeypatch):

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,3 +8,8 @@ sonar.test.inclusions=api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/
 sonar.test.exclusions=api/tests/unit/cli/test_cli_version_check.py
 sonar.exclusions=scripts/docs/**,client/e2e/docs/**,api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts
 sonar.cpd.exclusions=api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts
+# Tailwind v4 @custom-variant blocks intentionally use nested selector syntax
+# with @slot; Sonar CSS rule S8776 does not understand this Tailwind at-rule.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=css:S8776
+sonar.issue.ignore.multicriteria.e1.resourceKey=client/src/index.css


### PR DESCRIPTION
## Summary
- restrict file-activity WebSocket URLs to WSS except localhost development
- sanitize user-controlled paths/keys before logging diagnostics and SDK scanner messages
- harden the MTG CI boundary script against out-of-repo workflow paths
- fix dynamic endpoint route replacement/delegation and exclude a Tailwind v4 Sonar false positive

## Verification
- `PYTHONPATH=api ../bifrost/.venv/Scripts/python.exe -m pytest api/tests/unit/test_cli_watch.py api/tests/unit/services/test_diagnostics_unresolved_refs.py api/tests/unit/services/test_openapi_endpoints.py api/tests/unit/services/test_sdk_reference_scanner.py api/tests/unit/scripts/test_check_mtg_ci_boundaries.py -q` (`87 passed`)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch CLI watch transport policy, dynamic API route registration, and logging on file-save paths; fixes are narrow and well-tested, but incorrect endpoint wiring could break workflow HTTP execution.
> 
> **Overview**
> Addresses Sonar quality-gate findings with targeted security and correctness fixes across the CLI, API services, and CI tooling.
> 
> **Watch bidirectional sync** now builds the file-activity WebSocket URL via `_file_activity_ws_url`: **WSS** for HTTPS APIs, **WS** only for localhost HTTP, and an error for cleartext remote hosts—replacing naive `http→ws` string replacement.
> 
> **Logging** in file diagnostics and the SDK reference scanner wraps user-controlled paths and keys with `log_safe()` and uses parameterized log calls so forged newlines cannot pollute log output.
> 
> **MTG CI boundary script** resolves the workflow file against a repo root that works when `api/` is mounted at `/app`, rejects paths outside the repo, and adds unit tests for those guards.
> 
> **Dynamic workflow endpoints** remove stale routes via `app.router.routes` and delegate to `execute_endpoint` with the correct `workflow_id` keyword; a new test exercises registration end-to-end.
> 
> **Sonar** ignores a Tailwind v4 false positive in `client/src/index.css`; watch/SDK/diagnostics tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bd36a456d22d80a83359e232cfc3d1ddf3663c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->