### PR TITLE
Restrict solution dev proxy binds to loopback

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -1940,7 +1940,7 @@ Usage: solution start [OPTIONS] [APP_SLUG]
 Options:
   --solution TEXT    Install id or unique slug.
   --port INTEGER     Local origin port.  [default: 3000]
-  --host TEXT        Address for the local origin to bind.  [default:
+  --host TEXT        Loopback address for the local origin to bind.  [default:
                      127.0.0.1]
   --public-url TEXT  Browser-visible origin for the local proxy, e.g.
                      https://dev.example.

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import io
+import ipaddress
 import json
 import os
 import pathlib
@@ -2176,6 +2177,16 @@ def export_cmd(
         raise SystemExit(rc)
 
 
+def _is_loopback_bind_host(bind_host: str) -> bool:
+    normalized = bind_host.strip().strip("[]").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
 def _vite_child_env(
     base_env: dict[str, str],
     *,
@@ -2212,7 +2223,7 @@ def _vite_child_env(
 @click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
 @click.option("--port", default=3000, show_default=True, type=int, help="Local origin port.")
 @click.option("--host", "bind_host", default="127.0.0.1", show_default=True,
-              help="Address for the local origin to bind.")
+              help="Loopback address for the local origin to bind.")
 @click.option("--public-url", default=None,
               help="Browser-visible origin for the local proxy, e.g. https://dev.example.")
 def start_cmd(
@@ -2243,6 +2254,13 @@ def start_cmd(
             "parent directory). Run `bifrost solution init` first."
         )
     descriptor = load_descriptor(workspace)
+
+    if not _is_loopback_bind_host(bind_host):
+        raise click.UsageError(
+            "--host must be a loopback address (for example 127.0.0.1, ::1, or "
+            "localhost). The solution dev proxy injects your CLI access token "
+            "into API requests and must not be exposed to other hosts."
+        )
 
     client = BifrostClient.get_instance(require_auth=True)
     binding = asyncio.run(

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -548,7 +548,7 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
         assert argv[0] == npm_path, f"npm spawn used {argv[0]!r}, not the which() result"
 
 
-def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
+def test_start_accepts_loopback_bind_host_and_public_url(tmp_path: Path, monkeypatch):
     import shutil
     import subprocess
 
@@ -638,7 +638,7 @@ def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
         [
             "start",
             "--host",
-            "0.0.0.0",
+            "localhost",
             "--public-url",
             "http://devbox.test:3000/",
             "--port",
@@ -648,11 +648,25 @@ def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert served == {
-        "bind_host": "0.0.0.0",
+        "bind_host": "localhost",
         "port": 3000,
         "proxy_origin": "http://devbox.test:3000",
     }
     assert popen_envs[0]["BIFROST_API_URL"] == "http://devbox.test:3000"
+
+
+def test_start_rejects_non_loopback_bind_host(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["start", "--host", "0.0.0.0", "--port", "3000"],
+    )
+
+    assert result.exit_code != 0
+    assert "--host must be a loopback address" in result.output
+    assert "must not be exposed to other hosts" in result.output
 
 
 def test_handle_solution_renders_clickexception_not_traceback(tmp_path, monkeypatch, capsys):

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -1940,7 +1940,7 @@ Usage: solution start [OPTIONS] [APP_SLUG]
 Options:
   --solution TEXT    Install id or unique slug.
   --port INTEGER     Local origin port.  [default: 3000]
-  --host TEXT        Address for the local origin to bind.  [default:
+  --host TEXT        Loopback address for the local origin to bind.  [default:
                      127.0.0.1]
   --public-url TEXT  Browser-visible origin for the local proxy, e.g.
                      https://dev.example.


### PR DESCRIPTION
### Motivation
- A previous change added a `--host` option to `bifrost solution start` that could bind the dev proxy to non-loopback interfaces, exposing an injected developer CLI bearer token to network attackers. 
- The intent of this PR is to eliminate that network exposure by ensuring the dev proxy can only be bound to loopback addresses while preserving local dev behavior and the `--public-url` feature.

### Description
- Add an `_is_loopback_bind_host` helper (uses `ipaddress`) and validate `bind_host` early in `start_cmd`, raising `click.UsageError` when a non-loopback address is supplied. 
- Update the `--host` help text to explicitly document that the option is a loopback-only bind address. 
- Update unit tests in `api/tests/unit/test_solution_dev_command.py` to keep loopback behavior and add `test_start_rejects_non_loopback_bind_host` which asserts `0.0.0.0` is rejected. 
- Refresh generated CLI appendices (`plugins/.../cli-reference.md` and `.claude/.../cli-reference.md`) to reflect the tightened help text.

### Testing
- Ran `python -m pytest api/tests/unit/test_solution_dev_command.py -q` and all tests passed (`39 passed`).
- Regenerated/validated the CLI appendix with `BIFROST_SECRET_KEY=0123456789abcdef0123456789abcdef PYTHONPATH=api python -m pytest api/tests/unit/test_skill_appendix_fresh.py -q` and the check passed. 
- Verified `python -m py_compile api/bifrost/commands/solution.py` succeeded and `git diff --check` showed no whitespace/errors. 
- Note: `./test.sh` / stack-backed runs could not be executed in this environment because `docker` is unavailable, so full Dockerized `./test.sh` checks were not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55167f62a08328bb82905770bfdb65)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-hardening change to local dev CLI behavior; breaks anyone who relied on `--host 0.0.0.0`, with low production impact.
> 
> **Overview**
> **Closes a security gap** where `bifrost solution start --host` could bind the dev proxy on all interfaces and expose requests that carry the injected CLI access token.
> 
> `start_cmd` now rejects non-loopback `--host` values (e.g. `0.0.0.0`) via new `_is_loopback_bind_host` (`ipaddress` + `localhost`), with a `click.UsageError` that explains why. Loopback binds and `--public-url` are unchanged. Help text and generated CLI reference docs call `--host` loopback-only. Unit tests cover acceptance of `localhost` and rejection of `0.0.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726e929149ccf86ced6ee0acabcd6789fe986aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->