### PR TITLE
fix(security): remediate targeted CodeQL findings

### DIFF
--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -14,7 +14,7 @@ Organization Scoping:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 from uuid import UUID
 
 from datetime import datetime, timedelta, timezone
@@ -22,9 +22,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import delete, distinct, func, or_, select, union_all, update
-
-if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 
 # Import existing Pydantic models for API compatibility
 from src.models.enums import ExecutionStatus
@@ -656,7 +654,7 @@ async def get_workflow_usage_stats(
 
 async def _insert_scheduled_execution(
     *,
-    db: "AsyncSession",
+    db: AsyncSession,
     workflow_id: UUID,
     workflow_name: str,
     parameters: dict,

--- a/api/src/services/file_storage/deactivation.py
+++ b/api/src/services/file_storage/deactivation.py
@@ -13,6 +13,8 @@ from uuid import UUID as UUID_type
 from sqlalchemy import select, update, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.log_safety import log_safe
+
 from .models import PendingDeactivationInfo, AvailableReplacementInfo
 
 if TYPE_CHECKING:
@@ -267,7 +269,7 @@ class DeactivationProtectionService:
             try:
                 workflow_uuid = UUID_type(old_id)
             except ValueError:
-                logger.warning(f"Invalid workflow ID in replacement: {old_id}")
+                logger.warning(f"Invalid workflow ID in replacement: {log_safe(old_id)}")
                 continue
 
             # Update the workflow's function_name
@@ -278,7 +280,10 @@ class DeactivationProtectionService:
                 .values(function_name=new_function_name)
             )
             await self.db.execute(stmt)
-            logger.info(f"Applied replacement: workflow {old_id} -> function {new_function_name}")
+            logger.info(
+                f"Applied replacement: workflow {log_safe(old_id)} -> "
+                f"function {log_safe(new_function_name)}"
+            )
 
     async def deactivate_workflows_by_id(
         self,
@@ -306,7 +311,9 @@ class DeactivationProtectionService:
             try:
                 uuids.append(UUID_type(wid))
             except ValueError:
-                logger.warning(f"Invalid workflow ID in deactivation list: {wid}")
+                logger.warning(
+                    f"Invalid workflow ID in deactivation list: {log_safe(wid)}"
+                )
                 continue
 
         if not uuids:
@@ -378,6 +385,9 @@ class DeactivationProtectionService:
         count = result.rowcount if result.rowcount else 0
 
         if count > 0:
-            logger.info(f"Deactivated {count} workflow(s) from {path} via force_deactivation")
+            logger.info(
+                f"Deactivated {count} workflow(s) from {log_safe(path)} "
+                "via force_deactivation"
+            )
 
         return count

--- a/api/src/services/file_storage/file_ops.py
+++ b/api/src/services/file_storage/file_ops.py
@@ -669,7 +669,10 @@ class FileOperationsService:
                     Key=old_s3_key,
                 )
             except Exception as e:
-                logger.warning(f"S3 move failed for {old_path} -> {new_path}: {e}")
+                logger.warning(
+                    f"S3 move failed for {log_safe(old_path)} -> "
+                    f"{log_safe(new_path)}: {log_safe(e)}"
+                )
 
         # Update file_index: insert new path, delete old
         new_stmt = insert(FileIndex).values(
@@ -693,4 +696,6 @@ class FileOperationsService:
         del_stmt = delete(FileIndex).where(FileIndex.path == old_path)
         await self.db.execute(del_stmt)
 
-        logger.info(f"File moved: {old_path} -> {new_path}")
+        logger.info(
+            f"File moved: {log_safe(old_path)} -> {log_safe(new_path)}"
+        )

--- a/api/src/services/file_storage/service.py
+++ b/api/src/services/file_storage/service.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import Settings, get_settings
+from src.core.log_safety import log_safe
 from .models import (
     WriteResult,
     WorkflowIdConflictInfo,
@@ -492,7 +493,7 @@ class FileStorageService:
                         if pending:
                             return content, False, False, None, [], pending, available
                     logger.info(
-                        f"Skipping indexing for module without decorators: {path}"
+                        f"Skipping indexing for module without decorators: {log_safe(path)}"
                     )
                     return content, False, False, None, [], None, None
 
@@ -507,7 +508,9 @@ class FileStorageService:
                     workflows_to_deactivate=workflows_to_deactivate,
                 )
         except Exception as e:
-            logger.warning(f"Failed to extract metadata from {path}: {e}")
+            logger.warning(
+                f"Failed to extract metadata from {log_safe(path)}: {log_safe(e)}"
+            )
 
         return content, False, False, None, [], None, None
 
@@ -554,7 +557,9 @@ class FileStorageService:
             try:
                 tree = ast.parse(content_str, filename=path)
             except SyntaxError as e:
-                logger.warning(f"Syntax error parsing {path}: {e}")
+                logger.warning(
+                    f"Syntax error parsing {log_safe(path)}: {log_safe(e)}"
+                )
                 diagnostics.append(
                     FileDiagnosticInfo(
                         severity="error",

--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -15,7 +15,7 @@ import hashlib
 import logging
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import yaml
 from git import Repo as GitRepo
@@ -31,7 +31,6 @@ from src.services.git_repo_manager import GitRepoManager
 from src.services.github_sync_entity_metadata import extract_entity_metadata
 
 if TYPE_CHECKING:
-    from typing import Literal  # used only in string annotations below
     from src.models.contracts.github import (
         AbortMergeResult,
         CommitResult,
@@ -1213,7 +1212,7 @@ class GitHubSyncService:
 
         # Build entity change list from the diff
         # Diff uses add/change/delete; EntityChange uses added/updated/removed
-        _action_map: dict[str, "Literal['added', 'updated', 'removed']"] = {
+        _action_map: dict[str, Literal["added", "updated", "removed"]] = {
             "add": "added", "change": "updated", "delete": "removed",
         }
         entity_changes: list[EntityChange] = []

--- a/api/src/services/mcp_server/tools/_http_bridge.py
+++ b/api/src/services/mcp_server/tools/_http_bridge.py
@@ -34,7 +34,6 @@ Auth strategy — two mutually exclusive paths:
 
 from __future__ import annotations
 
-import logging
 import os
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterator
@@ -43,8 +42,6 @@ import httpx
 
 if TYPE_CHECKING:
     from src.services.mcp_server.server import MCPContext
-
-logger = logging.getLogger(__name__)
 
 # When set (e.g. in E2E tests), route parity-tool REST calls over the network
 # to an already-running API instance instead of the in-process FastAPI app.

--- a/api/src/services/webhooks/adapters/__init__.py
+++ b/api/src/services/webhooks/adapters/__init__.py
@@ -6,6 +6,7 @@ from src.services.webhooks.adapters.generic import GenericWebhookAdapter
 from src.services.webhooks.adapters.microsoft_graph import MicrosoftGraphAdapter
 
 __all__ = [
+    "BUILTIN_ADAPTERS",
     "GenericWebhookAdapter",
     "MicrosoftGraphAdapter",
 ]

--- a/api/tests/unit/services/file_storage/test_log_safety.py
+++ b/api/tests/unit/services/file_storage/test_log_safety.py
@@ -1,0 +1,81 @@
+"""Regression tests for user-controlled values logged by file storage services."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.services.file_storage.deactivation import DeactivationProtectionService
+from src.services.file_storage.service import FileStorageService
+
+
+def _assert_single_line(message: str) -> None:
+    assert "\n" not in message
+    assert "\r" not in message
+    assert "\\n" in message
+
+
+@pytest.mark.asyncio
+async def test_invalid_replacement_id_is_log_safe() -> None:
+    service = DeactivationProtectionService(AsyncMock())
+
+    with patch("src.services.file_storage.deactivation.logger.warning") as warning:
+        await service.apply_workflow_replacements({"invalid\nforged": "replacement"})
+
+    _assert_single_line(warning.call_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_replacement_function_name_is_log_safe() -> None:
+    service = DeactivationProtectionService(AsyncMock())
+
+    with patch("src.services.file_storage.deactivation.logger.info") as info:
+        await service.apply_workflow_replacements(
+            {str(uuid4()): "replacement\nforged"}
+        )
+
+    _assert_single_line(info.call_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_deactivated_file_path_is_log_safe() -> None:
+    db = AsyncMock()
+    db.execute.return_value = SimpleNamespace(rowcount=1)
+    service = DeactivationProtectionService(db)
+
+    with patch("src.services.file_storage.deactivation.logger.info") as info:
+        await service.deactivate_removed_workflows("workflow\nforged.py", set())
+
+    _assert_single_line(info.call_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_metadata_skip_path_is_log_safe() -> None:
+    service = FileStorageService.__new__(FileStorageService)
+    service._deactivation = MagicMock()
+    service._deactivation.detect_pending_deactivations = AsyncMock(
+        return_value=([], [])
+    )
+
+    with patch("src.services.file_storage.service.logger.info") as info:
+        await service._extract_metadata_full(
+            "workflow\nforged.py", b"", cached_content_str=""
+        )
+
+    _assert_single_line(info.call_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_syntax_error_path_and_detail_are_log_safe() -> None:
+    service = FileStorageService.__new__(FileStorageService)
+
+    with patch("src.services.file_storage.service.logger.warning") as warning:
+        await service._index_python_file_full(
+            "workflow\nforged.py", b"def broken(:\n"
+        )
+
+    message = warning.call_args.args[0]
+    assert "\n" not in message
+    assert "\r" not in message
+    assert "\\n" in message

--- a/api/tests/unit/services/test_mcp_auth.py
+++ b/api/tests/unit/services/test_mcp_auth.py
@@ -141,7 +141,6 @@ class TestAuthorizationServerMetadata:
         response = await auth_provider._authorization_server_metadata(mock_request)
         data = response.body.decode()
 
-        import json
         metadata = json.loads(data)
 
         assert metadata["issuer"] == "https://test.example.com"
@@ -164,7 +163,6 @@ class TestProtectedResourceMetadata:
         response = await auth_provider._protected_resource_metadata(mock_request)
         data = response.body.decode()
 
-        import json
         metadata = json.loads(data)
 
         assert metadata["resource"] == "https://test.example.com/mcp"


### PR DESCRIPTION
## Summary

- sanitize user-controlled file-storage values before writing them to logs
- add regression coverage for forged newline content in logged paths, IDs, function names, and syntax errors
- remove low-risk repeated/unused imports and unused module globals reported by CodeQL

## CodeQL alerts

- Log injection: #680, #681, #682, #683, #684, #685, #688, #689, #690
- Repeated or unused imports/globals: #218, #219, #252, #253, #667, #668
- Reviewed without code changes: path-injection #12, #13, #14, and #662 are already guarded by canonical containment plus absolute, traversal, and location rejection; existing boundary tests remain green

## Verification

- `git diff --check origin/main...HEAD`
- Targeted file-storage/file-backend/MCP-auth suite completed against the isolated Linux Docker test stack
- Worker security slice: 21 targeted tests passed
- Targeted Ruff checks passed in worker worktrees
- Full GitHub Actions and code-scanning checks are the merge gate

## Security notes

The behavioral change is limited to log rendering. `log_safe` escapes CR/LF and other control characters before interpolating user-controlled values; storage, tenant, and path-containment behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to log string sanitization and import/registry cleanup; no auth, storage, or execution behavior is modified.
> 
> **Overview**
> Addresses **CodeQL log-injection** findings by wrapping user-controlled values (paths, workflow IDs, function names, exceptions) in **`log_safe()`** before they appear in file-storage and deactivation logging in `deactivation.py`, `file_ops.py`, and `service.py`. Behavior of storage, indexing, and path handling is unchanged—only how those values are rendered in logs.
> 
> Adds **`test_log_safety.py`** regression tests that forged newline content in IDs, paths, and function names produces single-line log messages with escaped `\n`.
> 
> Minor **CodeQL hygiene** elsewhere: direct `AsyncSession` import in `workflows.py`, `Literal` moved out of `TYPE_CHECKING` in `github_sync.py`, duplicate `json` imports removed in MCP auth tests, unused logger removed from `_http_bridge.py`, and `BUILTIN_ADAPTERS` added to webhook adapters `__all__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb9dd84d914d7882153c202406f6e1ce08b9d9a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->