### PR TITLE
fix: keep solution dev proxy on loopback

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import ipaddress
 import io
 import json
 import os
@@ -2207,6 +2208,30 @@ def _vite_child_env(
     return env
 
 
+def _ensure_loopback_bind_host(bind_host: str) -> None:
+    """Keep the token-injecting Solution dev proxy on loopback interfaces.
+
+    The dev proxy intentionally injects the developer's CLI bearer token into
+    proxied ``/api/*`` requests and exposes that token to Vite during local
+    serving. Binding it to a non-loopback interface would let any reachable
+    network client exercise the developer's platform permissions.
+    """
+    normalized = bind_host.strip().strip("[]").lower()
+    if normalized == "localhost":
+        return
+    try:
+        if ipaddress.ip_address(normalized).is_loopback:
+            return
+    except ValueError:
+        pass
+    raise click.ClickException(
+        "Refusing to bind the Solution dev server to a non-loopback address "
+        f"({bind_host!r}) because it proxies with your CLI credentials. Use "
+        "127.0.0.1, ::1, or localhost and put any remote tunnel/reverse proxy "
+        "access control in front of that loopback listener."
+    )
+
+
 @solution_group.command(name="start", help="Run the app's dev server + local workflows (one origin).")
 @click.argument("app_slug", required=False)
 @click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
@@ -2243,6 +2268,7 @@ def start_cmd(
             "parent directory). Run `bifrost solution init` first."
         )
     descriptor = load_descriptor(workspace)
+    _ensure_loopback_bind_host(bind_host)
 
     client = BifrostClient.get_instance(require_auth=True)
     binding = asyncio.run(

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -548,7 +548,7 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
         assert argv[0] == npm_path, f"npm spawn used {argv[0]!r}, not the which() result"
 
 
-def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
+def test_start_accepts_loopback_bind_host_and_public_url(tmp_path: Path, monkeypatch):
     import shutil
     import subprocess
 
@@ -638,7 +638,7 @@ def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
         [
             "start",
             "--host",
-            "0.0.0.0",
+            "127.0.0.1",
             "--public-url",
             "http://devbox.test:3000/",
             "--port",
@@ -648,11 +648,41 @@ def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert served == {
-        "bind_host": "0.0.0.0",
+        "bind_host": "127.0.0.1",
         "port": 3000,
         "proxy_origin": "http://devbox.test:3000",
     }
     assert popen_envs[0]["BIFROST_API_URL"] == "http://devbox.test:3000"
+
+
+def test_start_rejects_non_loopback_bind_host_before_auth(tmp_path: Path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+
+    def _fail_auth(**kwargs):
+        raise AssertionError("non-loopback host validation must run before auth")
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient, "get_instance", staticmethod(_fail_auth)
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        [
+            "start",
+            "--host",
+            "0.0.0.0",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Refusing to bind the Solution dev server to a non-loopback address"
+        in result.output
+    )
+    assert "CLI credentials" in result.output
 
 
 def test_handle_solution_renders_clickexception_not_traceback(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
### Motivation
- The Solution dev proxy injects the developer CLI bearer token into proxied `/api/*` requests and exposes a dev Vite token to the served bundle, so binding the proxy to a non-loopback interface makes these credentials reachable by remote parties. 
- Restrict `bifrost solution start --host` to loopback addresses to prevent accidental network exposure of developer credentials.

### Description
- Add loopback validation by importing `ipaddress` and introducing `_ensure_loopback_bind_host(bind_host: str)` which raises a `click.ClickException` for non-loopback addresses. 
- Call `_ensure_loopback_bind_host(bind_host)` early in `start_cmd` so validation runs before any authentication or server startup. 
- Update unit test `api/tests/unit/test_solution_dev_command.py` to accept loopback binds and add `test_start_rejects_non_loopback_bind_host_before_auth` verifying non-loopback binds are rejected before `BifrostClient.get_instance` is called. 
- Preserve existing `--public-url` behavior and Vite env injection while ensuring the local listener remains loopback-only.

### Testing
- Ran `python3 -m py_compile api/bifrost/commands/solution.py api/tests/unit/test_solution_dev_command.py` which succeeded. 
- Performed `git diff --check` / basic repository checks which passed and committed the change. 
- Added targeted unit coverage for bind-host behavior but running the `./test.sh` unit/e2e harness was blocked because the test stack is down and Docker is not available in this environment, so the full automated test run was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51bcbb528c8328a8a2163fc83fa35a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security-hardening change to local dev CLI behavior with targeted unit tests; default bind remains `127.0.0.1` and remote access via `--public-url`/tunnels is unchanged.
> 
> **Overview**
> **`bifrost solution start`** now refuses **`--host`** values that are not loopback (`127.0.0.1`, `::1`, `localhost`, or other loopback IPs). The local dev proxy injects the developer’s CLI bearer token into proxied `/api/*` traffic and into the Vite child env, so binding on `0.0.0.0` or another reachable interface would expose those credentials to the network.
> 
> A new **`_ensure_loopback_bind_host`** helper (using **`ipaddress`**) raises a **`ClickException`** with guidance to keep the listener on loopback and put tunnels/reverse proxies in front if needed. Validation runs in **`start_cmd`** right after loading the descriptor and **before** **`BifrostClient.get_instance`**, so bad bind addresses fail without auth or server startup. **`--public-url`** behavior is unchanged.
> 
> Unit tests now use a loopback **`--host`** in the happy path and add **`test_start_rejects_non_loopback_bind_host_before_auth`** to assert rejection for **`0.0.0.0`** before auth runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 969c010094e9e12d3fb2ea9b5e20510fb192c124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->