### PR TITLE
ci: split backend e2e tests into four shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,14 +179,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # =============================================================================
-  # E2E Tests - Sharded across 2 parallel runners. Each shard boots its own
+  # E2E Tests - Sharded across 4 parallel runners. Each shard boots its own
   # isolated test stack (no xdist, no shared services between shards).
   # scripts/e2e_shard.py deterministically allocates test files: heavies
   # bin-packed first, then round-robin in sorted order — adding a file only
   # moves files in shards downstream of the insertion point.
   #
   # The internal matrix job (test-e2e) uses shard names like
-  # "E2E Tests (shard 1/2)". The aggregate gate job below (test-e2e-gate)
+  # "E2E Tests (shard 1/4)". The aggregate gate job below (test-e2e-gate)
   # is named EXACTLY "E2E Tests" to match the required status check name —
   # no ruleset edits needed.
   # =============================================================================
@@ -194,13 +194,13 @@ jobs:
     # Skip on push: main — covered by the merge_group run.
     if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
-    name: E2E Tests (shard ${{ matrix.shard }}/2)
+    name: E2E Tests (shard ${{ matrix.shard }}/4)
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -229,18 +229,18 @@ jobs:
           cache-from: type=gha,scope=test-client-dev
           cache-to: type=gha,scope=test-client-dev,mode=max
 
-      - name: Run E2E tests (shard ${{ matrix.shard }}/2)
+      - name: Run E2E tests (shard ${{ matrix.shard }}/4)
         env:
           BIFROST_SKIP_BUILD: "1"
         run: |
           chmod +x test.sh
           ./test.sh stack up
-          mapfile -t shard_files < <(python3 scripts/e2e_shard.py --shard-id ${{ matrix.shard }} --total 2)
+          mapfile -t shard_files < <(python3 scripts/e2e_shard.py --shard-id ${{ matrix.shard }} --total 4)
           if [ ${#shard_files[@]} -eq 0 ]; then
             echo "ERROR: shard ${{ matrix.shard }} resolved to zero files" >&2
             exit 1
           fi
-          echo "Shard ${{ matrix.shard }}/2: ${#shard_files[@]} files"
+          echo "Shard ${{ matrix.shard }}/4: ${#shard_files[@]} files"
           ./test.sh "${shard_files[@]}" -v --durations=50
 
   # Aggregate gate — required check named "E2E Tests" (matches ruleset 15329014).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,15 +232,16 @@ jobs:
       - name: Run E2E tests (shard ${{ matrix.shard }}/4)
         env:
           BIFROST_SKIP_BUILD: "1"
+          SHARD_ID: ${{ matrix.shard }}
         run: |
           chmod +x test.sh
           ./test.sh stack up
-          mapfile -t shard_files < <(python3 scripts/e2e_shard.py --shard-id ${{ matrix.shard }} --total 4)
+          mapfile -t shard_files < <(python3 scripts/e2e_shard.py --shard-id "$SHARD_ID" --total 4)
           if [ ${#shard_files[@]} -eq 0 ]; then
-            echo "ERROR: shard ${{ matrix.shard }} resolved to zero files" >&2
+            echo "ERROR: shard $SHARD_ID resolved to zero files" >&2
             exit 1
           fi
-          echo "Shard ${{ matrix.shard }}/4: ${#shard_files[@]} files"
+          echo "Shard $SHARD_ID/4: ${#shard_files[@]} files"
           ./test.sh "${shard_files[@]}" -v --durations=50
 
   # Aggregate gate — required check named "E2E Tests" (matches ruleset 15329014).

--- a/scripts/e2e_shard.py
+++ b/scripts/e2e_shard.py
@@ -2,7 +2,7 @@
 """Print the e2e test files for one shard of an N-shard split.
 
 Usage:
-    scripts/e2e_shard.py --shard-id 1 --total 2
+    scripts/e2e_shard.py --shard-id 1 --total 4
 
 Allocates files to shards by sorted-order round-robin, weighted by an
 optional weights file (see WEIGHTS below). Stable: adding a new file only
@@ -45,7 +45,7 @@ def collect_test_files() -> list[str]:
     out = []
     for p in sorted(TESTS_ROOT.rglob("test_*.py")):
         rel = p.relative_to(API_ROOT)
-        out.append(str(rel))
+        out.append(rel.as_posix())
     return out
 
 


### PR DESCRIPTION
## Summary
- split backend e2e CI from 2 shards to 4 isolated shards
- keep the existing aggregate \E2E Tests\ required-check gate unchanged
- normalize shard file paths with \s_posix()\ so weighted balancing works from Windows too

## Verification
- \python scripts/e2e_shard.py --shard-id N --total 4\ for N=1..4 resolves non-empty shards: 51 / 51 / 52 / 52 files on current main
- shard allocation check: 206 files assigned, 0 duplicates, 0 missing, 0 extra; weights 120 / 120 / 122 / 118
- \git diff --check\
- \ctionlint .github/workflows/ci.yml\ reports pre-existing shellcheck findings outside the touched e2e block

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only sharding and path formatting; no application runtime or auth changes, with the same aggregate E2E gate check.
> 
> **Overview**
> Backend E2E CI now runs on **four parallel matrix shards** instead of two, each still booting an isolated stack via `scripts/e2e_shard.py --total 4`. Job labels and comments reflect **shard N/4**; the run step sets **`SHARD_ID`** and uses it in shell logging/errors. The aggregate **`test-e2e-gate`** job name stays **E2E Tests**, so required branch checks are unchanged.
> 
> In **`scripts/e2e_shard.py`**, collected test paths use **`Path.as_posix()`** so keys align with the **`WEIGHTS`** map on Windows (backslash paths no longer skip weighted bin-packing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e04778c0beb4283d6a2a4a63d931716ed4202ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test sharding in CI for more balanced and reliable test execution.
  * Updated shard-related logging and error messages to provide clearer status when no test files are found.
  * Standardized test file path formatting for more consistent handling across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->