### PR TITLE
fix(renderer): block SSRF through document resources

### DIFF
--- a/api/tests/unit/test_doc_renderer_service.py
+++ b/api/tests/unit/test_doc_renderer_service.py
@@ -166,3 +166,37 @@ def test_markdown_renderer_bounds_pandoc_runtime(monkeypatch) -> None:
 
     with pytest.raises(RenderError, match="30-second render limit"):
         markdown_to_html("# Hello")
+
+
+def test_renderer_url_fetcher_blocks_network_and_arbitrary_files(monkeypatch) -> None:
+    from doc_renderer_service.rendering import restricted_url_fetcher
+
+    fetches: list[str] = []
+    fake_weasyprint = SimpleNamespace(
+        default_url_fetcher=lambda url, **kwargs: fetches.append(url) or {"string": b"ok"}
+    )
+    monkeypatch.setitem(sys.modules, "weasyprint", fake_weasyprint)
+
+    with pytest.raises(ValueError, match="External document resources"):
+        restricted_url_fetcher("https://169.254.169.254/latest/meta-data/")
+    with pytest.raises(ValueError, match="External document resources"):
+        restricted_url_fetcher(Path(__file__).resolve().as_uri())
+
+    assert fetches == []
+
+
+def test_renderer_url_fetcher_allows_data_and_bundled_theme(monkeypatch) -> None:
+    from doc_renderer_service.rendering import THEME_PATHS, restricted_url_fetcher
+
+    fetches: list[str] = []
+    fake_weasyprint = SimpleNamespace(
+        default_url_fetcher=lambda url, **kwargs: fetches.append(url) or {"string": b"ok"}
+    )
+    monkeypatch.setitem(sys.modules, "weasyprint", fake_weasyprint)
+
+    data_url = "data:image/png;base64,iVBORw0KGgo="
+    theme_url = THEME_PATHS["clean_report"].resolve().as_uri()
+    restricted_url_fetcher(data_url)
+    restricted_url_fetcher(theme_url)
+
+    assert fetches == [data_url, theme_url]

--- a/doc_renderer_service/rendering.py
+++ b/doc_renderer_service/rendering.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 import re
 import subprocess
+from urllib.parse import unquote, urlsplit
+from urllib.request import url2pathname
 
 SERVICE_ROOT = Path(__file__).resolve().parent
 THEMES_DIR = SERVICE_ROOT / "themes"
@@ -14,6 +17,7 @@ THEME_PATHS = {
     "clean_report": THEMES_DIR / "clean_report.css",
     "executive_brief": THEMES_DIR / "executive_brief.css",
 }
+ALLOWED_LOCAL_RESOURCES = frozenset(path.resolve() for path in THEME_PATHS.values())
 
 
 class RenderError(RuntimeError):
@@ -74,6 +78,24 @@ def _wrap_html_document(*, html_body: str, title: str | None, theme_path: Path) 
 """
 
 
+def restricted_url_fetcher(url: str, timeout: int = 10, ssl_context=None):
+    """Fetch only embedded content or an exact bundled theme stylesheet."""
+    from weasyprint import default_url_fetcher  # pyright: ignore[reportMissingImports]
+
+    parsed = urlsplit(url)
+    if parsed.scheme == "data":
+        return default_url_fetcher(url, timeout=timeout, ssl_context=ssl_context)
+
+    if parsed.scheme == "file" and not parsed.netloc:
+        local_path = Path(url2pathname(unquote(parsed.path)))
+        if os.name == "nt" and str(local_path).startswith("\\"):
+            local_path = Path(str(local_path).lstrip("\\"))
+        if local_path.resolve() in ALLOWED_LOCAL_RESOURCES:
+            return default_url_fetcher(url, timeout=timeout, ssl_context=ssl_context)
+
+    raise ValueError("External document resources are not allowed")
+
+
 def markdown_to_html(markdown: str, *, title: str | None = None) -> str:
     cmd = [
         "pandoc",
@@ -117,7 +139,11 @@ def render_pdf_from_html(
     rendered_html = _wrap_html_document(html_body=html, title=title, theme_path=theme_path)
     try:
         from weasyprint import HTML  # pyright: ignore[reportMissingImports]
-        pdf_bytes = HTML(string=rendered_html, base_url=str(THEMES_DIR)).write_pdf()
+        pdf_bytes = HTML(
+            string=rendered_html,
+            base_url=str(THEMES_DIR),
+            url_fetcher=restricted_url_fetcher,
+        ).write_pdf()
     except Exception as exc:  # pragma: no cover - WeasyPrint internals
         raise RenderError(f"WeasyPrint failed to render PDF: {exc}") from exc
 


### PR DESCRIPTION
## Summary
- deny renderer access to network URLs and arbitrary local files
- permit only embedded data URLs and exact bundled theme stylesheets
- add regression coverage for blocked metadata/file fetches and allowed resources

## Verification
- `python -m ruff check doc_renderer_service/rendering.py api/tests/unit/test_doc_renderer_service.py`
- direct restricted-fetcher smoke passed on Windows
- focused pytest collection is unavailable on this workstation because platform test dependencies are not installed; CI is the verification environment

Finding: https://chatgpt.com/codex/cloud/security/findings/995b528b9eb0819197fe7323cbbdad95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive change to how untrusted document HTML triggers outbound/local fetches; incorrect allowlisting could break themes or re-open SSRF.
> 
> **Overview**
> **Closes an SSRF path** where WeasyPrint could load arbitrary HTTP(S) URLs or local files while rendering PDFs from user-supplied HTML/markdown.
> 
> The renderer now passes a custom `restricted_url_fetcher` into `HTML(...).write_pdf()`. That fetcher only delegates to WeasyPrint’s default fetcher for `data:` URLs and for `file:` URLs whose resolved path is exactly one of the bundled theme CSS files (`ALLOWED_LOCAL_RESOURCES`); everything else raises `ValueError` with *External document resources are not allowed*.
> 
> Unit tests mock WeasyPrint and assert metadata-style HTTPS URLs and arbitrary `file:` URIs are blocked without fetching, while embedded data URLs and theme stylesheet URIs still go through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d6c9f13a551b9a3bddb6bc869c1b8ab7aca51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->