### PR TITLE
fix(deps): resolve remaining client advisories

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -221,12 +221,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -235,9 +235,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -245,21 +245,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -276,13 +276,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -292,14 +292,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -309,37 +309,37 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -349,27 +349,27 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -377,26 +377,26 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -424,31 +424,31 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -456,13 +456,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2750,9 +2750,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@redocly/openapi-core": {
-			"version": "1.34.12",
-			"resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.12.tgz",
-			"integrity": "sha512-b32XWsz6enN6K4bx8xWsqUaXTJR/DnYT3lL1CzDYzIYKw243NNlz6fexmr71q/U4HrEcMoJGBvwAfcxOb8ymQw==",
+			"version": "1.34.17",
+			"resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
+			"integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2761,7 +2761,7 @@
 				"colorette": "1.4.0",
 				"https-proxy-agent": "7.0.6",
 				"js-levenshtein": "1.1.6",
-				"js-yaml": "4.1.1",
+				"js-yaml": "4.2.0",
 				"minimatch": "5.1.9",
 				"pluralize": "8.0.0",
 				"yaml-ast-parser": "0.0.43"
@@ -2782,10 +2782,20 @@
 			}
 		},
 		"node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -9469,9 +9479,9 @@
 			}
 		},
 		"node_modules/react-diff-viewer-continued/node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"funding": [
 				{
 					"type": "github",


### PR DESCRIPTION
## Summary

- update the transitive Babel toolchain to `@babel/core` 7.29.7
- update Redocly's nested `js-yaml` to the first patched 4.2.0 release
- resolve Dependabot alerts #62 and #75 without adding direct dependencies or overrides

## Verification

- clean `npm ci --ignore-scripts`
- `npm audit --omit=optional`: 0 vulnerabilities
- package tree confirms `@babel/core` 7.29.7 and vulnerable Redocly `js-yaml` replaced by 4.2.0
- client TypeScript, lint, and unit commands completed locally; GitHub CI remains the merge gate

## Supply-chain scope

The change is lockfile-only. It uses existing semver ranges from `eslint-plugin-react-hooks` and `openapi-typescript`; no lifecycle scripts, new direct dependencies, overrides, or package-manager configuration were introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only transitive dependency bumps with no runtime code or auth/data-path changes; main risk is routine toolchain/regression from patch updates.
> 
> **Overview**
> **Lockfile-only** refresh to clear Dependabot alerts #62 and #75 without changing `package.json`, overrides, or direct dependency ranges.
> 
> The transitive **Babel** stack (pulled in via existing dev tooling such as `eslint-plugin-react-hooks`) is pinned to **7.29.7** across `@babel/core`, parser, traverse, and related packages. **Redocly** (`@redocly/openapi-core` → **1.34.17**) now resolves nested **`js-yaml` to 4.2.0**; **`react-diff-viewer-continued`**’s nested **`js-yaml`** moves to **4.3.0**.
> 
> No application source changes—supply-chain / audit hygiene only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c95c2388fee5f3e9afb823a041bb2f2edff8449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->