### PR TITLE
ci: reuse baked test images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,61 @@ env:
   API_IMAGE: mtg-thomas/bifrost-api
   CLIENT_IMAGE: mtg-thomas/bifrost-client
   WORKER_IMAGE: mtg-thomas/bifrost-worker
+  CI_API_TEST_IMAGE: mtg-thomas/bifrost-ci-api-dev
+  CI_CLIENT_TEST_IMAGE: mtg-thomas/bifrost-ci-client-dev
 
 jobs:
+  # =============================================================================
+  # CI Test Images - Baked dependency/toolchain images for future PR test runs.
+  # Source code is still mounted from each PR checkout by docker-compose.test.yml.
+  # =============================================================================
+  publish-ci-test-images:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    name: Publish CI Test Images
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push API CI test image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./api/Dockerfile.dev
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.CI_API_TEST_IMAGE }}:main
+            ${{ env.REGISTRY }}/${{ env.CI_API_TEST_IMAGE }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=test-api-dev
+          cache-to: type=gha,scope=test-api-dev,mode=max
+
+      - name: Build and push client CI test image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ./client
+          file: ./client/Dockerfile.dev
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.CI_CLIENT_TEST_IMAGE }}:main
+            ${{ env.REGISTRY }}/${{ env.CI_CLIENT_TEST_IMAGE }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=test-client-dev
+          cache-to: type=gha,scope=test-client-dev,mode=max
+
   # =============================================================================
   # Lint & Type Check - Fast, gates all builds alongside unit tests
   # =============================================================================
@@ -128,6 +181,7 @@ jobs:
     name: Unit Tests
     permissions:
       contents: read
+      packages: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -135,13 +189,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      # Pre-build dev images via build-push-action for GHA layer caching.
-      # docker-compose.test.yml pins all api-stack services to bifrost-test-api-dev:latest
-      # and the client service to bifrost-test-client-dev:latest. When
-      # BIFROST_SKIP_BUILD=1, test.sh passes --no-build to compose so it reuses
-      # these local images instead of rebuilding (which would skip the GHA cache).
-      # Cache scope is shared with test-e2e so whichever job runs second gets warm hits.
-      - name: Build API dev image (cached)
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect test image input changes
+        id: test-image-inputs
+        run: bash scripts/ci/detect-test-image-inputs.sh
+
+      # Prefer baked main images. docker-compose.test.yml still bind-mounts the
+      # current checkout, so PR source code is what tests execute.
+      - name: Pull API CI test image
+        id: pull-api-ci-image
+        if: steps.test-image-inputs.outputs.api_changed != 'true'
+        continue-on-error: true
+        env:
+          API_CI_IMAGE_REF: ${{ env.REGISTRY }}/${{ env.CI_API_TEST_IMAGE }}:main
+        run: |
+          docker pull "$API_CI_IMAGE_REF"
+          docker tag "$API_CI_IMAGE_REF" bifrost-test-api-dev:latest
+
+      - name: Build API dev image
+        if: steps.test-image-inputs.outputs.api_changed == 'true' || steps.pull-api-ci-image.outcome == 'failure' || steps.pull-api-ci-image.outcome == 'skipped'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -151,7 +223,18 @@ jobs:
           cache-from: type=gha,scope=test-api-dev
           cache-to: type=gha,scope=test-api-dev,mode=max
 
-      - name: Build client dev image (cached)
+      - name: Pull client CI test image
+        id: pull-client-ci-image
+        if: steps.test-image-inputs.outputs.client_changed != 'true'
+        continue-on-error: true
+        env:
+          CLIENT_CI_IMAGE_REF: ${{ env.REGISTRY }}/${{ env.CI_CLIENT_TEST_IMAGE }}:main
+        run: |
+          docker pull "$CLIENT_CI_IMAGE_REF"
+          docker tag "$CLIENT_CI_IMAGE_REF" bifrost-test-client-dev:latest
+
+      - name: Build client dev image
+        if: steps.test-image-inputs.outputs.client_changed == 'true' || steps.pull-client-ci-image.outcome == 'failure' || steps.pull-client-ci-image.outcome == 'skipped'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./client
@@ -197,6 +280,7 @@ jobs:
     name: E2E Tests (shard ${{ matrix.shard }}/4)
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -208,8 +292,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      # See test-unit for caching strategy notes.
-      - name: Build API dev image (cached)
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect test image input changes
+        id: test-image-inputs
+        run: bash scripts/ci/detect-test-image-inputs.sh
+
+      - name: Pull API CI test image
+        id: pull-api-ci-image
+        if: steps.test-image-inputs.outputs.api_changed != 'true'
+        continue-on-error: true
+        env:
+          API_CI_IMAGE_REF: ${{ env.REGISTRY }}/${{ env.CI_API_TEST_IMAGE }}:main
+        run: |
+          docker pull "$API_CI_IMAGE_REF"
+          docker tag "$API_CI_IMAGE_REF" bifrost-test-api-dev:latest
+
+      - name: Build API dev image
+        if: steps.test-image-inputs.outputs.api_changed == 'true' || steps.pull-api-ci-image.outcome == 'failure' || steps.pull-api-ci-image.outcome == 'skipped'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -219,7 +324,18 @@ jobs:
           cache-from: type=gha,scope=test-api-dev
           cache-to: type=gha,scope=test-api-dev,mode=max
 
-      - name: Build client dev image (cached)
+      - name: Pull client CI test image
+        id: pull-client-ci-image
+        if: steps.test-image-inputs.outputs.client_changed != 'true'
+        continue-on-error: true
+        env:
+          CLIENT_CI_IMAGE_REF: ${{ env.REGISTRY }}/${{ env.CI_CLIENT_TEST_IMAGE }}:main
+        run: |
+          docker pull "$CLIENT_CI_IMAGE_REF"
+          docker tag "$CLIENT_CI_IMAGE_REF" bifrost-test-client-dev:latest
+
+      - name: Build client dev image
+        if: steps.test-image-inputs.outputs.client_changed == 'true' || steps.pull-client-ci-image.outcome == 'failure' || steps.pull-client-ci-image.outcome == 'skipped'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./client

--- a/scripts/ci/detect-test-image-inputs.sh
+++ b/scripts/ci/detect-test-image-inputs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decide whether CI must rebuild the local dev/test images instead of reusing
+# the baked GHCR images from main. Runtime source is bind-mounted by
+# docker-compose.test.yml; only image-baked inputs need to force a rebuild.
+
+event_name="${GITHUB_EVENT_NAME:-}"
+github_output="${GITHUB_OUTPUT:-/dev/null}"
+github_step_summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+api_changed=false
+client_changed=false
+
+if [ "$event_name" = "merge_group" ]; then
+  # Merge queue refs can contain multiple PRs. Rebuild there so dependency or
+  # Dockerfile changes from any queued PR are tested against their own image.
+  api_changed=true
+  client_changed=true
+elif [ "$event_name" = "pull_request" ]; then
+  base_ref="${GITHUB_BASE_REF:-main}"
+  git fetch --no-tags --depth=1 origin "$base_ref"
+  changed_files="$(git diff --name-only "origin/$base_ref...HEAD" || true)"
+
+  api_pattern='^(api/Dockerfile\.dev|pyproject\.toml|requirements(-pyright)?\.lock|api/src/services/app_compiler/(package(-lock)?\.json|compile\.js|tailwind\.js)|api/src/services/app_bundler/package(-lock)?\.json|api/src/services/sdk_package/(package\.json|build_sdk\.js)|client/src/lib/app-sdk/.*)$'
+  client_pattern='^(client/Dockerfile\.dev|client/package(-lock)?\.json)$'
+
+  if printf '%s\n' "$changed_files" | grep -Eq "$api_pattern"; then
+    api_changed=true
+  fi
+  if printf '%s\n' "$changed_files" | grep -Eq "$client_pattern"; then
+    client_changed=true
+  fi
+fi
+
+{
+  echo "api_changed=$api_changed"
+  echo "client_changed=$client_changed"
+} >> "$github_output"
+
+{
+  echo "### CI test image input detection"
+  echo ""
+  echo "- API image rebuild required: \`$api_changed\`"
+  echo "- Client image rebuild required: \`$client_changed\`"
+} >> "$github_step_summary"

--- a/test.sh
+++ b/test.sh
@@ -273,7 +273,13 @@ run_pytest() {
     # changed migrations they should run `./test.sh stack reset` once.
     require_stack_up
     reset_state
-    docker compose -f "$COMPOSE_FILE" --profile test run --build --rm test-runner \
+    local build_flag="--build"
+    if [ "${BIFROST_SKIP_BUILD:-0}" = "1" ]; then
+        build_flag="--no-build"
+        echo "BIFROST_SKIP_BUILD=1 — using pre-built test-runner image from local docker."
+    fi
+
+    docker compose -f "$COMPOSE_FILE" --profile test run "$build_flag" --rm test-runner \
         pytest "$@" --durations=25 --junitxml="$LOG_DIR/test-results.xml" 2>&1 | tee "$LOG_DIR/test-runner.log"
     return "${PIPESTATUS[0]}"
 }

--- a/test.sh
+++ b/test.sh
@@ -273,13 +273,13 @@ run_pytest() {
     # changed migrations they should run `./test.sh stack reset` once.
     require_stack_up
     reset_state
-    local build_flag="--build"
+    local build_args=("--build")
     if [ "${BIFROST_SKIP_BUILD:-0}" = "1" ]; then
-        build_flag="--no-build"
+        build_args=()
         echo "BIFROST_SKIP_BUILD=1 — using pre-built test-runner image from local docker."
     fi
 
-    docker compose -f "$COMPOSE_FILE" --profile test run "$build_flag" --rm test-runner \
+    docker compose -f "$COMPOSE_FILE" --profile test run "${build_args[@]}" --rm test-runner \
         pytest "$@" --durations=25 --junitxml="$LOG_DIR/test-results.xml" 2>&1 | tee "$LOG_DIR/test-runner.log"
     return "${PIPESTATUS[0]}"
 }


### PR DESCRIPTION
## Summary
- publish backend/client CI dev images to GHCR on main/manual CI runs
- make unit/e2e jobs pull those baked images and tag them as the local compose images
- rebuild locally when image-baked inputs changed or when the baked image is not available
- make \	est.sh\ honor \BIFROST_SKIP_BUILD=1\ for \	est-runner\, so CI does not rebuild after loading images

## Safety model
- docker-compose.test.yml still bind-mounts PR source into containers, so tests run against the checked-out PR code
- merge queue rebuilds both images to avoid stale dependencies when multiple PRs are queued together
- PRs that change Dockerfiles, dependency locks, or SDK/image-baked inputs rebuild instead of reusing the main image

## Verification
- \ash -n scripts/ci/detect-test-image-inputs.sh\
- \ash -n test.sh\
- \shellcheck scripts/ci/detect-test-image-inputs.sh\
- \python api/scripts/check_mtg_ci_boundaries.py\
- \python api/scripts/check_github_action_pins.py\
- \git diff --check\
- \ctionlint .github/workflows/ci.yml\ reports existing shellcheck findings outside the touched sections

Note: local pull_request simulation of the detector is blocked by WSL not resolving this Windows worktree gitfile path; the script path is standard on Linux GitHub runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how test environments are assembled; incorrect pull/rebuild logic could run tests against stale dependencies, though PR source remains bind-mounted and merge queue forces rebuilds.
> 
> **Overview**
> **CI now publishes API/client dev test images to GHCR on `main` and manual runs**, then **unit and E2E jobs prefer pulling those `:main` images** and retagging them as the local `bifrost-test-*-dev:latest` compose images instead of always building on every PR.
> 
> A new **`scripts/ci/detect-test-image-inputs.sh`** gates pull vs rebuild: merge queue always rebuilds; on PRs it rebuilds when image-baked paths change (Dockerfiles, locks, compiler/bundler/SDK inputs, etc.), otherwise it pulls and falls back to build if pull fails. Jobs gain **`packages: read`** and GHCR login for pulls.
> 
> **`test.sh` `run_pytest`** now skips `docker compose run --build` for `test-runner` when **`BIFROST_SKIP_BUILD=1`**, matching the existing stack-up behavior so CI does not rebuild after preloaded images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedcae00736d8e19ae35c86e74430a83fc5fde63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->