### PR TITLE
fix: tolerate Foundry DeepSeek tool argument suffix

### DIFF
--- a/api/src/services/llm/openai_client.py
+++ b/api/src/services/llm/openai_client.py
@@ -25,6 +25,29 @@ from src.services.llm.base import (
 logger = logging.getLogger(__name__)
 
 
+def _parse_tool_arguments(raw: str | None) -> dict[str, Any]:
+    """Parse tool arguments, tolerating Foundry models' trailing empty strings.
+
+    DeepSeek V4 on the Azure OpenAI-compatible endpoint has been observed to
+    return otherwise valid arguments as ``{}\"\"``. Accept only trailing JSON
+    empty-string values; any other extra content remains an error so malformed
+    or ambiguous tool input cannot be executed.
+    """
+    if not raw:
+        return {}
+    decoder = json.JSONDecoder()
+    value, end = decoder.raw_decode(raw)
+    remainder = raw[end:].strip()
+    while remainder:
+        extra, extra_end = decoder.raw_decode(remainder)
+        if extra != "":
+            raise json.JSONDecodeError("unexpected trailing tool arguments", raw, end)
+        remainder = remainder[extra_end:].strip()
+    if not isinstance(value, dict):
+        raise json.JSONDecodeError("tool arguments must be a JSON object", raw, 0)
+    return value
+
+
 class OpenAIClient(BaseLLMClient):
     """OpenAI LLM client implementation."""
 
@@ -70,7 +93,7 @@ class OpenAIClient(BaseLLMClient):
                 ToolCallRequest(
                     id=tc.id,
                     name=tc.function.name,
-                    arguments=json.loads(tc.function.arguments),
+                    arguments=_parse_tool_arguments(tc.function.arguments),
                 )
                 for tc in message.tool_calls
             ]
@@ -183,7 +206,7 @@ class OpenAIClient(BaseLLMClient):
                         for tc_data in tool_call_builders.values():
                             if tc_data["id"] and tc_data["name"]:
                                 try:
-                                    args = json.loads(tc_data["arguments"]) if tc_data["arguments"] else {}
+                                    args = _parse_tool_arguments(tc_data["arguments"])
                                 except json.JSONDecodeError:
                                     args = {}
                                     logger.warning(f"Failed to parse tool arguments: {tc_data['arguments']}")

--- a/api/src/services/llm/openai_client.py
+++ b/api/src/services/llm/openai_client.py
@@ -89,6 +89,9 @@ class OpenAIClient(BaseLLMClient):
         # Parse tool calls if present
         tool_calls = None
         if message.tool_calls:
+            # Non-streaming autonomous runs fail closed on ambiguous arguments;
+            # executing a tool with guessed empty input is unsafe. Streaming UI
+            # calls retain their established warn-and-empty fallback behavior.
             tool_calls = [
                 ToolCallRequest(
                     id=tc.id,

--- a/api/tests/unit/services/llm/test_openai_client.py
+++ b/api/tests/unit/services/llm/test_openai_client.py
@@ -20,13 +20,18 @@ def test_provider_name() -> None:
 
 
 def test_parse_tool_arguments_accepts_foundry_deepseek_trailing_empty_string() -> None:
+    assert _parse_tool_arguments(None) == {}
+    assert _parse_tool_arguments("") == {}
     assert _parse_tool_arguments('{}""') == {}
+    assert _parse_tool_arguments('{}""""') == {}
     assert _parse_tool_arguments('{"ticket": 123}""') == {"ticket": 123}
 
 
 def test_parse_tool_arguments_rejects_nonempty_trailing_json() -> None:
     with pytest.raises(json.JSONDecodeError, match="unexpected trailing"):
         _parse_tool_arguments('{"ticket": 123}{"other": 456}')
+    with pytest.raises(json.JSONDecodeError, match="must be a JSON object"):
+        _parse_tool_arguments("[]")
 
 
 def test_convert_messages_handles_all_roles() -> None:

--- a/api/tests/unit/services/llm/test_openai_client.py
+++ b/api/tests/unit/services/llm/test_openai_client.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
 
 from src.services.llm.base import LLMConfig, LLMMessage, ToolCallRequest, ToolDefinition
-from src.services.llm.openai_client import OpenAIClient
+from src.services.llm.openai_client import OpenAIClient, _parse_tool_arguments
 
 
 def _client() -> OpenAIClient:
@@ -16,6 +17,16 @@ def _client() -> OpenAIClient:
 
 def test_provider_name() -> None:
     assert _client().provider_name == "openai"
+
+
+def test_parse_tool_arguments_accepts_foundry_deepseek_trailing_empty_string() -> None:
+    assert _parse_tool_arguments('{}""') == {}
+    assert _parse_tool_arguments('{"ticket": 123}""') == {"ticket": 123}
+
+
+def test_parse_tool_arguments_rejects_nonempty_trailing_json() -> None:
+    with pytest.raises(json.JSONDecodeError, match="unexpected trailing"):
+        _parse_tool_arguments('{"ticket": 123}{"other": 456}')
 
 
 def test_convert_messages_handles_all_roles() -> None:


### PR DESCRIPTION
Summary: strictly parse OpenAI-compatible tool arguments while tolerating Azure Foundry DeepSeek V4's observed trailing JSON empty string. Any nonempty trailing JSON remains rejected. Evidence: 11 focused OpenAI client tests pass; direct Foundry response reproduced the malformed suffix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized LLM client parsing change with stricter non-streaming failure semantics; streaming fallback unchanged. No auth or data-model impact.
> 
> **Overview**
> Fixes tool-call handling when Azure Foundry **DeepSeek V4** returns valid JSON arguments with extra trailing empty-string JSON fragments (e.g. `{}""`).
> 
> Adds **`_parse_tool_arguments`** and routes both **non-streaming** `complete()` and **streaming** `stream()` tool-call parsing through it instead of raw `json.loads`. The parser accepts only trailing `""` junk after the main object; any other trailing JSON or non-object payloads still raise **`JSONDecodeError`**. **Non-streaming** paths propagate those errors (fail closed). **Streaming** keeps the existing behavior: log a warning and use `{}` on parse failure.
> 
> Unit tests cover the Foundry suffix cases, rejection of ambiguous trailing JSON, and non-object arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c5acd5790d8a3845715df522e9647914eeff87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool-call arguments from compatible AI models.
  * Standardized argument parsing for both streaming and non-streaming responses.
  * Accepts valid JSON with harmless trailing empty-string fragments while rejecting other malformed content.
  * Ensures tool arguments are provided as JSON objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->