### PR TITLE
docs: restore MTG README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 **Open-source automation platform for Integration Services** - Built to democratize best-in-class tooling before venture capital gets the chance to own something we're all incredibly passionate about.
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
-[![CodeQL](https://github.com/gobifrost/bifrost/actions/workflows/codeql.yml/badge.svg)](https://github.com/gobifrost/bifrost/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/gobifrost/bifrost/badge)](https://securityscorecards.dev/viewer/?uri=github.com/gobifrost/bifrost)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12665/badge)](https://www.bestpractices.dev/projects/12665)
+[![CI](https://github.com/MTG-Thomas/bifrost/actions/workflows/ci.yml/badge.svg)](https://github.com/MTG-Thomas/bifrost/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/MTG-Thomas/bifrost/graph/badge.svg)](https://codecov.io/gh/MTG-Thomas/bifrost)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/quality_gate?project=MTG-Thomas_bifrost)](https://sonarcloud.io/summary/new_code?id=MTG-Thomas_bifrost)
+[![CodeQL](https://github.com/MTG-Thomas/bifrost/actions/workflows/codeql.yml/badge.svg)](https://github.com/MTG-Thomas/bifrost/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/MTG-Thomas/bifrost/badge)](https://securityscorecards.dev/viewer/?uri=github.com/MTG-Thomas/bifrost)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13022/badge)](https://www.bestpractices.dev/en/projects/13022)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-green.svg)](https://fastapi.tiangolo.com/)
 [![Python](https://img.shields.io/badge/Python-3.11-blue.svg)](https://www.python.org/)
 [![Docker](https://img.shields.io/badge/Docker-Compose-blue.svg)](https://www.docker.com/)


### PR DESCRIPTION
## Summary
- Restore MTG-specific README badges after the upstream sync overwrote them with gobifrost upstream badge links
- Re-add MTG CI, Codecov, SonarCloud, CodeQL, OpenSSF Scorecard, and MTG Best Practices badge/project links

## Verification
- git diff --check
- Inspected README badge block for MTG-Thomas/Sonar/Codecov/OpenSSF links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only badge URL changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> **Restores the README badge row** after an upstream sync pointed quality and security shields at `gobifrost/bifrost` instead of this fork.
> 
> Adds **MTG-specific** badges for CI, Codecov, SonarCloud quality gate, CodeQL, and OpenSSF Scorecard, all targeting `MTG-Thomas/bifrost` (and `MTG-Thomas_bifrost` on SonarCloud). The OpenSSF Best Practices badge is updated to project **13022** (MTG) rather than the upstream **12665** link. Stack badges (FastAPI, Python, Docker, PostgreSQL) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e25754041b65469d146e5fca0205f18c89ab7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->