### PR TITLE
Block inactive solution table document access

### DIFF
--- a/api/src/routers/tables.py
+++ b/api/src/routers/tables.py
@@ -55,6 +55,7 @@ from src.models.contracts.tables import (
     TableUpdate,
 )
 from src.models.orm.custom_claims import CustomClaim as CustomClaimORM
+from src.models.orm.solutions import Solution as SolutionORM
 from src.models.orm.tables import Document, Table
 from src.services.solutions.guard import assert_entity_id_not_solution_managed
 from src.services.solution_scope import (
@@ -627,7 +628,23 @@ async def get_table_or_404(
             detail=f"Table '{name_or_id}' not found",
         )
 
+    await _assert_table_solution_active(ctx, table, name_or_id)
     return table
+
+
+async def _assert_table_solution_active(
+    ctx: Context, table: Table, requested_table_id: str
+) -> None:
+    """Hide tables owned by inactive solution installs from direct table APIs."""
+    if table.solution_id is None:
+        return
+
+    solution = await ctx.db.get(SolutionORM, table.solution_id)
+    if solution is not None and solution.status == "inactive":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Table '{requested_table_id}' not found",
+        )
 
 
 async def _assert_solution_write_targets_owned_table(ctx: Context, table: Table) -> None:

--- a/api/tests/e2e/platform/test_inactive_solution_dormant.py
+++ b/api/tests/e2e/platform/test_inactive_solution_dormant.py
@@ -147,11 +147,11 @@ async def test_active_solution_executes_normally(
     )
 
 
-def _deploy_with_app_and_table(e2e_client, headers, sid: str) -> tuple[str, str]:
+def _deploy_with_app_and_table(e2e_client, headers, sid: str) -> tuple[str, str, str]:
     """Deploy a minimal bundle with one app + one table.
 
-    Returns (app_id, table_name) where app_id is the resolved
-    per-install entity id (suitable for the X-Bifrost-App header).
+    Returns (app_id, table_id, table_name) where app_id/table_id are the resolved
+    per-install entity ids.
     """
     app_manifest_id = str(uuid.uuid4())
     table_manifest_id = str(uuid.uuid4())
@@ -169,7 +169,8 @@ def _deploy_with_app_and_table(e2e_client, headers, sid: str) -> tuple[str, str]
     assert dep.status_code in (200, 201), dep.text
 
     app_id = str(solution_entity_id(UUID(sid), UUID(app_manifest_id)))
