### PR TITLE
fix: restrict SDK integration default secrets

### DIFF
--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -746,7 +746,9 @@ async def sdk_integrations_get(
         if mapping:
             # Org-specific mapping found
             is_external = await _is_external_user_db(current_user, db)
-            config_kwargs: dict[str, Any] = {"include_default_secrets": not is_external}
+            config_kwargs: dict[str, Any] = {
+                "include_default_secrets": current_user.is_superuser and not is_external
+            }
             if is_external:
                 config_kwargs["external"] = True
             config = await repo.get_config_for_mapping(

--- a/api/tests/unit/routers/test_cli_auto_refresh.py
+++ b/api/tests/unit/routers/test_cli_auto_refresh.py
@@ -500,8 +500,22 @@ class TestSDKIntegrationsGetConfig:
     """Tests for integration config resolution through the SDK endpoint."""
 
     @pytest.mark.asyncio
-    async def test_org_mapping_includes_default_secrets_for_execution_reads(self):
-        """Mapped SDK reads must include default secrets needed by workflow clients."""
+    @pytest.mark.parametrize(
+        ("is_superuser", "is_external", "expected_config_kwargs"),
+        [
+            (False, False, {"include_default_secrets": False}),
+            (True, False, {"include_default_secrets": True}),
+            (
+                True,
+                True,
+                {"include_default_secrets": False, "external": True},
+            ),
+        ],
+    )
+    async def test_org_mapping_default_secret_policy_follows_caller_privilege(
+        self, is_superuser, is_external, expected_config_kwargs
+    ):
+        """Mapped reads expose global default secrets only to internal superusers."""
         from src.models.contracts.cli import SDKIntegrationsGetRequest
         from src.routers import cli
 
@@ -527,12 +541,13 @@ class TestSDKIntegrationsGetConfig:
             return_value={
                 "base_url": "https://example.test",
                 "api_integration_code": "decrypted-code",
-                "secret": "decrypted-secret",
             }
         )
 
         user = MagicMock()
-        user.email = "engine@example.test"
+        user.email = "engine@example.test" if is_superuser else "user@example.test"
+        user.is_superuser = is_superuser
+        user.is_external = is_external
 
         with (
             patch.object(cli, "_resolve_sdk_org_id", AsyncMock(return_value=org_id)),
@@ -545,8 +560,6 @@ class TestSDKIntegrationsGetConfig:
             )
 
         repo.get_config_for_mapping.assert_awaited_once()
-        assert repo.get_config_for_mapping.await_args.kwargs == {
-            "include_default_secrets": True
-        }
+        assert repo.get_config_for_mapping.await_args.kwargs == expected_config_kwargs
         assert response is not None
-        assert response.config["secret"] == "decrypted-secret"
+        assert response.config["api_integration_code"] == "decrypted-code"


### PR DESCRIPTION
### Motivation
- The SDK endpoint `/api/sdk/integrations/get` began returning decrypted integration-level default secrets to any authenticated org user when a mapping existed, which exposes global provider secrets beyond the intended platform/system-account boundary.
- The goal is to prevent information disclosure by ensuring global/default integration secrets are only included for superuser/system execution contexts while preserving the engine/superuser execution read semantics.

### Description
- Change `sdk_integrations_get` to call `get_config_for_mapping(..., include_default_secrets=current_user.is_superuser)` so default secrets are included only for callers with superuser/system privileges (file: `api/src/routers/cli.py`).
- Update the SDK integration unit test to parametrize caller privilege and assert `include_default_secrets` follows the caller's `is_superuser` flag (file: `api/tests/unit/routers/test_cli_auto_refresh.py`).
- No changes were made to `IntegrationsRepository.get_config_for_mapping` itself; it still enforces the `include_default_secrets` policy and decrypts secrets only when permitted.

### Testing
- Ran targeted unit tests with `PYTHONPATH=api pytest -q api/tests/unit/repositories/test_integrations_repository.py::TestIntegrationsRepository::test_get_config_for_mapping_default_secret_policy api/tests/unit/routers/test_cli_auto_refresh.py::TestSDKIntegrationsGetConfig::test_org_mapping_default_secret_policy_follows_caller_privilege`, which completed with `4 passed`.
- Verified modified modules compile with `PYTHONPATH=api python -m py_compile api/src/routers/cli.py api/tests/unit/routers/test_cli_auto_refresh.py`, which succeeded.
- Ran `git diff --check` to ensure no whitespace/patch issues, which produced no errors.
- Attempted to run the full in-worktree unit stack with `./test.sh unit` and `./test.sh stack up` but the per-worktree test stack could not be started because `docker` is not available in this environment, so the broader suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ef9f670083289a8cdd0c9731b287)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This tightens secret exposure on a widely used SDK endpoint; workflow/runtime callers that relied on default secrets without superuser context may need org-level overrides or superuser execution.
> 
> **Overview**
> **Closes an information-disclosure path** on `POST /api/sdk/integrations/get` when an org-specific mapping exists: merged config no longer always requests integration-level default secrets for every authenticated caller.
> 
> For the org-mapping branch, **`include_default_secrets` is now `current_user.is_superuser and not is_external`** (still passing `external=True` for external users). Non–superuser internal users and external users therefore do not get global default secret values decrypted into the response; internal superusers keep the engine/system read behavior.
> 
> Unit coverage is updated with a **parametrized test** over superuser vs non-superuser and external vs internal, asserting the kwargs passed to `get_config_for_mapping` match that policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71535c477060cd8a8cb1edc03017ad6190e19779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->