### PR TITLE
fix: scope MCP OAuth access tokens

### DIFF
--- a/api/src/services/mcp_server/auth.py
+++ b/api/src/services/mcp_server/auth.py
@@ -40,6 +40,21 @@ TTL_MCP_AUTH_CODE = 300  # 5 minutes for authorization code
 TTL_MCP_CLIENT = 86400 * 30  # 30 days for registered clients
 
 
+async def _mcp_access_token_data(db: Any, user: Any) -> dict[str, Any]:
+    return {
+        "sub": str(user.id),
+        "email": user.email,
+        "name": user.name,
+        "is_superuser": user.is_superuser,
+        "is_external": await resolve_external_claim(db, user),
+        "is_provider_org": await resolve_provider_org_claim(db, user),
+        "org_id": str(user.organization_id) if user.organization_id else None,
+        "type": "access",
+        "mcp": True,
+        "scope": "mcp:access",
+    }
+
+
 def _mcp_auth_code_key(code: str) -> str:
     """Key for MCP authorization code storage."""
     return f"bifrost:mcp:auth_code:{code}"
@@ -443,18 +458,7 @@ class BifrostAuthProvider:
                 # (EXT-1) is neutralized for bypass principals at this mint —
                 # without it every MCP-OAuth token defaulted to is_external=False
                 # (LEAK #1), re-opening the global tier to external users.
-                token_data = {
-                    "sub": str(user.id),
-                    "email": user.email,
-                    "name": user.name,
-                    "is_superuser": user.is_superuser,
-                    "is_external": await resolve_external_claim(db, user),
-                    "is_provider_org": await resolve_provider_org_claim(db, user),
-                    "org_id": str(user.organization_id) if user.organization_id else None,
-                    "type": "access",
-                    "mcp": True,
-                    "scope": "mcp:access",
-                }
+                token_data = await _mcp_access_token_data(db, user)
                 access_token = create_access_token(data=token_data)
                 refresh_token, _jti = create_refresh_token(data={"sub": str(user.id), "mcp": True})
 
@@ -481,7 +485,11 @@ class BifrostAuthProvider:
             from src.core.security import decode_token
 
             payload = decode_token(refresh_token, expected_type="refresh")
-            if payload is None or not payload.get("sub"):
+            if (
+                payload is None
+                or not payload.get("sub")
+                or payload.get("mcp") is not True
+            ):
                 return JSONResponse(
                     {"error": "invalid_grant", "error_description": "Invalid refresh token"},
                     status_code=400
@@ -500,18 +508,7 @@ class BifrostAuthProvider:
                     )
 
                 # Create new tokens (carry the is_external claim — LEAK #1).
-                token_data = {
-                    "sub": str(user.id),
-                    "email": user.email,
-                    "name": user.name,
-                    "is_superuser": user.is_superuser,
-                    "is_external": await resolve_external_claim(db, user),
-                    "is_provider_org": await resolve_provider_org_claim(db, user),
-                    "org_id": str(user.organization_id) if user.organization_id else None,
-                    "type": "access",
-                    "mcp": True,
-                    "scope": "mcp:access",
-                }
+                token_data = await _mcp_access_token_data(db, user)
                 access_token = create_access_token(data=token_data)
                 new_refresh_token, _jti = create_refresh_token(data={"sub": str(user.id), "mcp": True})
 

--- a/api/src/services/mcp_server/auth.py
+++ b/api/src/services/mcp_server/auth.py
@@ -452,6 +452,8 @@ class BifrostAuthProvider:
                     "is_provider_org": await resolve_provider_org_claim(db, user),
                     "org_id": str(user.organization_id) if user.organization_id else None,
                     "type": "access",
+                    "mcp": True,
+                    "scope": "mcp:access",
                 }
                 access_token = create_access_token(data=token_data)
                 refresh_token, _jti = create_refresh_token(data={"sub": str(user.id), "mcp": True})
@@ -507,6 +509,8 @@ class BifrostAuthProvider:
                     "is_provider_org": await resolve_provider_org_claim(db, user),
                     "org_id": str(user.organization_id) if user.organization_id else None,
                     "type": "access",
+                    "mcp": True,
+                    "scope": "mcp:access",
                 }
                 access_token = create_access_token(data=token_data)
                 new_refresh_token, _jti = create_refresh_token(data={"sub": str(user.id), "mcp": True})

--- a/api/tests/unit/services/test_mcp_auth.py
+++ b/api/tests/unit/services/test_mcp_auth.py
@@ -504,8 +504,13 @@ class TestTokenEndpoint:
         assert json.loads(response.body)["error_description"] == "Missing refresh_token"
 
     @pytest.mark.asyncio
