### PR TITLE
fix(oauth): disable unsafe token repair migration

### DIFF
--- a/api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py
+++ b/api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py
@@ -1,36 +1,26 @@
-"""promote provider-org-stamped tokens of global connections back to global
+"""do not auto-promote provider-org-stamped global OAuth tokens
 
 Revision ID: 20260601_promote_global_tok
 Revises: 20260601_merge_heads
 Create Date: 2026-06-01
 
-Data fix companion to the refresh_token scope fix (api/src/routers/
-oauth_connections.py). Before that fix, the connections /refresh handler
-stored the refreshed token under the *caller's* org instead of the
-connection's own scope. A platform admin in the provider org refreshing a
-GLOBAL connection (oauth_providers.organization_id IS NULL) created an
-org-level token (user_id IS NULL) stamped with the provider org's id rather
-than NULL. The SDK read cascade only falls back to organization_id IS NULL,
-so every other org failed to resolve the token.
+The code fix in ``api/src/routers/oauth_connections.py`` ensures future refreshes
+of a global OAuth connection (``oauth_providers.organization_id IS NULL``) write
+that connection's org-level token at global scope (``oauth_tokens.organization_id
+IS NULL``) instead of under the caller's organization.
 
-This migration heals rows already mis-stamped, scoped tightly so it cannot
-touch a legitimately org-scoped token:
-
-  - the token's provider is itself GLOBAL (oauth_providers.organization_id
-    IS NULL) — never touches a per-org connection's provider;
-  - the token is org-level (user_id IS NULL);
-  - the token is stamped with the provider org specifically;
-  - no true-global (NULL) token already exists for that provider — so we
-    never collide with or shadow an existing correct row.
-
-When a provider has BOTH a provider-org-stamped token and a real NULL token
-(e.g. someone already cleared one manually and a refresh re-inserted the
-Covi one), we delete the redundant provider-org row instead of promoting it,
-to avoid two org-level rows for the same global provider.
+This revision intentionally performs no data mutation. An earlier draft tried to
+heal historical rows by promoting org-level tokens that were stamped with an
+``organizations.is_provider = true`` org back to ``NULL``. That predicate is not
+safe: provider organizations are also real tenants and may legitimately own
+org-scoped OAuth tokens for a global provider. Automatically converting such a
+row to ``NULL`` would make private provider-org credentials the global fallback
+for other tenants; deleting it when a global token already exists would cause
+data loss. Because the schema has no durable marker proving which rows were
+created by the old refresh bug, remediation must be handled case-by-case with
+operator-reviewed SQL rather than an automatic migration.
 """
 from typing import Sequence, Union
-
-from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260601_promote_global_tok"
@@ -40,78 +30,13 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # 1. Drop redundant provider-org-stamped org-level tokens when a correct
-    #    global (NULL) token already exists for the same global provider.
-    op.execute(
-        """
-        DELETE FROM oauth_tokens t
-        USING organizations o, oauth_providers p
-        WHERE t.organization_id = o.id
-          AND o.is_provider = true
-          AND t.user_id IS NULL
-          AND p.id = t.provider_id
-          AND p.organization_id IS NULL
-          AND EXISTS (
-              SELECT 1 FROM oauth_tokens g
-              WHERE g.provider_id = t.provider_id
-                AND g.organization_id IS NULL
-                AND g.user_id IS NULL
-          )
-        """
-    )
+    """Leave existing OAuth tokens untouched.
 
