### PR TITLE
fix: exclude Tailwind CSS from Sonar analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,10 +6,9 @@ sonar.test.inclusions=api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/
 # This unit test owns CLI endpoint URL fixtures; local/dev URLs may be http://
 # without representing production-facing transport.
 sonar.test.exclusions=api/tests/unit/cli/test_cli_version_check.py
-sonar.exclusions=scripts/docs/**,client/e2e/docs/**,api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts
+sonar.exclusions=scripts/docs/**,client/e2e/docs/**,api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts,client/src/index.css
 sonar.cpd.exclusions=api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts
 # Tailwind v4 @custom-variant blocks intentionally use nested selector syntax
 # with @slot; Sonar CSS rule S8776 does not understand this Tailwind at-rule.
-sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=css:S8776
-sonar.issue.ignore.multicriteria.e1.resourceKey=client/src/index.css
+# Exclude this stylesheet instead of suppressing per-rule because SonarCloud's
+# automatic analysis did not honor the multicriteria suppression for this file.


### PR DESCRIPTION
## Summary
- exclude Tailwind v4 stylesheet from Sonar source analysis because CSS rule S8776 misparses @custom-variant/@slot blocks
- remove the ineffective multicriteria suppression for that file

## Verification
- SonarCloud main analysis after PR #392 still failed only new reliability rating, with security fixed
- remaining reliability signal is Sonar CSS S8776 false positives in client/src/index.css

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/quality-gate configuration only; no runtime application or security behavior changes.
> 
> **Overview**
> Stops SonarCloud from analyzing **`client/src/index.css`** by adding it to **`sonar.exclusions`**, replacing a **multicriteria ignore** for CSS rule **S8776** that automatic analysis did not apply.
> 
> This targets false positives on Tailwind v4 **`@custom-variant` / `@slot`** syntax that Sonar’s CSS parser mishandles, so reliability metrics are not dragged down by that stylesheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d3e8b1b20cc4ecece868280ca449d89bf6ede2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->