### PR TITLE
Support omitting OAuth authorization scopes

### DIFF
--- a/api/src/models/contracts/oauth.py
+++ b/api/src/models/contracts/oauth.py
@@ -20,9 +20,10 @@ PROVIDER_METADATA_DESCRIPTION = "Provider-specific OAuth behavior flags and meta
 
 
 def _validate_provider_metadata(v: dict[str, Any]) -> dict[str, Any]:
-    flag = v.get("omit_token_exchange_scope")
-    if flag is not None and not isinstance(flag, bool):
-        raise ValueError("provider_metadata.omit_token_exchange_scope must be a boolean")
+    for key in ("omit_token_exchange_scope", "omit_authorization_scope"):
+        flag = v.get(key)
+        if flag is not None and not isinstance(flag, bool):
+            raise ValueError(f"provider_metadata.{key} must be a boolean")
     return v
 
 

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -47,6 +47,7 @@ from src.models.orm import IntegrationConfigSchema
 from src.models.orm import OAuthToken
 from src.services.oauth_provider import (
     append_query_params,
+    compute_authorization_request_scopes,
     get_url_resolution_defaults,
     resolve_url_template,
 )
@@ -1311,9 +1312,11 @@ async def authorize_mapping(
         "client_id": provider.client_id,
         "response_type": "code",
         "state": state,
-        "scope": " ".join(provider.scopes) if provider.scopes else "",
         "redirect_uri": request.redirect_uri,
     }
