### PR TITLE
fix(cli): prevent project env from hijacking self-update

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -1093,6 +1093,7 @@ Examples:
 
     resolved_url, _source = credentials.resolve_current_connection(
         api_url,
+        include_cwd_dotenv=False,
         prompt_for_default=True,
     )
     if not resolved_url:

--- a/api/tests/unit/cli/test_cli_update.py
+++ b/api/tests/unit/cli/test_cli_update.py
@@ -46,7 +46,11 @@ def test_update_resolves_current_connection_and_normalizes_url(
         rc = cli.handle_update([])
 
     assert rc == 0
-    resolve.assert_called_once_with(None, prompt_for_default=True)
+    resolve.assert_called_once_with(
+        None,
+        include_cwd_dotenv=False,
+        prompt_for_default=True,
+    )
     run.assert_called_once_with(
         ["installer", "https://bifrost.example.com/api/cli/download"],
         check=False,
@@ -66,6 +70,25 @@ def test_update_url_override_wins() -> None:
     assert rc == 0
     resolve.assert_called_once_with(
         "https://override.example.com/",
+        include_cwd_dotenv=False,
+        prompt_for_default=True,
+    )
+
+
+def test_update_ignores_cwd_dotenv_connection() -> None:
+    completed = subprocess.CompletedProcess(["installer"], 0)
+    with patch(
+        "bifrost.credentials.resolve_current_connection",
+        return_value=("https://stored.example.com", "default"),
+    ) as resolve, patch(
+        "bifrost.cli._update_install_command", return_value=["installer"]
+    ), patch("subprocess.run", return_value=completed):
+        rc = cli.handle_update([])
+
+    assert rc == 0
+    resolve.assert_called_once_with(
+        None,
+        include_cwd_dotenv=False,
         prompt_for_default=True,
     )
 


### PR DESCRIPTION
## Summary
- exclude project-local `.env` files when selecting the self-update source
- preserve explicit `--url`, process environment, selected default, and stored connection behavior
- lock the resolver call down with focused unit assertions

## Verification
- `python -m ruff check api/bifrost/cli.py api/tests/unit/cli/test_cli_update.py`
- focused pytest cannot import the full CLI dependency set on this workstation; CI is the verification environment

Finding: https://chatgpt.com/codex/cloud/security/findings/56e1a10966e881919fa53a6b3e01ebd0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to connection resolution for one CLI command only; other commands still honor CWD `.env` as before.
> 
> **Overview**
> **`bifrost update`** no longer treats the current directory’s `.env` as the source for which Bifrost instance to reinstall from. Connection resolution now calls `resolve_current_connection` with **`include_cwd_dotenv=False`**, so a project-local `BIFROST_API_URL` cannot redirect self-update away from the user’s real default, process env, explicit `--url`, or stored credentials.
> 
> Unit tests were tightened to expect that flag on every update path and a dedicated case documents the intended “ignore cwd dotenv” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04ff33e670cb4ee403fb283d82ddd12dd7c3d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->