-    # 2. If several provider orgs refreshed the same global provider before
-    #    the code fix, keep one canonical row and delete the rest before the
-    #    NULL-promotion below.
-    op.execute(
-        """
-        WITH ranked AS (
-            SELECT t.id,
-                   row_number() OVER (PARTITION BY t.provider_id ORDER BY t.id) AS rn
-            FROM oauth_tokens t
-            JOIN organizations o ON t.organization_id = o.id
-            JOIN oauth_providers p ON p.id = t.provider_id
-            WHERE o.is_provider = true
-              AND t.user_id IS NULL
-              AND p.organization_id IS NULL
-              AND NOT EXISTS (
-                  SELECT 1 FROM oauth_tokens g
-                  WHERE g.provider_id = t.provider_id
-                    AND g.organization_id IS NULL
-                    AND g.user_id IS NULL
-              )
-        )
-        DELETE FROM oauth_tokens t
-        USING ranked r
-        WHERE t.id = r.id
-          AND r.rn > 1
-        """
-    )
-
-    # 3. Promote the remaining provider-org-stamped org-level tokens of global
-    #    providers to global (organization_id = NULL).
-    op.execute(
-        """
-        UPDATE oauth_tokens t
-        SET organization_id = NULL
-        FROM organizations o, oauth_providers p
-        WHERE t.organization_id = o.id
-          AND o.is_provider = true
-          AND t.user_id IS NULL
-          AND p.id = t.provider_id
-          AND p.organization_id IS NULL
-          AND NOT EXISTS (
-              SELECT 1 FROM oauth_tokens g
-              WHERE g.provider_id = t.provider_id
-                AND g.organization_id IS NULL
-                AND g.user_id IS NULL
-          )
-        """
-    )
+    See the module docstring for why automatic promotion/deletion is unsafe.
+    """
+    pass
 
 
 def downgrade() -> None:
-    # No restore. Re-stamping these tokens with the provider org would
-    # reintroduce the cross-org resolution bug this migration fixes, and the
-    # original (deleted) rows cannot be reconstructed. Intentionally a no-op.
+    """No-op because upgrade() intentionally does not mutate data."""
     pass

--- a/api/tests/unit/test_promote_global_oauth_tokens_migration.py
+++ b/api/tests/unit/test_promote_global_oauth_tokens_migration.py
@@ -1,26 +1,14 @@
-"""Behavioral test for the global-OAuth-token heal migration.
+"""Regression tests for the global-OAuth-token migration safety boundary.
 
-The migration (alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py)
-is pure SQL, so we run its two statements against a seeded DB and assert it:
-
-  - promotes a provider-org-stamped org-level token of a GLOBAL provider to NULL;
-  - leaves a legitimately org-scoped connection's token alone;
-  - drops the redundant provider-org row when a real NULL token already exists;
-  - never touches per-user tokens.
-
-Coupled to the migration file by importing its SQL via op.execute capture, so a
-drift in the migration's WHERE clauses fails this test rather than passing silently.
+The migration must not infer that an org-level token is mis-stamped solely
+because its organization is marked ``is_provider`` and its provider row is global.
+Provider organizations are real tenants, so those rows can be legitimate private
+org-scoped credentials. Promoting them to ``organization_id = NULL`` would make
+them the global fallback for other tenants, and deleting them would be data loss.
 """
 
 import importlib.util
 from pathlib import Path
