### PR TITLE
Restrict local file backend to superusers

### DIFF
--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -552,6 +552,14 @@ def _tiers_for_backend_mode(tiers: list[_T], mode: str) -> list[_T]:
     return tiers
 
 
+def _require_local_mode_superuser(mode: str, user: UserPrincipal) -> None:
+    if mode == "local" and not user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Local file mode is restricted to superusers.",
+        )
+
+
 async def _filter_listed_paths(
     ctx: Context,
     *,
@@ -1096,6 +1104,7 @@ async def read_file(
 ) -> FileReadResponse:
     """Read a file from a managed or custom location."""
     try:
+        _require_local_mode_superuser(request.mode, ctx.user)
         from src.services.solution_scope import file_read_tiers
 
         if request.location != "workspace":
@@ -1175,6 +1184,7 @@ async def write_file(
 ) -> None:
     """Write a file to a managed or custom location."""
     try:
+        _require_local_mode_superuser(request.mode, ctx.user)
         effective_scope = _resolve_effective_scope(ctx, request.location, request.scope)
         solution_id = _ctx_solution_id(ctx, request.location)
         await _require_declared_solution_file_location(
@@ -1243,6 +1253,7 @@ async def delete_file(
 ) -> None:
     """Delete a file from a managed or custom location."""
     try:
+        _require_local_mode_superuser(request.mode, ctx.user)
         effective_scope = _resolve_effective_scope(ctx, request.location, request.scope)
         solution_id = _ctx_solution_id(ctx, request.location)
         await _require_declared_solution_file_location(
@@ -1301,6 +1312,7 @@ async def list_files_simple(
 ) -> FileListResponse:
     """List files in a directory (simple SDK-focused endpoint)."""
     try:
+        _require_local_mode_superuser(request.mode, ctx.user)
         from src.services.solution_scope import file_read_tiers
 
         if request.location != "workspace":
@@ -1454,6 +1466,7 @@ async def file_exists(
 ) -> FileExistsResponse:
     """Check if a file exists."""
     try:
+        _require_local_mode_superuser(request.mode, ctx.user)
         from src.services.solution_scope import file_read_tiers
 
         if request.location != "workspace":

--- a/api/tests/unit/routers/test_files_helpers.py
+++ b/api/tests/unit/routers/test_files_helpers.py
@@ -378,12 +378,36 @@ async def test_write_file_local_binary_decodes_without_cloud_metadata(monkeypatc
             scope=str(ORG_A),
             mode="local",
         ),
-        _ctx(),
-        SimpleNamespace(user_id=USER_ID),
+        _ctx(is_superuser=True),
+        SimpleNamespace(user_id=USER_ID, is_superuser=True),
         db=SimpleNamespace(),
     )
 
     assert writes == [("folder/raw.bin", b"\x00\x01raw", "reports", "user@example.test", str(ORG_A))]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("file_request", "endpoint"),
+    [
+        (files.FileReadRequest(path="server_secret.py", mode="local"), files.read_file),
+        (files.FileWriteRequest(path="server_secret.py", content="owned", mode="local"), files.write_file),
+        (files.FileDeleteRequest(path="server_secret.py", mode="local"), files.delete_file),
+        (files.FileListRequest(directory="", mode="local"), files.list_files_simple),
+        (files.FileExistsRequest(path="server_secret.py", mode="local"), files.file_exists),
+    ],
+)
+async def test_policy_gated_file_endpoints_reject_local_mode_for_regular_users(file_request, endpoint):
+    with pytest.raises(HTTPException) as exc_info:
+        await endpoint(
+            file_request,
+            _ctx(is_superuser=False),
+            SimpleNamespace(user_id=USER_ID, is_superuser=False),
+            db=SimpleNamespace(),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Local file mode is restricted to superusers."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Policy-gated Files API endpoints accepted a caller-controlled `mode` and could pick the `LocalBackend` after authorization, allowing non-admin users to operate on the API container filesystem instead of cloud storage.  
- This backend-confusion is a high-severity security risk because `LocalBackend` maps `workspace` to the process CWD and freeform locations to local directories.  

### Description
- Add a guard function `_require_local_mode_superuser(mode, user)` that raises `403` when `mode == "local"` and the caller is not a superuser.  
- Invoke the guard at the start of the policy-gated endpoints for read, write, delete, list, and exists so non-superusers cannot reach `LocalBackend`.  
- Update existing unit coverage to ensure local-mode behavior remains available to superusers and add a parameterized unit test asserting regular users receive `403` when requesting `mode="local"`.  
- Preserve cloud-mode behavior and existing policy checks; this change only restricts selection of the local filesystem backend to platform admins.  

### Testing
- `python3 -m py_compile api/src/routers/files.py api/tests/unit/routers/test_files_helpers.py` succeeded with no syntax errors.  
- Unit tests `python3 -m pytest api/tests/unit/routers/test_files_helpers.py -q` passed (63 passed, 1 warning).  
- Lint/type checks `python3 -m ruff check api/src/routers/files.py api/tests/unit/routers/test_files_helpers.py` passed.  
- Attempted the full Dockerized test stack (`./test.sh stack up` / full `./test.sh all`) but it could not be run in this environment because `docker` is unavailable; those stack-backed tests should be run in CI or a dev environment with the test stack up before final merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5511f82bb88328b5db0a9427650fdd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a security fix on file I/O backend selection; incorrect enforcement could break legitimate superuser/CLI local workflows or leave local-mode exposure open.
> 
> **Overview**
> Closes a security gap where policy-gated Files API handlers honored caller-controlled `mode="local"` and could route operations to **`LocalBackend`** (API container filesystem) after policy checks passed.
> 
> Adds **`_require_local_mode_superuser`** and invokes it at the start of **read**, **write**, **delete**, **list**, and **exists** so non-superusers get **403** with *"Local file mode is restricted to superusers."* before any local backend work. **Cloud** mode and existing policy/scope behavior are unchanged.
> 
> Unit tests keep local-mode writes for superusers and add a parameterized test that all five endpoints reject `mode="local"` for regular users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa24449acbe710b77be8fd549e2aaa12356c3ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->