### PR TITLE
Add focused SDK and webhook registry coverage

### DIFF
--- a/api/tests/unit/sdk/test_forms_sdk.py
+++ b/api/tests/unit/sdk/test_forms_sdk.py
@@ -1,0 +1,84 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bifrost.forms import forms
+
+
+def _form_payload(**overrides):
+    payload = {
+        "id": "form-1",
+        "name": "Onboarding",
+        "description": "Collect onboarding inputs",
+        "workflow_id": "workflow-1",
+        "launch_workflow_id": "workflow-2",
+        "default_launch_params": {"priority": "normal"},
+        "allowed_query_params": ["ticket_id"],
+        "form_schema": {"type": "object", "properties": {"ticket_id": {"type": "string"}}},
+        "access_level": "organization",
+        "organization_id": "org-1",
+        "is_active": True,
+        "file_path": "forms/onboarding.json",
+        "created_at": None,
+        "updated_at": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _response(status_code: int, body):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = body
+    return response
+
+
+@pytest.mark.asyncio
+async def test_list_forms_returns_validated_models():
+    fake = MagicMock()
+    fake.get = AsyncMock(return_value=_response(200, [_form_payload(), _form_payload(id="form-2")]))
+
+    with patch("bifrost.forms.get_client", return_value=fake), patch(
+        "bifrost.forms.raise_for_status_with_detail"
+    ) as raise_for_status:
+        result = await forms.list()
+
+    fake.get.assert_awaited_once_with("/api/forms")
+    raise_for_status.assert_called_once()
+    assert [form.id for form in result] == ["form-1", "form-2"]
+    assert result[0].form_schema["properties"]["ticket_id"]["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_get_form_returns_validated_model():
+    fake = MagicMock()
+    fake.get = AsyncMock(return_value=_response(200, _form_payload(name="Access Request")))
+
+    with patch("bifrost.forms.get_client", return_value=fake), patch(
+        "bifrost.forms.raise_for_status_with_detail"
+    ):
+        result = await forms.get("form-1")
+
+    fake.get.assert_awaited_once_with("/api/forms/form-1")
+    assert result.name == "Access Request"
+    assert result.launch_workflow_id == "workflow-2"
+
+
+@pytest.mark.asyncio
+async def test_get_form_maps_not_found_to_value_error():
+    fake = MagicMock()
+    fake.get = AsyncMock(return_value=_response(404, {"detail": "not found"}))
+
+    with patch("bifrost.forms.get_client", return_value=fake):
+        with pytest.raises(ValueError, match="Form not found: form-missing"):
+            await forms.get("form-missing")
+
+
+@pytest.mark.asyncio
+async def test_get_form_maps_forbidden_to_permission_error():
+    fake = MagicMock()
+    fake.get = AsyncMock(return_value=_response(403, {"detail": "forbidden"}))
+
+    with patch("bifrost.forms.get_client", return_value=fake):
+        with pytest.raises(PermissionError, match="Access denied to form: form-private"):
+            await forms.get("form-private")

--- a/api/tests/unit/services/webhooks/test_registry.py
+++ b/api/tests/unit/services/webhooks/test_registry.py
@@ -1,0 +1,90 @@
+from src.services.webhooks.protocol import Deliver, SubscribeResult, WebhookAdapter
+from src.services.webhooks.registry import AdapterRegistry
+
+
+class RecordingAdapter(WebhookAdapter):
+    name = "recording"
+    display_name = "Recording Adapter"
+    description = "Records registry interactions"
+    requires_integration = "Example"
+    config_schema = {"type": "object", "properties": {"mode": {"type": "string"}}}
+
+    async def subscribe(self, callback_url, config, integration):
+        return SubscribeResult(external_id="sub-1", state={"callback_url": callback_url})
+
+    async def unsubscribe(self, external_id, state, integration):
+        return None
+
+    async def handle_request(self, request, config, state):
+        return Deliver(data={"ok": True})
+
+
+class ReplacementAdapter(RecordingAdapter):
+    display_name = "Replacement Adapter"
+
+
+class BrokenAdapter(RecordingAdapter):
+    def __init__(self):
+        raise RuntimeError("constructor failed")
+
+
+def test_registry_defaults_to_generic_and_caches_instances():
+    registry = AdapterRegistry()
+
+    first = registry.get(None)
+    second = registry.get("")
+
+    assert first is second
+    assert first.name == "generic"
+
+
+def test_registry_reregistering_adapter_clears_cached_instance():
+    registry = AdapterRegistry()
+    registry.register("recording", RecordingAdapter)
+    first = registry.get("recording")
+
+    registry.register("recording", ReplacementAdapter)
+    second = registry.get("recording")
+
+    assert first is not second
+    assert second.display_name == "Replacement Adapter"
+
+
+def test_registry_returns_none_when_adapter_constructor_fails():
+    registry = AdapterRegistry()
+    registry.register("broken", BrokenAdapter)
+
+    assert registry.get("broken") is None
+
+
+def test_registry_lists_adapter_metadata_after_loading_custom_once(monkeypatch):
+    registry = AdapterRegistry()
+    registry.register("recording", RecordingAdapter)
+    load_calls = 0
+
+    def mark_loaded():
+        nonlocal load_calls
+        load_calls += 1
+        registry._loaded_custom = True
+
+    monkeypatch.setattr(registry, "_load_custom_adapters", mark_loaded)
+
+    adapters = registry.list_adapters()
+    recording = next(adapter for adapter in adapters if adapter["name"] == "recording")
+
+    assert load_calls == 1
+    assert recording == {
+        "name": "recording",
+        "display_name": "Recording Adapter",
+        "description": "Records registry interactions",
+        "requires_integration": "Example",
+        "config_schema": {"type": "object", "properties": {"mode": {"type": "string"}}},
+        "supports_renewal": False,
+    }
+
+
+def test_registry_get_adapter_info_returns_none_for_unknown_after_custom_load():
+    registry = AdapterRegistry()
+
+    assert registry.get_adapter_info("missing") is None
+    assert registry._loaded_custom is True


### PR DESCRIPTION
## Summary\n- add SDK tests for bifrost.forms list/get parsing and 403/404 error mapping\n- add webhook registry tests for default adapter lookup, cache invalidation, constructor failures, adapter metadata, and missing adapter handling\n\n## Verification\n- python -m ruff check api/tests/unit/sdk/test_forms_sdk.py api/tests/unit/services/webhooks/test_registry.py\n- Kubernetes job arc-runners/ktest-bifrost-coverage-final-002745: ruff passed; pytest collected 9 items; 9 passed; bifrost.forms 100%, src.services.webhooks.registry 92.06% in focused coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime or API behavior changes.
> 
> **Overview**
> Adds **unit tests only**—no production code changes.
> 
> **`bifrost.forms` SDK** (`test_forms_sdk.py`): mocks the HTTP client to assert `list()` and `get()` hit `/api/forms` and `/api/forms/{id}`, validate response payloads into models, and map **404** to `ValueError` and **403** to `PermissionError` on `get()`.
> 
> **Webhook `AdapterRegistry`** (`test_registry.py`): covers default/generic adapter for empty names with instance caching, cache invalidation on re-register, `None` when adapter construction fails, `list_adapters()` metadata (with one-time custom load), and `get_adapter_info()` for unknown adapters after custom load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7e55a46678194fa5229c10af3ce1f7c0a98b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->