-from uuid import uuid4
-
-import pytest
-from sqlalchemy import select, text
-
-from src.models.orm.oauth import OAuthProvider, OAuthToken
-from src.models.orm.organizations import Organization
 
 MIGRATION_PATH = (
     Path(__file__).resolve().parents[2]
@@ -31,7 +19,7 @@ MIGRATION_PATH = (
 
 
 def _migration_sql() -> list[str]:
-    """Capture the SQL strings the migration's upgrade() passes to op.execute."""
+    """Capture SQL strings the migration's upgrade() passes to op.execute."""
     spec = importlib.util.spec_from_file_location("_heal_migration", MIGRATION_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
@@ -43,140 +31,39 @@ def _migration_sql() -> list[str]:
         def execute(sql):
             captured.append(str(sql))
 
-    # Inject a fake `op` before exec so `from alembic import op` resolves to it.
     import sys
     import types
 
     fake_alembic = types.ModuleType("alembic")
     fake_alembic.op = _FakeOp()  # type: ignore[attr-defined]
+    original_alembic = sys.modules.get("alembic")
     sys.modules["alembic"] = fake_alembic
     try:
         spec.loader.exec_module(module)
         module.upgrade()
     finally:
-        sys.modules.pop("alembic", None)
-    assert len(captured) == 3, "migration should delete, dedupe, then promote"
+        if original_alembic is None:
+            sys.modules.pop("alembic", None)
+        else:
+            sys.modules["alembic"] = original_alembic
     return captured
 
 
-async def _org(db, name, *, is_provider=False):
-    o = Organization(name=name, created_by="test", is_provider=is_provider)
-    db.add(o)
-    await db.flush()
-    return o
+def test_migration_does_not_emit_automatic_token_repair_sql():
+    assert _migration_sql() == []
 
 
-async def _provider(db, *, organization_id):
-    p = OAuthProvider(
-        provider_name=f"conn_{uuid4().hex[:8]}",
-        oauth_flow_type="client_credentials",
-        client_id="cid",
-        encrypted_client_secret=b"sec",
-        organization_id=organization_id,
-    )
-    db.add(p)
-    await db.flush()
-    return p
+def test_migration_source_does_not_mutate_oauth_tokens():
+    source = MIGRATION_PATH.read_text()
+
+    assert "DELETE FROM oauth_tokens" not in source
+    assert "UPDATE oauth_tokens" not in source
+    assert "SET organization_id = NULL" not in source
 
 
-async def _token(db, *, provider_id, organization_id, user_id=None):
-    t = OAuthToken(
-        provider_id=provider_id,
-        organization_id=organization_id,
-        user_id=user_id,
-        encrypted_access_token=b"acc",
-        status="completed",
-    )
-    db.add(t)
-    await db.flush()
-    return t
+def test_migration_documents_why_provider_org_tokens_are_preserved():
+    source = MIGRATION_PATH.read_text()
 
-
-async def _run_migration(db):
-    for sql in _migration_sql():
-        await db.execute(text(sql))
-    await db.flush()
-
-
-@pytest.mark.asyncio
-async def test_promotes_provider_org_token_of_global_provider(db_session):
-    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
-    gp = await _provider(db_session, organization_id=None)  # GLOBAL provider
-    tok = await _token(db_session, provider_id=gp.id, organization_id=provider_org.id)
-
-    await _run_migration(db_session)
-
-    await db_session.refresh(tok)
-    assert tok.organization_id is None, "mis-stamped global token should be promoted to NULL"
-
-
-@pytest.mark.asyncio
-async def test_leaves_org_specific_connection_token_alone(db_session):
-    """A connection whose PROVIDER is org-scoped is a legitimate per-org
-    connection — its token must not be touched even if stamped with the
-    provider org.
-    """
-    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
-    op_ = await _provider(db_session, organization_id=provider_org.id)  # org-scoped provider
-    tok = await _token(db_session, provider_id=op_.id, organization_id=provider_org.id)
-
-    await _run_migration(db_session)
-
-    await db_session.refresh(tok)
-    assert tok.organization_id == provider_org.id, "per-org connection token must be preserved"
-
-
-@pytest.mark.asyncio
-async def test_drops_redundant_provider_org_token_when_global_exists(db_session):
-    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
-    gp = await _provider(db_session, organization_id=None)
-    good = await _token(db_session, provider_id=gp.id, organization_id=None)
-    dup = await _token(db_session, provider_id=gp.id, organization_id=provider_org.id)
-
-    await _run_migration(db_session)
-
-    rows = (
-        await db_session.execute(
-            select(OAuthToken).where(OAuthToken.provider_id == gp.id)
-        )
-    ).scalars().all()
-    ids = {r.id for r in rows}
-    assert good.id in ids, "the real global token must survive"
-    assert dup.id not in ids, "the redundant provider-org token must be dropped"
-    assert len(rows) == 1
-
-
-@pytest.mark.asyncio
-async def test_deduplicates_multiple_provider_org_tokens_before_promotion(db_session):
-    provider_org_a = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
-    provider_org_b = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
-    gp = await _provider(db_session, organization_id=None)
-    first = await _token(db_session, provider_id=gp.id, organization_id=provider_org_a.id)
-    second = await _token(db_session, provider_id=gp.id, organization_id=provider_org_b.id)
-
-    await _run_migration(db_session)
-
-    rows = (
-        await db_session.execute(
-            select(OAuthToken).where(OAuthToken.provider_id == gp.id)
-        )
-    ).scalars().all()
-    assert len(rows) == 1
-    await db_session.refresh(rows[0])
-    assert rows[0].id in {first.id, second.id}
-    assert rows[0].organization_id is None
-
-
-@pytest.mark.asyncio
-async def test_ignores_non_provider_org_token(db_session):
-    """A token stamped with a normal (non-provider) org is a real per-org
-    token and must never be promoted.
-    """
-    normal_org = await _org(db_session, f"Managed {uuid4().hex[:6]}", is_provider=False)
-    gp = await _provider(db_session, organization_id=None)
-    tok = await _token(db_session, provider_id=gp.id, organization_id=normal_org.id)
-
-    await _run_migration(db_session)
-
-    await db_session.refresh(tok)
-    assert tok.organization_id == normal_org.id, "non-provider-org token must be left alone"
+    assert "provider organizations are also real tenants" in source
+    assert "private provider-org credentials" in source
+    assert "operator-reviewed SQL" in source


### PR DESCRIPTION
### Motivation
- A data-fix migration attempted to promote or delete org-scoped OAuth tokens for global providers using a predicate that cannot reliably distinguish mis-stamped rows from legitimate provider-org tokens, which risks cross-tenant credential exposure or data loss.
- The migration must not automatically globalize or remove rows that may legitimately belong to provider organizations, so automated repair is unsafe without operator review.

### Description
- Replace the previous heal migration SQL with a no-op `upgrade()`/`downgrade()` and expanded module docstring explaining why automatic promotion/deletion is unsafe and that remediation requires operator-reviewed SQL; see `api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py`.
- Remove the DELETE/UPDATE promotion logic from the migration so existing OAuth tokens are left untouched by the automatic migration.
- Replace the prior DB-backed behavioral tests with regression checks that the migration emits no token-repair SQL and documents the safety rationale; see `api/tests/unit/test_promote_global_oauth_tokens_migration.py`.
- Keep the fix narrowly scoped and preserve existing runtime behavior so that future token refreshes (fixed in `api/src/routers/oauth_connections.py`) will be written correctly while historical remediation is handled manually.

### Testing
- Ran `cd api && python -m pytest tests/unit/test_promote_global_oauth_tokens_migration.py -v`, which passed (3 passed). 
- Ran static checks with `cd api && ruff check alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py tests/unit/test_promote_global_oauth_tokens_migration.py`, which passed.
- Attempted backend stack tests requiring the Docker-backed Postgres (`./test.sh stack up` and `cd api && python -m pytest tests/unit/routers/test_oauth_refresh_token_scope.py -v`), but those runs were blocked/failed in this environment due to the test stack not being available (Docker/postgres resolution errors), so DB-backed router tests could not be fully exercised here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4cb150648328ac2c7f66a6a7590a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The change only stops automatic data mutation at migrate time and adds tests; runtime OAuth refresh behavior is unchanged by this diff.
> 
> **Overview**
> **Disables automatic OAuth token healing** in Alembic revision `20260601_promote_mis_stamped_global_oauth_tokens.py`. The previous `upgrade()` ran DELETE/UPDATE SQL to promote or remove org-level tokens on global providers when stamped with a provider org (`is_provider`). That logic is removed in favor of a **no-op** `upgrade()`/`downgrade()` and a longer docstring: provider orgs are real tenants, so those rows may be legitimate private credentials—auto-promoting to `organization_id = NULL` could expose them as the global fallback for other tenants, and auto-deleting risks data loss. Historical fixes are deferred to **operator-reviewed SQL**.
> 
> Tests in `test_promote_global_oauth_tokens_migration.py` no longer seed the DB and run migration SQL. They now assert `upgrade()` emits **no** `op.execute` SQL, the migration file contains no `DELETE`/`UPDATE` on `oauth_tokens`, and the docstring documents the safety boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0c6eb587153eee19a8c7da97baccf7f94cf2fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic OAuth token changes during database upgrades.
  * Preserved provider-specific organizations and tokens to avoid unintended data loss or global fallback behavior.

* **Tests**
  * Added safeguards confirming migrations perform no destructive token updates or deletions.
  * Added coverage ensuring the migration documents and enforces this safety boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->