-    return app_id, table_name
+    table_id = str(solution_entity_id(UUID(sid), UUID(table_manifest_id)))
+    return app_id, table_id, table_name
 
 
 async def test_inactive_solution_app_path_refused(
@@ -184,7 +185,7 @@ async def test_inactive_solution_app_path_refused(
     headers = platform_admin.headers
     slug = f"dormant-app-{uuid.uuid4().hex[:8]}"
     sid = _create_solution(e2e_client, headers, slug)
-    app_id, table_name = _deploy_with_app_and_table(e2e_client, headers, sid)
+    app_id, _table_id, table_name = _deploy_with_app_and_table(e2e_client, headers, sid)
     _uninstall(e2e_client, headers, sid)
 
     # Any request carrying the inactive solution's app id in X-Bifrost-App must
@@ -203,6 +204,34 @@ async def test_inactive_solution_app_path_refused(
     )
 
 
+async def test_inactive_solution_table_uuid_document_access_refused_without_solution_context(
+    e2e_client, platform_admin,
+):
+    """Direct table UUID document APIs must not bypass inactive solution dormancy."""
+    headers = platform_admin.headers
+    slug = f"dormant-table-uuid-{uuid.uuid4().hex[:8]}"
+    sid = _create_solution(e2e_client, headers, slug)
+    _app_id, table_id, _table_name = _deploy_with_app_and_table(e2e_client, headers, sid)
+    _uninstall(e2e_client, headers, sid)
+
+    r = e2e_client.post(
+        f"/api/tables/{table_id}/documents",
+        headers=headers,
+        json={"id": "probe", "data": {"val": "x"}},
+    )
+    assert r.status_code == 404, (
+        f"Expected inactive solution-owned table UUID write to be hidden, got {r.status_code}: {r.text}"
+    )
+
+    r = e2e_client.get(
+        f"/api/tables/{table_id}/documents/probe",
+        headers=headers,
+    )
+    assert r.status_code == 404, (
+        f"Expected inactive solution-owned table UUID read to be hidden, got {r.status_code}: {r.text}"
+    )
+
+
 async def test_active_solution_app_path_not_refused(
     e2e_client, platform_admin,
 ):
@@ -210,7 +239,7 @@ async def test_active_solution_app_path_not_refused(
     headers = platform_admin.headers
     slug = f"active-app-{uuid.uuid4().hex[:8]}"
     sid = _create_solution(e2e_client, headers, slug)
-    app_id, table_name = _deploy_with_app_and_table(e2e_client, headers, sid)
+    app_id, _table_id, table_name = _deploy_with_app_and_table(e2e_client, headers, sid)
 
     # Active solution: the dormant gate must not fire.  The row insert may
     # succeed or 409-conflict (duplicate) — what must NOT happen is a 409 from


### PR DESCRIPTION
### Motivation
- Direct table UUID lookups could bypass the new inactive-solution dormancy gate because the solution-context checks only ran when `?solution=` or `X-Bifrost-App` were supplied, allowing same-org authenticated users to read or mutate documents in tables owned by an inactive solution.

### Description
- Add `Solution` ORM lookup and a new helper `async def _assert_table_solution_active(ctx, table, requested_table_id)` that raises `404` for tables whose owning `Solution.status == "inactive"`.
- Call `_assert_table_solution_active` from `get_table_or_404` after resolving the table so both UUID and name lookups are subject to the inactive-solution check.
- Add an e2e regression `test_inactive_solution_table_uuid_document_access_refused_without_solution_context` to assert direct table UUID read/write attempts against an inactive solution return `404`, and update the `_deploy_with_app_and_table` test helper to return the resolved `table_id`.
- Preserve existing `?_solution` and `X-Bifrost-App` gating and the `_assert_solution_write_targets_owned_table` semantics so behavior with explicit solution context is unchanged.

### Testing
- Successfully type/compile-checked `api/src/routers/tables.py` with `python -m py_compile src/routers/tables.py`.
- Ran unit tests `tests/unit/test_tables_sdk_solution_scope.py` which passed (`9 passed`).
- Ran `ruff check` on the modified files with no issues via `python -m ruff check src/routers/tables.py tests/e2e/platform/test_inactive_solution_dormant.py`.
- Attempted the e2e regression run `python -m pytest tests/e2e/platform/test_inactive_solution_dormant.py::test_inactive_solution_table_uuid_document_access_refused_without_solution_context -q` but it was skipped in this environment because the local e2e stack is unavailable (`docker` not present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46c6bfd5c483289ec0c358d21b53a6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central table resolution used by every document endpoint; incorrect inactive detection could hide active tables or leak dormant data, but the change is narrow (one ORM lookup + status check) with targeted e2e coverage.
> 
> **Overview**
> Closes a **dormancy bypass**: authenticated users could hit document APIs with a **table UUID** (no `?solution=` or `X-Bifrost-App`) and still reach tables owned by an **inactive** solution install.
> 
> **`get_table_or_404`** now calls **`_assert_table_solution_active`**, which loads the owning **`Solution`** and returns **404** (same “table not found” shape) when **`status == "inactive"`**. That applies to **UUID and name** resolution, so all document routes that resolve tables through this helper inherit the check.
> 
> E2E adds **`test_inactive_solution_table_uuid_document_access_refused_without_solution_context`** and extends **`_deploy_with_app_and_table`** to return the resolved **`table_id`** for UUID-based probes after uninstall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6079c70125c7617bc10acbe24e99ee27b0edf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->