### PR TITLE
fix(dev): authenticate solution proxy sessions

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -24,6 +24,7 @@ import json
 import os
 import pathlib
 import re
+import secrets
 import subprocess
 import time
 import zipfile
@@ -2182,7 +2183,6 @@ def _vite_child_env(
     app_id: str,
     org_id: str | None,
     proxy_origin: str,
-    access_token: str,
 ) -> dict[str, str]:
     """Environment for the `solution start` Vite child.
 
@@ -2203,7 +2203,11 @@ def _vite_child_env(
     else:
         env.pop("VITE_BIFROST_ORG_ID", None)
     env["BIFROST_API_URL"] = proxy_origin
-    env["BIFROST_ACCESS_TOKEN"] = access_token
+    # The authenticated proxy injects the real CLI credential upstream. Keep
+    # it out of Vite's bundle-visible environment. A non-secret placeholder
+    # also prevents older scaffold configs from falling back to `auth token`.
+    env["BIFROST_ACCESS_TOKEN"] = "dev-proxy-authenticated"
+    env.pop("VITE_BIFROST_TOKEN", None)
     return env
 
 
@@ -2333,7 +2337,6 @@ def start_cmd(
         app_id=chosen.app_id,
         org_id=(org_info or {}).get("id"),
         proxy_origin=proxy_origin,
-        access_token=client._access_token,
     )
 
     # Run `npm run dev` in its OWN process group (start_new_session) so teardown
@@ -2995,7 +2998,16 @@ def _terminate_process_group(proc: "subprocess.Popen") -> None:
         _signal_group(signal.SIGKILL)
 
 
-def _dev_proxy_config(client, chosen, org_info, solution_id, global_repo_access):
+def _dev_proxy_config(
+    client,
+    chosen,
+    org_info,
+    solution_id,
+    global_repo_access,
+    *,
+    session_token=None,
+    secure_cookie=False,
+):
     from bifrost.solution_dev.proxy import DevProxyConfig
 
     return DevProxyConfig(
@@ -3006,6 +3018,8 @@ def _dev_proxy_config(client, chosen, org_info, solution_id, global_repo_access)
         solution_id=solution_id,
         global_repo_access=global_repo_access,
         refresh_token=client.refresh_access_token,
+        session_token=session_token,
+        secure_cookie=secure_cookie,
     )
 
 
@@ -3027,8 +3041,15 @@ async def _serve(
     from bifrost.solution_dev.proxy import build_dev_app
     from bifrost.solution_dev.reload import start_function_watch
 
+    session_token = secrets.token_urlsafe(32)
     cfg = _dev_proxy_config(
-        client, chosen, org_info, solution_id, global_repo_access
+        client,
+        chosen,
+        org_info,
+        solution_id,
+        global_repo_access,
+        session_token=session_token,
+        secure_cookie=proxy_origin.startswith("https://"),
     )
     app = build_dev_app(cfg, host, vite_url=f"http://127.0.0.1:{vite_port}")
     runner = web.AppRunner(app)
@@ -3036,7 +3057,10 @@ async def _serve(
     site = web.TCPSite(runner, bind_host, port)
     await site.start()
     observer = start_function_watch(workspace, host)
-    click.echo(f"\n  Bifrost solution dev server → {proxy_origin}\n")
+    click.echo(
+        f"\n  Bifrost solution dev server → "
+        f"{proxy_origin}#bifrost-dev-token={session_token}\n"
+    )
     click.echo(f"  Bound to {bind_host}:{port}\n")
     click.echo("  Press Ctrl-C to stop.\n")
     try:

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import html
 import re
+import secrets
 import uuid as _uuid
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
@@ -61,6 +62,7 @@ class _UpstreamAuthorityError(ValueError):
 
 
 DEV_AUTH_EXPIRED_DETAIL = "Your CLI token has expired. Restart `bifrost solution start`."
+DEV_SESSION_COOKIE = "bifrost_dev_session"
 
 
 def _join_upstream(base_url: str, rel_url: yarl.URL) -> str:
@@ -111,6 +113,8 @@ class DevProxyConfig:
     auth_expired: bool = False
     branding: dict[str, Any] | None = None
     branding_loaded: bool = False
+    session_token: str | None = None
+    secure_cookie: bool = False
 
 
 # Typed app keys (avoid aiohttp's NotAppKeyWarning for plain-string keys).
@@ -122,7 +126,7 @@ _WARNED_UUID_REFS = web.AppKey("warned_uuid_refs", set)
 
 
 def build_dev_app(cfg: DevProxyConfig, host, vite_url: str) -> web.Application:
-    app = web.Application()
+    app = web.Application(middlewares=[_dev_session_middleware])
     app[_CFG] = cfg
     app[_HOST] = host
     app[_VITE] = vite_url.rstrip("/")
@@ -139,6 +143,72 @@ def build_dev_app(cfg: DevProxyConfig, host, vite_url: str) -> web.Application:
 
     app.on_cleanup.append(_close)
     return app
+
+
+def _dev_session_bootstrap() -> web.Response:
+    page = """<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>
+  <body>
+    <script>
+      const params = new URLSearchParams(location.hash.slice(1));
+      const token = params.get("bifrost-dev-token");
+      if (!token) {
+        document.body.textContent = "This Bifrost dev session requires its private launch URL.";
+      } else {
+        fetch("/__bifrost/dev-auth", {
+          method: "POST",
+          headers: {"X-Bifrost-Dev-Token": token},
+        }).then((response) => {
+          if (!response.ok) throw new Error("Dev session authentication failed");
+          history.replaceState(null, "", location.pathname + location.search);
+          location.reload();
+        }).catch(() => {
+          document.body.textContent = "Bifrost dev session authentication failed.";
+        });
+      }
+    </script>
+  </body>
+</html>"""
+    return web.Response(
+        text=page,
+        content_type="text/html",
+        headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
+    )
+
+
+@web.middleware
+async def _dev_session_middleware(request: web.Request, handler):
+    cfg: DevProxyConfig = request.app[_CFG]
+    if cfg.session_token is None:
+        return await handler(request)
+
+    if request.path == "/__bifrost/dev-auth" and request.method == "POST":
+        supplied = request.headers.get("X-Bifrost-Dev-Token", "")
+        if not secrets.compare_digest(supplied, cfg.session_token):
+            return web.json_response({"detail": "Invalid dev session"}, status=401)
+        response = web.json_response({"authenticated": True})
+        response.set_cookie(
+            DEV_SESSION_COOKIE,
+            cfg.session_token,
+            httponly=True,
+            secure=cfg.secure_cookie,
+            samesite="Strict",
+            path="/",
+        )
+        return response
+
+    cookie = request.cookies.get(DEV_SESSION_COOKIE, "")
+    if secrets.compare_digest(cookie, cfg.session_token):
+        return await handler(request)
+
+    accept = request.headers.get("Accept", "")
+    fetch_dest = request.headers.get("Sec-Fetch-Dest", "")
+    if request.method == "GET" and (
+        "text/html" in accept or fetch_dest in {"document", "iframe"}
+    ):
+        return _dev_session_bootstrap()
+    return web.json_response({"detail": "Dev session authentication required"}, status=401)
 
 
 def _auth_headers(cfg: DevProxyConfig, incoming) -> dict[str, str]:

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -216,6 +216,57 @@ async def test_local_path_ref_runs_in_function_host():
         await up_runner.cleanup()
 
 
+async def test_dev_session_gate_protects_proxy_and_uses_httponly_cookie():
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_upstream(record), up_port)
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="cli-token",
+        app_id="A",
+        org_id="O",
+        session_token="private-session-token",
+    )
+    dev_runner = await _serve(
+        build_dev_app(cfg, _StubHost(set()), vite_url="http://127.0.0.1:1"),
+        dev_port,
+    )
+    try:
+        async with httpx.AsyncClient() as client:
+            denied = await client.get(f"http://127.0.0.1:{dev_port}/api/test")
+            assert denied.status_code == 401
+
+            bootstrap = await client.get(
+                f"http://127.0.0.1:{dev_port}/",
+                headers={"Accept": "text/html"},
+            )
+            assert bootstrap.status_code == 200
+            assert "location.hash" in bootstrap.text
+            assert "private-session-token" not in bootstrap.text
+
+            rejected = await client.post(
+                f"http://127.0.0.1:{dev_port}/__bifrost/dev-auth",
+                headers={"X-Bifrost-Dev-Token": "wrong"},
+            )
+            assert rejected.status_code == 401
+
+            accepted = await client.post(
+                f"http://127.0.0.1:{dev_port}/__bifrost/dev-auth",
+                headers={"X-Bifrost-Dev-Token": "private-session-token"},
+            )
+            assert accepted.status_code == 200
+            set_cookie = accepted.headers["set-cookie"]
+            assert "HttpOnly" in set_cookie
+            assert "SameSite=Strict" in set_cookie
+
+            proxied = await client.get(f"http://127.0.0.1:{dev_port}/api/test")
+            assert proxied.status_code == 200
+            assert record["other_path"] == "/api/test"
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
 class _RaisingHost:
     def resolve(self, ref):
         return ref

--- a/api/tests/unit/test_solution_start_env.py
+++ b/api/tests/unit/test_solution_start_env.py
@@ -51,17 +51,22 @@ class TestScaffoldApiUrl:
 
 def test_vite_child_env_points_bundle_at_local_proxy():
     env = _vite_child_env(
-        {"PATH": "/usr/bin", "BIFROST_API_URL": "http://upstream:34173"},
+        {
+            "PATH": "/usr/bin",
+            "BIFROST_API_URL": "http://upstream:34173",
+            "BIFROST_ACCESS_TOKEN": "real-cli-token",
+            "VITE_BIFROST_TOKEN": "also-real",
+        },
         app_id="2a9d06da-cc86-49ff-b3b5-26748c31f73e",
         org_id="org-1",
         proxy_origin="http://127.0.0.1:3777",
-        access_token="tok",
     )
     # The bundle-visible API URL is the PROXY, never the upstream.
     assert env["BIFROST_API_URL"] == "http://127.0.0.1:3777"
     assert env["VITE_BIFROST_APP_ID"] == "2a9d06da-cc86-49ff-b3b5-26748c31f73e"
     assert env["VITE_BIFROST_ORG_ID"] == "org-1"
-    assert env["BIFROST_ACCESS_TOKEN"] == "tok"
+    assert env["BIFROST_ACCESS_TOKEN"] == "dev-proxy-authenticated"
+    assert "VITE_BIFROST_TOKEN" not in env
     # Base env is inherited, not replaced.
     assert env["PATH"] == "/usr/bin"
 
@@ -78,7 +83,6 @@ def test_vite_child_env_omits_org_var_for_global_installs():
         app_id="2a9d06da-cc86-49ff-b3b5-26748c31f73e",
         org_id=None,
         proxy_origin="http://127.0.0.1:3777",
-        access_token="tok",
     )
     assert "VITE_BIFROST_ORG_ID" not in env
 


### PR DESCRIPTION
## Summary
- require a random per-run browser session before serving Vite, API proxy, or websocket traffic
- exchange the launch URL fragment for an HttpOnly SameSite cookie so the secret never reaches proxy logs
- keep the real CLI bearer token out of Vite and expose only a non-credential placeholder
- retain upstream bearer injection and refresh inside the authenticated proxy

## Verification
- `python -m ruff check api/bifrost/commands/solution.py api/bifrost/solution_dev/proxy.py api/tests/unit/test_solution_start_env.py api/tests/unit/test_solution_dev_proxy.py`
- `python -m compileall -q ...`
- focused session-gate and Vite-env regression tests added; full execution runs in CI

Findings:
- https://chatgpt.com/codex/cloud/security/findings/10d99b75e1b88191939fe646176868e2
- https://chatgpt.com/codex/cloud/security/findings/efab8564f83c8191a1a955cf01c68a12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local dev authentication and credential handling (session cookies, token removal from Vite env); upstream bearer injection is unchanged but misconfiguration could break the dev loop until restart.
> 
> **Overview**
> **Adds a per-run browser gate** on `bifrost solution start` so Vite, API proxy, and websocket traffic are not served until the developer opens the private launch URL.
> 
> Each run generates a random `session_token`. The CLI prints `{proxy_origin}#bifrost-dev-token=…`. Unauthenticated document loads get a small bootstrap page that reads the **URL fragment** (not logged in proxy access logs), `POST`s to `/__bifrost/dev-auth`, and sets an **HttpOnly, SameSite=Strict** `bifrost_dev_session` cookie. Other requests without that cookie get **401** until authenticated.
> 
> **Keeps the real CLI bearer token server-side only:** Vite env no longer receives the CLI token—`BIFROST_ACCESS_TOKEN` is the placeholder `dev-proxy-authenticated`, and `VITE_BIFROST_TOKEN` is stripped. The proxy still injects the CLI token (with refresh) on upstream API calls.
> 
> Unit tests cover the session gate, cookie flags, and updated Vite child env expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11e0cd3d72e088558dc19ac547f9f59b65efc7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->