### PR TITLE
Fix OAuth token promotion migration scope

### DIFF
--- a/api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py
+++ b/api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py
@@ -18,6 +18,8 @@ touch a legitimately org-scoped token:
 
   - the token's provider is itself GLOBAL (oauth_providers.organization_id
     IS NULL) — never touches a per-org connection's provider;
+  - the token's provider uses client_credentials — never touches
+    org-scoped authorization_code callback tokens;
   - the token is org-level (user_id IS NULL);
   - the token is stamped with the provider org specifically;
   - no true-global (NULL) token already exists for that provider — so we
@@ -51,6 +53,7 @@ def upgrade() -> None:
           AND t.user_id IS NULL
           AND p.id = t.provider_id
           AND p.organization_id IS NULL
+          AND p.oauth_flow_type = 'client_credentials'
           AND EXISTS (
               SELECT 1 FROM oauth_tokens g
               WHERE g.provider_id = t.provider_id
@@ -74,6 +77,7 @@ def upgrade() -> None:
             WHERE o.is_provider = true
               AND t.user_id IS NULL
               AND p.organization_id IS NULL
+              AND p.oauth_flow_type = 'client_credentials'
               AND NOT EXISTS (
                   SELECT 1 FROM oauth_tokens g
                   WHERE g.provider_id = t.provider_id
@@ -100,6 +104,7 @@ def upgrade() -> None:
           AND t.user_id IS NULL
           AND p.id = t.provider_id
           AND p.organization_id IS NULL
+          AND p.oauth_flow_type = 'client_credentials'
           AND NOT EXISTS (
               SELECT 1 FROM oauth_tokens g
               WHERE g.provider_id = t.provider_id

--- a/api/tests/unit/test_promote_global_oauth_tokens_migration.py
+++ b/api/tests/unit/test_promote_global_oauth_tokens_migration.py
@@ -1,10 +1,11 @@
 """Behavioral test for the global-OAuth-token heal migration.
 
 The migration (alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py)
-is pure SQL, so we run its two statements against a seeded DB and assert it:
+is pure SQL, so we run its three statements against a seeded DB and assert it:
 
   - promotes a provider-org-stamped org-level token of a GLOBAL provider to NULL;
   - leaves a legitimately org-scoped connection's token alone;
+  - leaves legitimately org-scoped authorization-code callback tokens alone;
   - drops the redundant provider-org row when a real NULL token already exists;
   - never touches per-user tokens.
 
@@ -66,10 +67,10 @@ async def _org(db, name, *, is_provider=False):
     return o
 
 
-async def _provider(db, *, organization_id):
+async def _provider(db, *, organization_id, oauth_flow_type="client_credentials"):
     p = OAuthProvider(
         provider_name=f"conn_{uuid4().hex[:8]}",
-        oauth_flow_type="client_credentials",
+        oauth_flow_type=oauth_flow_type,
         client_id="cid",
         encrypted_client_secret=b"sec",
         organization_id=organization_id,
@@ -124,6 +125,52 @@ async def test_leaves_org_specific_connection_token_alone(db_session):
 
     await db_session.refresh(tok)
     assert tok.organization_id == provider_org.id, "per-org connection token must be preserved"
+
+
+@pytest.mark.asyncio
+async def test_leaves_provider_org_authorization_code_token_alone(db_session):
+    """Authorization-code callbacks can legitimately store org-level tokens
+    under the provider org. The migration must not promote them to global.
+    """
+    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
+    gp = await _provider(
+        db_session,
+        organization_id=None,
+        oauth_flow_type="authorization_code",
+    )
+    tok = await _token(db_session, provider_id=gp.id, organization_id=provider_org.id)
+
+    await _run_migration(db_session)
+
+    await db_session.refresh(tok)
+    assert tok.organization_id == provider_org.id, "auth-code org token must be preserved"
+
+
+@pytest.mark.asyncio
+async def test_keeps_provider_org_authorization_code_token_when_global_exists(db_session):
+    """A legitimate authorization-code org token must not be deleted just
+    because a separate global fallback token exists for the same provider.
+    """
+    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
+    gp = await _provider(
+        db_session,
+        organization_id=None,
+        oauth_flow_type="authorization_code",
+    )
+    global_token = await _token(db_session, provider_id=gp.id, organization_id=None)
+    org_token = await _token(db_session, provider_id=gp.id, organization_id=provider_org.id)
+
+    await _run_migration(db_session)
+
+    rows = (
+        await db_session.execute(
+            select(OAuthToken).where(OAuthToken.provider_id == gp.id)
+        )
+    ).scalars().all()
+    ids = {r.id for r in rows}
+    assert global_token.id in ids, "the global auth-code token must survive"
+    assert org_token.id in ids, "the org-scoped auth-code token must be preserved"
+    assert len(rows) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- The migration that repaired mis-stamped provider-org OAuth tokens was too broad and could promote or delete legitimately org-scoped `authorization_code` tokens, causing cross-tenant exposure; it must only touch rows created by the buggy `client_credentials` refresh path for global providers.

### Description
- Add `AND p.oauth_flow_type = 'client_credentials'` to the `DELETE`, deduplication (`WITH ranked`), and `UPDATE` statements in `api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py` so only global `client_credentials` providers are affected.
- Extend the migration test in `api/tests/unit/test_promote_global_oauth_tokens_migration.py` to include `authorization_code` provider scenarios and make the test `OAuthProvider` factory accept an `oauth_flow_type` parameter.
- Update the migration docstring to document the tightened scope and the reason for preserving org-scoped authorization-code tokens.

### Testing
- Captured the migration SQL by importing the migration module and asserted all three executed statements include the `p.oauth_flow_type = 'client_credentials'` predicate, and that check passed.
- Ran static checks with `python3 -m ruff check api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py api/tests/unit/test_promote_global_oauth_tokens_migration.py`, which passed.
- Attempted to run the unit test suite (`./test.sh tests/unit/...` and `cd api && python -m pytest tests/unit/test_promote_global_oauth_tokens_migration.py -v`) but the Docker-backed test stack is not available in this environment so tests could not complete end-to-end and failed with database connection errors; re-running the unit tests in CI or a dev stack with Docker is required to fully validate the migration behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3b0bb5a88328be30059cc33ebb5a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production migration SQL on OAuth tokens; the fix reduces cross-tenant risk but still mutates token rows at deploy time.
> 
> **Overview**
> Narrows the data-fix migration that promotes mis-stamped global OAuth tokens so it only runs for **`client_credentials`** global providers, not **`authorization_code`** flows where org-level tokens under the provider org can be legitimate.
> 
> All three SQL steps (redundant delete, dedupe, promote to `organization_id = NULL`) now include `p.oauth_flow_type = 'client_credentials'`. The migration docstring documents that constraint.
> 
> Unit tests gain an `oauth_flow_type` factory parameter and two cases: auth-code org tokens are not promoted, and they are not removed when a separate global token exists for the same provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e0bc2787ddc124a422e805b24d0176682bda2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->