### PR TITLE
fix: clear mechanical CodeQL findings

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -1523,9 +1523,6 @@ def pull_cmd(path: str, solution_id: str | None, org: str | None, is_global: boo
     entities it materialized so the matching ``pending_captures`` rows clear.
     Safe for an agent to run (it only rewrites the generated manifest).
     """
-    import io
-    import zipfile
-
     workspace = _workspace_from_path_arg(path)
     if not is_solution_workspace(workspace):
         raise click.ClickException(

--- a/api/src/routers/auth.py
+++ b/api/src/routers/auth.py
@@ -1751,7 +1751,6 @@ async def request_device_code(
     Returns:
         DeviceCodeResponse with device_code, user_code, verification URL, and polling interval
     """
-    import json
     import uuid
 
     # Rate limiting
@@ -1822,8 +1821,6 @@ async def exchange_device_token(
     Returns:
         DeviceTokenResponse with tokens or DeviceTokenErrorResponse with error
     """
-    import json
-
     # Rate limiting (more lenient for polling)
     client_ip = get_client_ip(request)
     await auth_limiter.check("device_token", client_ip)
@@ -2014,8 +2011,6 @@ async def setup_passkey_verify(
     Raises:
         HTTPException: If token is invalid/expired or verification fails
     """
-    import json
-
     from src.services.passkey_service import PasskeyService
 
     # Rate limiting
@@ -2098,8 +2093,6 @@ async def authorize_device(
     Raises:
         HTTPException: If user_code is invalid or expired
     """
-    import json
-
     r = await get_shared_redis()
 
     # Look up device_code from user_code (reverse index)
@@ -2232,8 +2225,6 @@ async def register_from_invite_passkey_verify(
     db: DbSession,
 ) -> SetupPasskeyVerifyResponse:
     """Complete invite registration by verifying a passkey and logging the user in."""
-    import json
-
     from src.services.passkey_service import PasskeyService
 
     invite_svc = UserInviteService(db)

--- a/api/tests/e2e/platform/test_deactivation_protection.py
+++ b/api/tests/e2e/platform/test_deactivation_protection.py
@@ -307,7 +307,7 @@ class TestDeactivationProtection:
         path = "test_replacements.py"
 
         # Step 1: Save initial two-workflow file
-        result = await storage.write_file(path, TWO_WORKFLOW_CODE.encode("utf-8"), updated_by="test")
+        await storage.write_file(path, TWO_WORKFLOW_CODE.encode("utf-8"), updated_by="test")
         await db_session.commit()
 
         # Register both workflows in DB (auto-discovery removed)
@@ -675,7 +675,7 @@ def test_provider():
     """A test data provider."""
     return []
 '''
-        result = await storage.write_file(path, dp_code.encode("utf-8"), updated_by="test")
+        await storage.write_file(path, dp_code.encode("utf-8"), updated_by="test")
         await db_session.commit()
 
         # Register the data provider in DB (auto-discovery removed)

--- a/api/tests/e2e/platform/test_large_file_memory.py
+++ b/api/tests/e2e/platform/test_large_file_memory.py
@@ -61,7 +61,7 @@ class TestLargeFileMemory:
             baseline = tracemalloc.get_traced_memory()[0]
 
             for name in ["test_mem_1.py", "test_mem_2.py", "test_mem_3.py"]:
-                result = await file_storage.write_file(
+                await file_storage.write_file(
                     path=f"modules/{name}",
                     content=content_4mb,
                     updated_by="test",

--- a/api/tests/unit/test_cli_helpers_coverage.py
+++ b/api/tests/unit/test_cli_helpers_coverage.py
@@ -613,7 +613,7 @@ def test_push_sync_and_pull_dispatch_to_sync_files(monkeypatch, tmp_path):
         def __enter__(self):
             return self
 
-        def __exit__(self, _exc_type, _exc_value, _traceback):
+        def __exit__(self, _exc_type=None, _exc_value=None, _traceback=None):
             locks.append(("exit", None))
 
     class ClientFactory:
@@ -677,7 +677,7 @@ def test_watch_dispatches_and_stops_server_on_interrupt(monkeypatch, tmp_path, c
         def __enter__(self):
             return self
 
-        def __exit__(self, _exc_type, _exc_value, _traceback):
+        def __exit__(self, _exc_type=None, _exc_value=None, _traceback=None):
             calls.append(("unlock",))
 
     class Client:

--- a/api/tests/unit/test_cli_helpers_coverage.py
+++ b/api/tests/unit/test_cli_helpers_coverage.py
@@ -613,7 +613,7 @@ def test_push_sync_and_pull_dispatch_to_sync_files(monkeypatch, tmp_path):
         def __enter__(self):
             return self
 
-        def __exit__(self):
+        def __exit__(self, _exc_type, _exc_value, _traceback):
             locks.append(("exit", None))
 
     class ClientFactory:
@@ -677,7 +677,7 @@ def test_watch_dispatches_and_stops_server_on_interrupt(monkeypatch, tmp_path, c
         def __enter__(self):
             return self
 
-        def __exit__(self):
+        def __exit__(self, _exc_type, _exc_value, _traceback):
             calls.append(("unlock",))
 
     class Client:


### PR DESCRIPTION
## Summary

- remove six redundant local imports already provided at module scope
- correct two context-manager test doubles to implement Python's `__exit__` protocol
- stop assigning three async storage results that the tests intentionally ignore

## CodeQL alerts

- repeated imports: #489, #490, #491, #492, #500, #691
- special-method signature: #672, #673
- multiple definition: #213, #214, #215

## Verification

- targeted unit and E2E files executed against the isolated Linux Docker test stack
- Python compile check for all five changed files
- `git diff --check`
- full CI and code scanning are the merge gate

No runtime behavior changes are intended; this is a mechanical correctness and test-hygiene slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and test-hygiene only; auth and CLI paths are unchanged aside from import placement.
> 
> **Overview**
> Mechanical cleanup to satisfy CodeQL/static analysis with **no intended runtime behavior change**.
> 
> **Imports:** Drops redundant function-scoped `import json` in `auth.py` device/passkey handlers and removes duplicate `io`/`zipfile` imports inside `solution pull` where those modules are already imported at file scope.
> 
> **Tests:** E2E storage tests stop binding ignored `write_file` return values (fixes “multiple definition” alerts). Unit CLI helper mocks implement `__exit__(exc_type, exc_value, traceback)` so context-manager test doubles match the real protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e5b76772ed834414d4ad0339a31020d9c7992c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->