### PR TITLE
Run coverage jobs after main merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,6 @@ jobs:
   # Unit Tests - Fast, gates all builds
   # =============================================================================
   test-unit:
-    # Skip on push: main — covered by the merge_group run.
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     name: Unit Tests
     permissions:
@@ -274,8 +272,6 @@ jobs:
   # no ruleset edits needed.
   # =============================================================================
   test-e2e:
-    # Skip on push: main — covered by the merge_group run.
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     name: E2E Tests (shard ${{ matrix.shard }}/4)
     permissions:
@@ -374,7 +370,7 @@ jobs:
   # Fails if any shard failed or was cancelled. Runs even when shards fail
   # (if: always()) so branch protection always sees a conclusive result.
   test-e2e-gate:
-    if: always() && (github.event_name != 'push' || github.ref != 'refs/heads/main')
+    if: always()
     needs: [test-e2e]
     runs-on: ubuntu-latest
     name: E2E Tests


### PR DESCRIPTION
## Summary
- let backend unit and E2E coverage jobs run on push to main
- keep the E2E aggregate job present on main pushes so Codecov gets fresh post-merge uploads
- preserve the existing MTG deploy boundary guard

## Why
PR #390 merged with green patch coverage, but the post-merge main CI skipped the coverage-producing jobs. Codecov main is therefore stale and still points at an older commit. This PR makes merged main commits publish fresh total coverage again.

## Verification
- python api/scripts/check_mtg_ci_boundaries.py
- git diff --check
- Talos wrapper capability check: arc-runners/ktest-bifrost-runner-cap-0404 confirmed the current wrapper image has no Docker daemon, so full stack ./test.sh coverage must be verified by GitHub CI while Talos remains available for focused non-stack slices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to when existing test jobs run; no application or deploy logic changes, and MTG deploy boundary checks are unchanged.
> 
> **Overview**
> **Post-merge `main` pushes will run backend coverage again** by removing the `if` guards that skipped `test-unit`, `test-e2e`, and (partially) `test-e2e-gate` on `push` to `main`. Those jobs still upload to Codecov on every event they run, so merged commits should refresh **total** main-branch coverage instead of leaving Codecov on an older SHA.
> 
> The **E2E aggregate gate** (`test-e2e-gate`) now uses `if: always()` only, so it still runs when shards fail or are cancelled on **main** as well—keeping the required **"E2E Tests"** status check meaningful without skipping the gate on main pushes.
> 
> **Unchanged:** `lint`, `test-client-unit`, and other jobs that still skip on `push` to `main` (merge queue / PR coverage unchanged). `deploy-dev` upstream-only boundary is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28410138a0f098bbb9879781e8b96ba3e5791455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration now runs key API and end-to-end checks on main branch pushes.
  * End-to-end results are now reported more consistently, making failures and cancellations easier to spot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->