### PR TITLE
fix: rewrite Tailwind custom variants for Sonar

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -37,73 +37,23 @@
 	}
 }
 
-@custom-variant data-open {
-	&:where([data-state="open"]),
-	&:where([data-open]:not([data-open="false"])) {
-		@slot;
-	}
-}
+@custom-variant data-open (&:where([data-state="open"]), &:where([data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"]), &:where([data-closed]:not([data-closed="false"])));
+@custom-variant data-checked (&:where([data-state="checked"]), &:where([data-checked]:not([data-checked="false"])));
+@custom-variant data-unchecked (&:where([data-state="unchecked"]), &:where([data-unchecked]:not([data-unchecked="false"])));
+@custom-variant data-selected (&:where([data-selected="true"]));
+@custom-variant data-disabled (&:where([data-disabled="true"]), &:where([data-disabled]:not([data-disabled="false"])));
+@custom-variant data-active (&:where([data-state="active"]), &:where([data-active]:not([data-active="false"])));
+@custom-variant data-horizontal (&:where([data-orientation="horizontal"]));
+@custom-variant data-vertical (&:where([data-orientation="vertical"]));
 
-@custom-variant data-closed {
-	&:where([data-state="closed"]),
-	&:where([data-closed]:not([data-closed="false"])) {
-		@slot;
-	}
-}
-
-@custom-variant data-checked {
-	&:where([data-state="checked"]),
-	&:where([data-checked]:not([data-checked="false"])) {
-		@slot;
-	}
-}
-
-@custom-variant data-unchecked {
-	&:where([data-state="unchecked"]),
-	&:where([data-unchecked]:not([data-unchecked="false"])) {
-		@slot;
-	}
-}
-
-@custom-variant data-selected {
-	&:where([data-selected="true"]) {
-		@slot;
-	}
-}
-
-@custom-variant data-disabled {
-	&:where([data-disabled="true"]),
-	&:where([data-disabled]:not([data-disabled="false"])) {
-		@slot;
-	}
-}
-
-@custom-variant data-active {
-	&:where([data-state="active"]),
-	&:where([data-active]:not([data-active="false"])) {
-		@slot;
-	}
-}
-
-@custom-variant data-horizontal {
-	&:where([data-orientation="horizontal"]) {
-		@slot;
-	}
-}
-
-@custom-variant data-vertical {
-	&:where([data-orientation="vertical"]) {
-		@slot;
-	}
-}
-
-@utility no-scrollbar {
+.no-scrollbar {
 	-ms-overflow-style: none;
 	scrollbar-width: none;
+}
 
-	&::-webkit-scrollbar {
-		display: none;
-	}
+.no-scrollbar::-webkit-scrollbar {
+	display: none;
 }
 
 /* ----------------------- end shadcn/tailwind.css ------------------- */

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,9 +6,5 @@ sonar.test.inclusions=api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/
 # This unit test owns CLI endpoint URL fixtures; local/dev URLs may be http://
 # without representing production-facing transport.
 sonar.test.exclusions=api/tests/unit/cli/test_cli_version_check.py
-sonar.exclusions=scripts/docs/**,client/e2e/docs/**,api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts,client/src/index.css
+sonar.exclusions=scripts/docs/**,client/e2e/docs/**,api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts
 sonar.cpd.exclusions=api/tests/**,client/e2e/**,client/src/**/*.test.ts,client/src/**/*.test.tsx,client/src/lib/v1.d.ts
-# Tailwind v4 @custom-variant blocks intentionally use nested selector syntax
-# with @slot; Sonar CSS rule S8776 does not understand this Tailwind at-rule.
-# Exclude this stylesheet instead of suppressing per-rule because SonarCloud's
-# automatic analysis did not honor the multicriteria suppression for this file.


### PR DESCRIPTION
## Summary
- rewrite Tailwind custom variants from nested @slot blocks to single-line @custom-variant forms
- replace the nested no-scrollbar @utility block with ordinary CSS
- remove the now-unneeded Sonar exclusion attempt for client/src/index.css

## Verification
- npm run build (client)
- current SonarCloud main analysis fails only css:S8776 reliability issues in client/src/index.css

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only refactor aimed at equivalent Tailwind variant and scrollbar behavior; main risk is a subtle UI regression if the new variant syntax diverges from the old blocks.
> 
> **Overview**
> Refactors **`client/src/index.css`** so SonarCloud stops flagging **css:S8776** on the inlined shadcn/Tailwind v4 styles, without excluding that file from analysis.
> 
> **`@custom-variant` definitions** (`data-open`, `data-closed`, `data-checked`, etc.) move from nested blocks with `@slot` to **single-line** `@custom-variant` forms that keep the same `data-state` / `data-*` selector logic UI components already use (e.g. `data-open:animate-in`).
> 
> **`no-scrollbar`** is no longer a nested `@utility` block; it is **plain CSS** (`.no-scrollbar` plus a `::-webkit-scrollbar` rule) so behavior stays the same for callers like the command list.
> 
> **`sonar-project.properties`** drops **`client/src/index.css`** from `sonar.exclusions` and removes the comment about suppressing S8776 for that stylesheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f4d87a87c54baecfb25a2ea384ffd42a22e8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stylesheet variant and utility definitions to align with the latest Tailwind format.
  * Improved scrollbar hiding behavior across browsers.
  * Adjusted code quality settings so the main stylesheet is now included in analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->