### PR TITLE
fix(security): resolve WebSocket table policy claims

### DIFF
--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -6,6 +6,7 @@ Replaces Azure Web PubSub with native FastAPI WebSockets.
 """
 
 import asyncio
+import copy
 import logging
 from dataclasses import dataclass
 from typing import Annotated, Any, cast
@@ -16,6 +17,7 @@ from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from shared.claims.preresolve import preresolve_for_policies
 from shared.policies.probe import is_subscribe_authorized
 from shared.policy_rules import PolicyRuleDomainMismatch, PolicyRuleNotFound, resolve_policy_refs
 from src.repositories.policy_rule import PolicyRuleRepository
@@ -173,8 +175,11 @@ def _invalidate_table_policy_cache(table_id: str) -> None:
     _table_policy_cache.pop(table_id, None)
 
 
-async def _load_policies_for_table(table_id: str) -> TablePolicies | None:
-    """Load and resolve policies for a table by id (UUID) or name.
+async def _load_policies_for_table(
+    table_id: str,
+    user: UserPrincipal,
+) -> TablePolicies | None:
+    """Load policies and safely pre-resolve their custom claims.
 
     Returns None if the table doesn't exist.
 
@@ -259,6 +264,14 @@ async def _load_policies_for_table(table_id: str) -> TablePolicies | None:
             )
             return TablePolicies()
 
+        await preresolve_for_policies(
+            user,
+            policies,
+            db,
+            raw.org_id,
+            raw.solution_id,
+        )
+
     return policies
 
 
@@ -278,6 +291,18 @@ async def _populate_user_roles(user: UserPrincipal) -> None:
         role_ids, role_names = await get_user_roles(user.user_id, db)
         user.role_ids = role_ids
         user.role_names = role_names
+
+
+def _fresh_table_policy_user(user: UserPrincipal) -> UserPrincipal:
+    """Copy a websocket principal without reusing custom-claim values.
+
+    Websocket principals live across tables and policy changes. Custom claims
+    can be solution-scoped and mutable, so each evaluation must resolve them
+    afresh rather than sharing a name-keyed cache across subscriptions.
+    """
+    policy_user = copy.copy(user)
+    policy_user.claims = {}  # type: ignore[attr-defined]
+    return policy_user
 
 
 def _make_table_dispatcher(websocket: WebSocket, user: UserPrincipal) -> Any:
@@ -335,7 +360,8 @@ async def _handle_table_message(
     if msg_type != "document_change":
         return
 
-    policies = await _load_policies_for_table(table_id)
+    policy_user = _fresh_table_policy_user(user)
+    policies = await _load_policies_for_table(table_id, policy_user)
     if policies is None:
         return
 
@@ -343,7 +369,7 @@ async def _handle_table_message(
         old_row=payload.get("old_row"),
         new_row=payload.get("new_row"),
         policies=policies,
-        user=user,
+        user=policy_user,
         user_filter=sub.get("filter"),
     )
     if decision is None:
@@ -372,8 +398,9 @@ async def _re_evaluate_subscription(
     table_id: str,
 ) -> None:
     """Re-run subscribe-time authorization after a policy edit; revoke if no."""
-    policies = await _load_policies_for_table(table_id)
-    if policies is None or not is_subscribe_authorized(policies, user):
+    policy_user = _fresh_table_policy_user(user)
+    policies = await _load_policies_for_table(table_id, policy_user)
+    if policies is None or not is_subscribe_authorized(policies, policy_user):
         await websocket.send_json({
             "type": "subscription_revoked",
             "channel": f"table:{table_id}",
@@ -415,7 +442,9 @@ async def _authorize_table_subscribe(
     # would NOT have reached us (no subscriber to fan out to). Force a
     # fresh load on subscribe to close that staleness window.
     _invalidate_table_policy_cache(canonical_id)
-    policies = await _load_policies_for_table(canonical_id)
+    await _populate_user_roles(user)
+    policy_user = _fresh_table_policy_user(user)
+    policies = await _load_policies_for_table(canonical_id, policy_user)
     if policies is None:
         await websocket.send_json({
             "type": "error",
@@ -424,8 +453,7 @@ async def _authorize_table_subscribe(
         })
         return None
 
-    await _populate_user_roles(user)
-    if not is_subscribe_authorized(policies, user):
+    if not is_subscribe_authorized(policies, policy_user):
         await websocket.send_json({
             "type": "error",
             "channel": spec.name,

--- a/api/tests/unit/routers/test_websocket_access_coverage.py
+++ b/api/tests/unit/routers/test_websocket_access_coverage.py
@@ -145,13 +145,14 @@ def test_file_channel_scope_and_path_helpers_cover_access_boundaries():
 async def test_load_policies_for_table_handles_cache_validation_and_ref_errors():
     table_id = str(uuid4())
     row = ({"policies": [{"name": "read", "actions": ["read"]}]}, uuid4(), None)
+    user = _user(org_id=row[1])
     ws_mod._table_policy_cache.clear()
 
     with (
         patch.object(ws_mod, "get_db_context", _db_context(_Db(_OneResult(row)))),
         patch.object(ws_mod, "resolve_policy_refs", AsyncMock()) as resolve_refs,
     ):
-        policies = await ws_mod._load_policies_for_table(table_id)
+        policies = await ws_mod._load_policies_for_table(table_id, user)
 
     assert policies is not None
     assert len(policies.policies) == 1
@@ -171,17 +172,61 @@ async def test_load_policies_for_table_handles_cache_validation_and_ref_errors()
             AsyncMock(side_effect=ws_mod.PolicyRuleNotFound("missing")),
         ),
     ):
-        denied = await ws_mod._load_policies_for_table(table_id)
+        denied = await ws_mod._load_policies_for_table(table_id, user)
 
     assert denied is not None
     assert denied.policies == []
 
     invalid_row = ({"policies": [{"name": "bad", "actions": []}]}, None, None)
     with patch.object(ws_mod, "get_db_context", _db_context(_Db(_OneResult(invalid_row)))):
-        invalid = await ws_mod._load_policies_for_table("table-name")
+        invalid = await ws_mod._load_policies_for_table("table-name", user)
 
     assert invalid is not None
     assert invalid.policies == []
+
+
+@pytest.mark.asyncio
+async def test_load_policies_for_table_preresolves_custom_claims_in_table_scope():
+    table_id = str(uuid4())
+    org_id = uuid4()
+    solution_id = uuid4()
+    user = _user(org_id=org_id)
+    row = (
+        {
+            "policies": [
+                {
+                    "name": "campus_read",
+                    "actions": ["read"],
+                    "when": {
+                        "in": [
+                            {"row": "campus_id"},
+                            {"claims": "allowed_campus_ids"},
+                        ]
+                    },
+                }
+            ]
+        },
+        org_id,
+        solution_id,
+    )
+    ws_mod._table_policy_cache.clear()
+
+    async def resolve_claims(principal, policies, db, scoped_org_id, scoped_solution_id):
+        assert principal is user
+        assert policies.policies[0].name == "campus_read"
+        assert scoped_org_id == org_id
+        assert scoped_solution_id == solution_id
+        principal.claims = {"allowed_campus_ids": ["north"]}
+
+    with (
+        patch.object(ws_mod, "get_db_context", _db_context(_Db(_OneResult(row)))),
+        patch.object(ws_mod, "resolve_policy_refs", AsyncMock()),
+        patch.object(ws_mod, "preresolve_for_policies", resolve_claims),
+    ):
+        policies = await ws_mod._load_policies_for_table(table_id, user)
+
+    assert policies is not None
+    assert user.claims == {"allowed_campus_ids": ["north"]}
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/routers/test_websocket_file_helpers.py
+++ b/api/tests/unit/routers/test_websocket_file_helpers.py
@@ -385,7 +385,7 @@ class TestHandleTableMessage:
             assert name_or_id == "docs"
             return table_id
 
-        async def missing_policies(resolved_id: str) -> None:
+        async def missing_policies(resolved_id: str, user: UserPrincipal) -> None:
             assert resolved_id == table_id
             return None
 
@@ -412,7 +412,7 @@ class TestHandleTableMessage:
         async def resolve_table(name_or_id: str, user: UserPrincipal) -> str:
             return table_id
 
-        async def load_policies(resolved_id: str) -> TablePolicies:
+        async def load_policies(resolved_id: str, user: UserPrincipal) -> TablePolicies:
             return TablePolicies()
 
         async def populate_roles(user: UserPrincipal) -> None:
@@ -443,7 +443,7 @@ class TestHandleTableMessage:
         async def resolve_table(name_or_id: str, user: UserPrincipal) -> str:
             return table_id
 
-        async def load_policies(resolved_id: str) -> TablePolicies:
+        async def load_policies(resolved_id: str, user: UserPrincipal) -> TablePolicies:
             return TablePolicies()
 
         async def populate_roles(user: UserPrincipal) -> None:
@@ -510,7 +510,7 @@ class TestHandleTableMessage:
     async def test_re_evaluate_revokes_when_policies_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        async def no_policies(table_id: str):
+        async def no_policies(table_id: str, user: UserPrincipal):
             assert table_id == "table-1"
             return None
 
@@ -534,7 +534,7 @@ class TestHandleTableMessage:
     async def test_document_change_emits_delete_decision(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        async def policies(table_id: str):
+        async def policies(table_id: str, user: UserPrincipal):
             assert table_id == "table-1"
             return object()
 
@@ -569,7 +569,7 @@ class TestHandleTableMessage:
     ) -> None:
         row = {"id": "row-1", "status": "open"}
 
-        async def policies(table_id: str):
+        async def policies(table_id: str, user: UserPrincipal):
             assert table_id == "table-1"
             return object()
 
@@ -598,6 +598,55 @@ class TestHandleTableMessage:
                 "row": row,
             }
         ]
+
+    async def test_document_change_does_not_reuse_stale_custom_claims(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        user = _user(org_id=uuid.uuid4())
+        user.claims = {"allowed_campus_ids": ["north"]}
+        policies = TablePolicies.model_validate({
+            "policies": [
+                {
+                    "name": "campus_read",
+                    "actions": ["read"],
+                    "when": {
+                        "in": [
+                            {"row": "campus_id"},
+                            {"claims": "allowed_campus_ids"},
+                        ]
+                    },
+                }
+            ]
+        })
+
+        async def load_policies(
+            table_id: str,
+            policy_user: UserPrincipal,
+        ) -> TablePolicies:
+            assert table_id == "table-1"
+            assert policy_user is not user
+            assert policy_user.claims == {}
+            return policies
+
+        monkeypatch.setattr(ws_mod, "_load_policies_for_table", load_policies)
+        websocket = FakeWebSocket()
+        websocket.state.table_subscriptions = {
+            "table-1": {"filter": None, "channel_name": "table:table-1"}
+        }
+
+        await ws_mod._handle_table_message(
+            websocket,
+            user,
+            "table:table-1",
+            {
+                "type": "document_change",
+                "old_row": None,
+                "new_row": {"id": "row-1", "campus_id": "north"},
+            },
+        )
+
+        assert websocket.sent == []
+        assert user.claims == {"allowed_campus_ids": ["north"]}
 
     async def test_revokes_subscription_when_policy_removed(
         self, monkeypatch: pytest.MonkeyPatch

--- a/api/tests/unit/test_websocket_table_resolution.py
+++ b/api/tests/unit/test_websocket_table_resolution.py
@@ -138,5 +138,5 @@ class TestLoadPoliciesForTableByName:
         db.add_all([live, managed])
         await db.flush()
 
-        policies = await ws_mod._load_policies_for_table(name)
+        policies = await ws_mod._load_policies_for_table(name, _org_user(org))
         assert policies == TablePolicies()


### PR DESCRIPTION
## Security
- pre-resolve custom claims before WebSocket table subscribe probes and per-message visibility checks, matching REST table-policy evaluation
- evaluate each WebSocket policy against a fresh principal copy so stale or solution-scoped claim values cannot carry across subscriptions
- preserve fail-closed behavior for missing, malformed, or unresolvable policies and claims

## Verification
- `ruff check` on changed backend files
- `python -m compileall -q` on changed backend files
- focused tests cover table-scope pre-resolution and stale-claim denial

Runtime backend tests are delegated to Linux GitHub Actions because this checkout is on Windows and the platform test stack is Linux-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization for real-time table subscriptions and row visibility; incorrect claim handling could leak or hide rows, though behavior is intended to match REST and fail closed on bad policies.
> 
> **Overview**
> Aligns **WebSocket table policy checks** with REST by **pre-resolving custom claims** when policies are loaded, using table org/solution scope via `preresolve_for_policies`.
> 
> Each subscribe probe, policy re-evaluation, and `document_change` visibility pass now uses **`_fresh_table_policy_user`**: a shallow copy of the connection principal with **claims cleared**, so solution-scoped or mutable claim values are not reused across tables or messages on the same socket.
> 
> `_load_policies_for_table` now takes a `user` argument; subscribe flow loads roles before building the fresh policy principal. Unit tests cover table-scope pre-resolution and that `document_change` does not evaluate against stale cached claims on the long-lived user object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bbeb9068c7bbd03b1146de89ab71baba0208626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->