-    async def test_refresh_token_rejects_invalid_payload(self, auth_provider):
-        with patch("src.core.security.decode_token", return_value=None):
+    @pytest.mark.parametrize(
+        "payload",
+        [None, {"sub": "user-1"}],
+        ids=["invalid", "non-mcp"],
+    )
+    async def test_refresh_token_rejects_invalid_payload(self, auth_provider, payload):
+        with patch("src.core.security.decode_token", return_value=payload):
             response = await auth_provider._token(self._request_with_form({
                 "grant_type": "refresh_token",
                 "refresh_token": "bad-refresh",
@@ -520,7 +525,7 @@ class TestTokenEndpoint:
         db_context.__aenter__ = AsyncMock(return_value=MagicMock())
         db_context.__aexit__ = AsyncMock(return_value=None)
 
-        with patch("src.core.security.decode_token", return_value={"sub": "user-1"}), \
+        with patch("src.core.security.decode_token", return_value={"sub": "user-1", "mcp": True}), \
              patch("src.core.database.get_db_context", return_value=db_context), \
              patch("src.repositories.users.UserRepository") as mock_repo_cls:
             mock_repo_cls.return_value.get_by_id = AsyncMock(return_value=None)
@@ -546,7 +551,7 @@ class TestTokenEndpoint:
         db_context.__aenter__ = AsyncMock(return_value=db)
         db_context.__aexit__ = AsyncMock(return_value=None)
 
-        with patch("src.core.security.decode_token", return_value={"sub": "user-1"}), \
+        with patch("src.core.security.decode_token", return_value={"sub": "user-1", "mcp": True}), \
              patch("src.core.database.get_db_context", return_value=db_context), \
              patch("src.repositories.users.UserRepository") as mock_repo_cls, \
              patch("src.services.mcp_server.auth.resolve_external_claim", AsyncMock(return_value=False)), \

--- a/api/tests/unit/test_mcp_oauth_external_claim.py
+++ b/api/tests/unit/test_mcp_oauth_external_claim.py
@@ -138,7 +138,8 @@ async def test_refresh_grant_stamps_is_external():
 
     ctx = _patches(captured, user)
     with patch(
-        "src.core.security.decode_token", return_value={"sub": str(user.id)}
+        "src.core.security.decode_token",
+        return_value={"sub": str(user.id), "mcp": True},
     ):
         for p in ctx:
             p.start()

--- a/api/tests/unit/test_mcp_oauth_external_claim.py
+++ b/api/tests/unit/test_mcp_oauth_external_claim.py
@@ -121,6 +121,8 @@ async def test_auth_code_grant_stamps_is_external():
 
     assert "token_data" in captured, "create_access_token was never called"
     assert captured["token_data"].get("is_external") is True
+    assert captured["token_data"].get("mcp") is True
+    assert captured["token_data"].get("scope") == "mcp:access"
 
 
 @pytest.mark.asyncio
@@ -148,3 +150,5 @@ async def test_refresh_grant_stamps_is_external():
 
     assert "token_data" in captured, "create_access_token was never called"
     assert captured["token_data"].get("is_external") is True
+    assert captured["token_data"].get("mcp") is True
+    assert captured["token_data"].get("scope") == "mcp:access"


### PR DESCRIPTION
### Motivation
- The MCP OAuth flow was minting access tokens without the `mcp` marker or `scope: mcp:access`, making them indistinguishable from first-party REST access tokens and bypassing the REST guard that rejects MCP-scoped tokens.
- This allowed a malicious or compromised MCP client to replay an MCP-issued token against the normal REST API as the authorizing user.
- The change restores explicit MCP scoping on MCP-issued access tokens so the existing REST auth rejection logic can continue to enforce token separation.

### Description
- Add `"mcp": True` and `"scope": "mcp:access"` to the access token payload generated by the MCP authorization-code grant in `api/src/services/mcp_server/auth.py`.
- Add the same `mcp` and `scope` claims to the access token payload generated during MCP refresh-token rotation in `api/src/services/mcp_server/auth.py`.
- Extend unit coverage in `api/tests/unit/test_mcp_oauth_external_claim.py` to assert that both grant paths stamp `mcp: true` and `scope: "mcp:access"` on the minted access token.

### Testing
- Ran the targeted unit tests with `python -m pytest api/tests/unit/test_mcp_oauth_external_claim.py api/tests/unit/services/test_mcp_auth.py::TestMcpBoundTokens -v`, and all collected tests passed (`3 passed`).
- Ran static checks with `ruff` on the modified files using `python -m ruff check api/src/services/mcp_server/auth.py api/tests/unit/test_mcp_oauth_external_claim.py`, and the check passed.
- Running `./test.sh` variants that require Docker was blocked in this environment (`docker: command not found`), so full `./test.sh`-driven Dockerized verification was not executed here. Please run the normal `./test.sh` flows in CI or a dev stack to complete environment-backed verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4acdc870788328b3c4a4460d432b84)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication token minting and validation boundaries between MCP and REST; incorrect scoping could lock out MCP clients or leave a token-replay path open.
> 
> **Overview**
> **MCP OAuth access tokens are now explicitly MCP-scoped** so they cannot be replayed as first-party REST credentials. A shared `_mcp_access_token_data` helper stamps **`mcp: true`** and **`scope: mcp:access`** on access tokens minted from both the authorization-code and refresh-token grants (alongside existing user claims such as `is_external`).
> 
> **Refresh rotation is tightened:** the token endpoint rejects refresh tokens that are missing or not marked with **`mcp: true`**, so only MCP-issued refresh tokens can rotate MCP access tokens.
> 
> Unit tests assert the new claims on both grant paths and parametrize rejection of non-MCP refresh payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0103b7f1d746f1ec7f64f602e06d5bc7643bd44b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP OAuth access tokens now include explicit MCP identification and access-scope claims for authorization-code and refresh-token flows.
* **Bug Fixes**
  * Tightened refresh-token validation to ensure only MCP-qualified payloads are accepted.
  * Updated token-claim handling so external MCP access claims are asserted consistently across flows.
* **Tests**
  * Expanded unit tests to verify the new MCP and scope claims for both authorization-code and refresh-token scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->