+    scopes_str = compute_authorization_request_scopes(provider)
+    if scopes_str:
+        params["scope"] = scopes_str
 
     logger.info(
         f"Generated per-mapping OAuth authorization URL for mapping {log_safe(mapping_id)}, "
@@ -1617,16 +1620,15 @@ async def get_oauth_authorization_url(
     # Generate state for CSRF protection
     state = secrets.token_urlsafe(32)
 
-    # Build authorization URL
-    # Convert scopes list to space-separated string (OAuth 2.0 standard format)
-    scopes_str = " ".join(oauth_provider.scopes) if oauth_provider.scopes else ""
     params = {
         "client_id": oauth_provider.client_id,
         "response_type": "code",
         "state": state,
-        "scope": scopes_str,
         "redirect_uri": redirect_uri,
     }
+    scopes_str = compute_authorization_request_scopes(oauth_provider)
+    if scopes_str:
+        params["scope"] = scopes_str
 
     authorization_url = append_query_params(oauth_provider.authorization_url, params)
 

--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -34,6 +34,7 @@ from src.services.oauth_entity_id import extract_entity_id
 from src.services.oauth_provider import (
     append_query_params,
     build_token_refresh_context,
+    compute_authorization_request_scopes,
     get_url_resolution_defaults,
     refresh_oauth_token_http,
     resolve_url_template,
@@ -335,16 +336,15 @@ async def authorize_connection(
     # Generate state for CSRF protection
     state = secrets.token_urlsafe(32)
 
-    # Build authorization URL
-    # Convert scopes list to space-separated string (OAuth standard format)
-    scopes_str = " ".join(provider.scopes) if provider.scopes else ""
     params = {
         "client_id": provider.client_id,
         "response_type": "code",
         "state": state,
-        "scope": scopes_str,
         "redirect_uri": redirect_uri,
     }
+    scopes_str = compute_authorization_request_scopes(provider)
+    if scopes_str:
+        params["scope"] = scopes_str
 
     authorization_url = append_query_params(resolved_authorization_url, params)
 

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -32,6 +32,15 @@ def compute_token_exchange_scopes(provider: "OAuthProvider") -> str | None:
     return " ".join(provider.scopes) if provider.scopes else None
 
 
+def compute_authorization_request_scopes(provider: "OAuthProvider") -> str | None:
+    """Return scopes to send during authorization URL generation."""
+    provider_metadata = provider.provider_metadata or {}
+    if provider_metadata.get("omit_authorization_scope") is True:
+        return None
+
+    return " ".join(provider.scopes) if provider.scopes else None
+
+
 def resolve_url_template(
     url: str, entity_id: str | None = None, defaults: dict[str, str] | None = None
 ) -> str:

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -34,7 +34,7 @@ def compute_token_exchange_scopes(provider: "OAuthProvider") -> str | None:
 
 def compute_authorization_request_scopes(provider: "OAuthProvider") -> str | None:
     """Return scopes to send during authorization URL generation."""
-    provider_metadata = provider.provider_metadata or {}
+    provider_metadata = getattr(provider, "provider_metadata", None) or {}
     if provider_metadata.get("omit_authorization_scope") is True:
         return None
 

--- a/api/tests/unit/routers/test_integrations_mapping_oauth_coverage.py
+++ b/api/tests/unit/routers/test_integrations_mapping_oauth_coverage.py
@@ -66,10 +66,11 @@ class FakeDb:
 
 
 class FakeRepo:
-    def __init__(self, db, *, integration=None, mapping=None):
+    def __init__(self, db, *, integration=None, mapping=None, oauth_provider=None):
         self.db = db
         self.integration = integration
         self.mapping = mapping
+        self.oauth_provider = oauth_provider
 
     async def get_integration_by_id(self, integration_id):
         assert integration_id == INTEGRATION_ID
@@ -80,25 +81,42 @@ class FakeRepo:
         assert mapping_id == MAPPING_ID
         return self.mapping
 
+    async def get_oauth_provider(self, integration_id):
+        assert integration_id == INTEGRATION_ID
+        return self.oauth_provider
 
-def _patch_repo(monkeypatch, *, integration=None, mapping=None):
+
+def _patch_repo(monkeypatch, *, integration=None, mapping=None, oauth_provider=None):
     monkeypatch.setattr(
         integrations,
         "IntegrationsRepository",
-        lambda db: FakeRepo(db, integration=integration, mapping=mapping),
+        lambda db: FakeRepo(
+            db,
+            integration=integration,
+            mapping=mapping,
+            oauth_provider=oauth_provider,
+        ),
     )
+
+
+def _provider(**overrides):
+    data = {
+        "id": PROVIDER_ID,
+        "provider_name": "acme",
+        "authorization_url": "https://auth.example.test/{tenant}/authorize",
+        "client_id": "client-123",
+        "scopes": ["read", "write"],
+        "provider_metadata": {},
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
 
 
 @pytest.mark.asyncio
 async def test_authorize_mapping_resolves_provider_url_and_remembers_signed_state(
     monkeypatch,
 ):
-    provider = SimpleNamespace(
-        id=PROVIDER_ID,
-        authorization_url="https://auth.example.test/{tenant}/authorize",
-        client_id="client-123",
-        scopes=["read", "write"],
-    )
+    provider = _provider()
     integration = SimpleNamespace(id=INTEGRATION_ID, oauth_provider=provider)
     db = FakeDb()
     _patch_repo(monkeypatch, integration=integration, mapping=_mapping())
@@ -144,6 +162,70 @@ async def test_authorize_mapping_resolves_provider_url_and_remembers_signed_stat
         response.authorization_url
     )
     assert remembered_nonces == ["nonce-1"]
+
+
+@pytest.mark.asyncio
+async def test_authorize_mapping_can_omit_scope_parameter(monkeypatch):
+    provider = _provider(provider_metadata={"omit_authorization_scope": True})
+    integration = SimpleNamespace(id=INTEGRATION_ID, oauth_provider=provider)
+    _patch_repo(monkeypatch, integration=integration, mapping=_mapping())
+
+    monkeypatch.setattr(
+        integrations,
+        "get_url_resolution_defaults",
+        lambda db_arg, provider_arg: _async_value({"tenant": "midtown"}),
+    )
+    monkeypatch.setattr(
+        integrations,
+        "resolve_url_template",
+        lambda *, url, defaults: url.replace("{tenant}", defaults["tenant"]),
+    )
+    monkeypatch.setattr(
+        integrations,
+        "encode_state",
+        lambda *, provider_id, mapping_id: ("signed-state", "nonce-1"),
+    )
+    monkeypatch.setattr(
+        integrations,
+        "remember_nonce",
+        lambda nonce: _async_value(None),
+    )
+
+    response = await integrations.authorize_mapping(
+        INTEGRATION_ID,
+        MAPPING_ID,
+        MappingAuthorizeRequest(redirect_uri="https://app.example.test/callback"),
+        _ctx(FakeDb()),
+        SimpleNamespace(user_id=USER_ID),
+    )
+
+    assert "scope=" not in response.authorization_url
+    assert "client_id=client-123" in response.authorization_url
+    assert "state=signed-state" in response.authorization_url
+
+
+@pytest.mark.asyncio
+async def test_integration_authorization_url_can_omit_scope_parameter(monkeypatch):
+    provider = _provider(
+        authorization_url="https://auth.example.test/oauth/authorize",
+        provider_metadata={"omit_authorization_scope": True},
+    )
+    _patch_repo(monkeypatch, oauth_provider=provider)
+    monkeypatch.setattr(integrations.secrets, "token_urlsafe", lambda length: "state-token")
+
+    response = await integrations.get_oauth_authorization_url(
+        INTEGRATION_ID,
+        _ctx(FakeDb()),
+        SimpleNamespace(user_id=USER_ID),
+        redirect_uri="https://app.example.test/callback",
+    )
+
+    assert response.state == "state-token"
+    assert "scope=" not in response.authorization_url
+    assert "client_id=client-123" in response.authorization_url
+    assert "redirect_uri=https%3A%2F%2Fapp.example.test%2Fcallback" in (
+        response.authorization_url
+    )
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/routers/test_oauth_connections_router_coverage.py
+++ b/api/tests/unit/routers/test_oauth_connections_router_coverage.py
@@ -177,6 +177,35 @@ async def test_authorize_connection_resolves_url_and_marks_waiting():
 
 
 @pytest.mark.asyncio
+async def test_authorize_connection_can_omit_scope_parameter():
+    provider = _provider(
+        scopes=["read", "write"],
+        provider_metadata={"omit_authorization_scope": True},
+    )
+    repo = _repo(get_by_connection_name=provider, update_status=None)
+
+    with (
+        patch.object(oauth_connections, "OAuthProviderRepository", return_value=repo),
+        patch.object(oauth_connections.secrets, "token_urlsafe", return_value="state-token"),
+        patch.object(
+            oauth_connections,
+            "get_url_resolution_defaults",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        result = await oauth_connections.authorize_connection(
+            "halo",
+            _ctx(),
+            MagicMock(),
+            redirect_uri="https://app.example.test/oauth/callback",
+        )
+
+    assert "scope=" not in result.authorization_url
+    assert "client_id=client-id" in result.authorization_url
+    assert "redirect_uri=https%3A%2F%2Fapp.example.test%2Foauth%2Fcallback" in result.authorization_url
+
+
+@pytest.mark.asyncio
 async def test_authorize_connection_rejects_client_credentials_connection():
     provider = _provider(authorization_url=None)
     repo = _repo(get_by_connection_name=provider)

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -17,6 +17,7 @@ from src.models.contracts.oauth import CreateOAuthConnectionRequest, UpdateOAuth
 from src.services.oauth_provider import (
     OAuthProviderClient,
     append_query_params,
+    compute_authorization_request_scopes,
     compute_token_exchange_scopes,
 )
 
@@ -61,6 +62,30 @@ class TestTokenExchangeScopePolicy:
         assert compute_token_exchange_scopes(provider) == "read write"
 
 
+class TestAuthorizationRequestScopePolicy:
+    """Test provider-configured scope behavior for authorization URLs."""
+
+    def test_generic_provider_requests_configured_scopes(self):
+        """Generic OAuth providers should send configured scopes when authorizing."""
+        provider = SimpleNamespace(
+            provider_metadata={},
+            provider_name="Generic OAuth",
+            scopes=["read", "write"],
+        )
+
+        assert compute_authorization_request_scopes(provider) == "read write"
+
+    def test_provider_metadata_can_omit_authorization_scope(self):
+        """Providers whose consent screen uses client-configured scopes can opt out."""
+        provider = SimpleNamespace(
+            provider_metadata={"omit_authorization_scope": True},
+            provider_name="ScopeSensitiveProvider",
+            scopes=["read", "write"],
+        )
+
+        assert compute_authorization_request_scopes(provider) is None
+
+
 class TestProviderMetadataValidation:
     """Test request validation for provider behavior metadata."""
 
@@ -79,6 +104,23 @@ class TestProviderMetadataValidation:
         with pytest.raises(ValidationError, match="omit_token_exchange_scope must be a boolean"):
             UpdateOAuthConnectionRequest(
                 provider_metadata={"omit_token_exchange_scope": 1},
+            )
+
+    def test_create_request_rejects_non_boolean_omit_authorization_scope_flag(self):
+        with pytest.raises(ValidationError, match="omit_authorization_scope must be a boolean"):
+            CreateOAuthConnectionRequest(
+                integration_id="integration-id",
+                oauth_flow_type="authorization_code",
+                client_id="client-id",
+                authorization_url="https://auth.example.com/oauth/authorize",
+                token_url="https://auth.example.com/oauth/token",
+                provider_metadata={"omit_authorization_scope": "true"},
+            )
+
+    def test_update_request_rejects_non_boolean_omit_authorization_scope_flag(self):
+        with pytest.raises(ValidationError, match="omit_authorization_scope must be a boolean"):
+            UpdateOAuthConnectionRequest(
+                provider_metadata={"omit_authorization_scope": 1},
             )
 
 


### PR DESCRIPTION
## Summary
- add provider_metadata.omit_authorization_scope for providers whose consent screen uses client-configured scopes
- omit scope from integration and OAuth connection authorize URLs when that flag is true
- keep existing omit_token_exchange_scope behavior unchanged

## Root Cause
GoTo documents authorization-code requests without a scope parameter and notes that only scopes set on the OAuth client are requested. Bifrost was always sending scope=... during authorization; the live GoTo request sent a subset of the OAuth client's consent scopes, which matches GoTo's error: all submitted consent scopes must be in the original authorization request.

## Verification
- RED: new helper import failed before implementation
- GREEN: C:\Users\ThomasBray\src\MTG-Thomas\bifrost\.venv\Scripts\python.exe -m pytest api\tests\unit\services\test_oauth_provider.py api\tests\unit\routers\test_oauth_connections_router_coverage.py -q -> 47 passed

## Notes
Host-side pytest was used only for the pure unit TDD loop on Windows. CI remains the platform-grade verification path for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in metadata flag preserves default behavior; changes only affect authorization URL query params, not token storage or exchange.
> 
> **Overview**
> Adds **`provider_metadata.omit_authorization_scope`** so integrations can skip the `scope` query param on authorization redirects when the IdP uses client-configured consent scopes (e.g. GoTo), fixing mismatches where a sent subset of scopes breaks consent.
> 
> Authorization URL building in **integration**, **per-mapping**, and **OAuth connection** flows now goes through **`compute_authorization_request_scopes`**, which mirrors the existing token-exchange helper: configured scopes are joined by default, and the param is omitted entirely when the flag is true. **`omit_token_exchange_scope`** and callback/token exchange behavior are unchanged.
> 
> Contract validation now requires both omit flags to be booleans when present; unit tests cover the helper, validation, and authorize URLs with and without `scope`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7f8e5c750bf3f9d3c9d184b79d8cc2371d73ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth authorization requests now only include a scope parameter when needed, improving compatibility with providers that do not require it.
  * Providers can now opt out of sending authorization scopes through supported settings, with better validation for invalid values.
  * Scope handling is now consistent across different OAuth authorization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->