### PR TITLE
fix: restrict document renderer resource fetching

### DIFF
--- a/api/tests/unit/test_doc_renderer_service.py
+++ b/api/tests/unit/test_doc_renderer_service.py
@@ -166,3 +166,68 @@ def test_markdown_renderer_bounds_pandoc_runtime(monkeypatch) -> None:
 
     with pytest.raises(RenderError, match="30-second render limit"):
         markdown_to_html("# Hello")
+
+
+def test_html_renderer_uses_restricted_url_fetcher(monkeypatch) -> None:
+    import sys
+
+    captured = {}
+
+    class FakeHTML:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def write_pdf(self):
+            return b"%PDF-safe"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "weasyprint",
+        SimpleNamespace(HTML=FakeHTML, default_url_fetcher=lambda url: {"url": url}),
+    )
+
+    from doc_renderer_service.rendering import _safe_url_fetcher, render_pdf_from_html
+
+    result = render_pdf_from_html(
+        html='<img src="http://127.0.0.1/internal.svg">',
+        title="Safe Report",
+        theme="clean_report",
+    )
+
+    assert result.pdf_bytes == b"%PDF-safe"
+    assert captured["url_fetcher"] is _safe_url_fetcher
+
+
+def test_safe_url_fetcher_blocks_network_and_non_theme_files(monkeypatch) -> None:
+    import sys
+
+    fetches = []
+
+    def fake_default_url_fetcher(url: str):
+        fetches.append(url)
+        return {"url": url}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "weasyprint",
+        SimpleNamespace(default_url_fetcher=fake_default_url_fetcher),
+    )
+
+    from doc_renderer_service.rendering import THEMES_DIR, _safe_url_fetcher
+
+    theme_url = (THEMES_DIR / "clean_report.css").resolve().as_uri()
+    assert _safe_url_fetcher(theme_url) == {"url": theme_url}
+    assert _safe_url_fetcher("data:image/png;base64,AAAA") == {
+        "url": "data:image/png;base64,AAAA"
+    }
+
+    for unsafe_url in (
+        "http://127.0.0.1/internal.svg",
+        "https://example.com/style.css",
+        Path("/etc/passwd").as_uri(),
+        "data:text/html;base64,PGgxPkJsb2NrZWQ8L2gxPg==",
+    ):
+        with pytest.raises(ValueError, match="Blocked unsafe document resource URL"):
+            _safe_url_fetcher(unsafe_url)
+
+    assert fetches == [theme_url, "data:image/png;base64,AAAA"]

--- a/doc_renderer_service/rendering.py
+++ b/doc_renderer_service/rendering.py
@@ -4,10 +4,12 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 import subprocess
+from urllib.parse import urlparse
 
 SERVICE_ROOT = Path(__file__).resolve().parent
 THEMES_DIR = SERVICE_ROOT / "themes"
 PANDOC_TIMEOUT_SECONDS = 30
+ALLOWED_DATA_URL_PREFIXES = ("data:image/", "data:font/")
 
 THEME_PATHS = {
     "business_case": THEMES_DIR / "business_case.css",
@@ -49,6 +51,33 @@ def resolve_theme_path(theme: str) -> Path:
 
 def _stylesheet_link(theme_path: Path) -> str:
     return f'<link rel="stylesheet" href="{theme_path.resolve().as_uri()}">'
+
+
+def _is_path_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _safe_url_fetcher(url: str):
+    """Restrict WeasyPrint resource loading to bundled themes and safe data URLs."""
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme == "data" and url.lower().startswith(ALLOWED_DATA_URL_PREFIXES):
+        from weasyprint import default_url_fetcher  # pyright: ignore[reportMissingImports]
+
+        return default_url_fetcher(url)
+
+    if scheme == "file":
+        path = Path(parsed.path).resolve()
+        if _is_path_relative_to(path, THEMES_DIR.resolve()):
+            from weasyprint import default_url_fetcher  # pyright: ignore[reportMissingImports]
+
+            return default_url_fetcher(url)
+
+    raise ValueError("Blocked unsafe document resource URL")
 
 
 def _wrap_html_document(*, html_body: str, title: str | None, theme_path: Path) -> str:
@@ -117,7 +146,11 @@ def render_pdf_from_html(
     rendered_html = _wrap_html_document(html_body=html, title=title, theme_path=theme_path)
     try:
         from weasyprint import HTML  # pyright: ignore[reportMissingImports]
-        pdf_bytes = HTML(string=rendered_html, base_url=str(THEMES_DIR)).write_pdf()
+        pdf_bytes = HTML(
+            string=rendered_html,
+            base_url=str(THEMES_DIR),
+            url_fetcher=_safe_url_fetcher,
+        ).write_pdf()
     except Exception as exc:  # pragma: no cover - WeasyPrint internals
         raise RenderError(f"WeasyPrint failed to render PDF: {exc}") from exc
 


### PR DESCRIPTION
### Motivation
- The standalone document renderer accepted attacker-controlled Markdown/HTML and used WeasyPrint's default resource fetcher, allowing server-side requests to arbitrary `http://`, `https://`, or `file://` URLs and creating an SSRF/data-exfiltration risk.
- The renderer also exposed the same risk via Markdown (image syntax or embedded HTML), so a conservative server-side policy is required to limit resource loading to known-safe assets.

### Description
- Add a strict URL fetcher `_safe_url_fetcher` in `doc_renderer_service/rendering.py` that only permits bundled theme `file://` assets under `doc_renderer_service/themes` and safe `data:image/*` / `data:font/*` data URLs, and raises on other schemes or paths.
- Wire the renderer to pass `url_fetcher=_safe_url_fetcher` into `weasyprint.HTML(...)` so WeasyPrint no longer performs unrestricted network or filesystem fetches during `write_pdf()`.
- Add unit tests in `api/tests/unit/test_doc_renderer_service.py` validating that the renderer uses the restricted fetcher and that `_safe_url_fetcher` accepts theme and safe data URLs while blocking `http(s)://`, non-theme `file://`, and unsafe `data:` URLs.

### Testing
- Ran unit tests with `python3 -m pytest api/tests/unit/test_doc_renderer_service.py -q`, and all tests passed (`10 passed`).
- Ran static checks `python3 -m ruff check doc_renderer_service/rendering.py api/tests/unit/test_doc_renderer_service.py` successfully and compiled relevant modules with `python3 -m compileall -q` with no errors.
- Docker-backed quality and stack tests (`./test.sh stack up`, `./test.sh quality api`) could not be executed in this environment because Docker is not available (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55359919548328b6f404764b6d1a24)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix in the document renderer’s resource-loading path; behavior is narrow and covered by tests, but mistakes could break legitimate assets or leave fetch holes.
> 
> **Overview**
> Closes an **SSRF / local file read** path where attacker-controlled HTML or Markdown could make WeasyPrint load arbitrary `http(s)://`, `file://`, or unsafe `data:` resources during PDF generation.
> 
> **`doc_renderer_service/rendering.py`** adds `_safe_url_fetcher` (with `_is_path_relative_to` and `ALLOWED_DATA_URL_PREFIXES`) so only bundled theme files under `themes/` and `data:image/*` / `data:font/*` URLs are delegated to WeasyPrint’s default fetcher; everything else raises `ValueError`. `render_pdf_from_html` now passes `url_fetcher=_safe_url_fetcher` into `weasyprint.HTML(...)`.
> 
> **`api/tests/unit/test_doc_renderer_service.py`** adds tests that the HTML renderer wires in `_safe_url_fetcher` and that allowed vs blocked URL patterns behave as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9a8dc9024bbd5fdbaf31645e7fc6dbcb5d061e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->