### PR TITLE
Prevent self-update from using project-local .env as update source

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -1075,8 +1075,9 @@ Usage: bifrost update [options]
 
 Update this CLI from the selected Bifrost instance. If --url is omitted,
 the current connection is resolved from BIFROST_API_URL, the selected default,
-or the only stored connection. If several connections exist with no default,
-an interactive terminal prompts you to choose one.
+or the only stored connection. Project-local .env files are ignored for this
+self-update command. If several connections exist with no default, an
+interactive terminal prompts you to choose one.
 
 Options:
   --url, -u URL   Bifrost instance to update from
@@ -1093,6 +1094,7 @@ Examples:
 
     resolved_url, _source = credentials.resolve_current_connection(
         api_url,
+        include_cwd_dotenv=False,
         prompt_for_default=True,
     )
     if not resolved_url:

--- a/api/tests/unit/cli/test_cli_update.py
+++ b/api/tests/unit/cli/test_cli_update.py
@@ -46,7 +46,11 @@ def test_update_resolves_current_connection_and_normalizes_url(
         rc = cli.handle_update([])
 
     assert rc == 0
-    resolve.assert_called_once_with(None, prompt_for_default=True)
+    resolve.assert_called_once_with(
+        None,
+        include_cwd_dotenv=False,
+        prompt_for_default=True,
+    )
     run.assert_called_once_with(
         ["installer", "https://bifrost.example.com/api/cli/download"],
         check=False,
@@ -66,7 +70,35 @@ def test_update_url_override_wins() -> None:
     assert rc == 0
     resolve.assert_called_once_with(
         "https://override.example.com/",
+        include_cwd_dotenv=False,
         prompt_for_default=True,
+    )
+
+
+def test_update_does_not_use_cwd_dotenv_for_self_update(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("BIFROST_API_URL=https://attacker.example.com\n")
+    monkeypatch.setattr(cli, "_update_install_command", lambda url: ["installer", url])
+
+    with patch(
+        "bifrost.credentials.get_persistent_backend",
+    ) as get_backend, patch(
+        "bifrost.credentials.get_default_connection",
+        return_value="https://trusted.example.com",
+    ), patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(["installer"], 0),
+    ) as run:
+        get_backend.return_value.list_urls.return_value = ["https://trusted.example.com"]
+        rc = cli.handle_update([])
+
+    assert rc == 0
+    run.assert_called_once_with(
+        ["installer", "https://trusted.example.com/api/cli/download"],
+        check=False,
     )
 
 


### PR DESCRIPTION
### Motivation
- The `bifrost update` command previously resolved `BIFROST_API_URL` from a project-local `.env` and used that value to build an installer URL, which allows a malicious repository to redirect the self-update to attacker-controlled packages and achieve code execution during `pip`/`pipx` installation.

### Description
- Stop trusting project-local `.env` for self-updates by calling `credentials.resolve_current_connection(..., include_cwd_dotenv=False)` in `handle_update` in `api/bifrost/cli.py` and update the help text to state that project-local `.env` files are ignored for this command.
- Add a regression test `test_update_does_not_use_cwd_dotenv_for_self_update` and update `api/tests/unit/cli/test_cli_update.py` expectations to assert `include_cwd_dotenv=False` is passed and that a CWD `.env` does not override a trusted stored/default connection.

### Testing
- Performed syntax/compile check with `python3 -m py_compile api/bifrost/cli.py api/tests/unit/cli/test_cli_update.py`, which succeeded.
- Attempted to run the unit suite with `./test.sh` but the environment lacks Docker (`docker: command not found`), so `pytest`-based tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550a757fec832898a3ba14e121de31)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, intentional behavior change on a security-sensitive command with regression tests; other commands still use CWD `.env` as before.
> 
> **Overview**
> **Security fix for `bifrost update`:** connection resolution no longer reads `BIFROST_API_URL` from the current directory’s `.env`, so a cloned repo cannot steer self-update toward a malicious `/api/cli/download` host.
> 
> `handle_update` now calls `credentials.resolve_current_connection(..., include_cwd_dotenv=False)`; help text documents that project-local `.env` is ignored for this command. Tests assert the flag and add `test_update_does_not_use_cwd_dotenv_for_self_update` (malicious CWD `.env` vs trusted stored default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36315cc3abdc71b3861c90b74f74ec4f83e435e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->