### PR TITLE
fix(security): sanitize remaining cache logs

### DIFF
--- a/api/shared/role_cache.py
+++ b/api/shared/role_cache.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from src.core.cache.redis_client import get_shared_redis
+from src.core.log_safety import log_safe
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -67,7 +68,9 @@ async def get_user_roles(
         r = await get_shared_redis()
         raw = await r.get(key)
     except Exception as e:
-        logger.warning(f"Role cache read failed, falling back to DB: {e}")
+        logger.warning(
+            f"Role cache read failed, falling back to DB: {log_safe(e)}"
+        )
         raw = None
 
     if raw is not None:
@@ -83,9 +86,14 @@ async def get_user_roles(
                 role_names = list(payload["role_names"])
                 return role_ids, role_names
             # Wrong shape / stale schema: treat as miss, fall through to DB.
-            logger.debug(f"Role cache entry for {user_id} has unexpected shape; refetching")
+            logger.debug(
+                f"Role cache entry for {log_safe(user_id)} has unexpected shape; refetching"
+            )
         except (ValueError, TypeError) as e:
-            logger.warning(f"Role cache entry for {user_id} unparseable; refetching: {e}")
+            logger.warning(
+                f"Role cache entry for {log_safe(user_id)} unparseable; "
+                f"refetching: {log_safe(e)}"
+            )
 
     # Miss -> DB
     from sqlalchemy import select
@@ -111,7 +119,9 @@ async def get_user_roles(
         r = await get_shared_redis()
         await r.set(key, json.dumps(payload), ex=_ROLE_CACHE_TTL)
     except Exception as e:
-        logger.warning(f"Role cache populate failed for user {user_id}: {e}")
+        logger.warning(
+            f"Role cache populate failed for user {log_safe(user_id)}: {log_safe(e)}"
+        )
 
     return role_ids, role_names
 
@@ -125,9 +135,11 @@ async def invalidate_user(user_id: UUID) -> None:
     try:
         r = await get_shared_redis()
         await r.delete(_key(user_id))
-        logger.debug(f"Invalidated role cache for user {user_id}")
+        logger.debug(f"Invalidated role cache for user {log_safe(user_id)}")
     except Exception as e:
-        logger.warning(f"Failed to invalidate role cache for user {user_id}: {e}")
+        logger.warning(
+            f"Failed to invalidate role cache for user {log_safe(user_id)}: {log_safe(e)}"
+        )
 
 
 async def invalidate_role(role_id: UUID) -> None:
@@ -153,8 +165,12 @@ async def invalidate_role(role_id: UUID) -> None:
             except (ValueError, TypeError) as e:
                 # Unparseable entry — drop it so we don't keep hitting the same
                 # bad value on every invalidation sweep.
-                logger.debug(f"Dropping unparseable role cache entry {key}: {e}")
+                logger.debug(
+                    f"Dropping unparseable role cache entry {log_safe(key)}: {log_safe(e)}"
+                )
                 await r.delete(key)
-        logger.debug(f"Invalidated role cache for role {role_id}")
+        logger.debug(f"Invalidated role cache for role {log_safe(role_id)}")
     except Exception as e:
-        logger.warning(f"Failed to invalidate role cache for role {role_id}: {e}")
+        logger.warning(
+            f"Failed to invalidate role cache for role {log_safe(role_id)}: {log_safe(e)}"
+        )

--- a/api/src/core/module_cache.py
+++ b/api/src/core/module_cache.py
@@ -94,7 +94,7 @@ async def get_module(path: str) -> CachedModule | None:
         redis_conn = await redis._get_redis()
         await cast(Awaitable[int], redis_conn.sadd(MODULE_INDEX_KEY, path))
     except Exception as e:
-        logger.warning(f"Failed to re-cache S3 module to Redis: {e}")
+        logger.warning(f"Failed to re-cache S3 module to Redis: {log_safe(e)}")
 
     return module
 
@@ -120,7 +120,7 @@ async def set_module(path: str, content: str, content_hash: str) -> None:
     redis_conn = await redis._get_redis()
     await cast(Awaitable[int], redis_conn.sadd(MODULE_INDEX_KEY, path))
 
-    logger.debug(f"Cached module: {path}")
+    logger.debug(f"Cached module: {log_safe(path)}")
 
 
 async def invalidate_module(path: str) -> None:
@@ -141,7 +141,7 @@ async def invalidate_module(path: str) -> None:
     redis_conn = await redis._get_redis()
     await cast(Awaitable[int], redis_conn.srem(MODULE_INDEX_KEY, path))
 
-    logger.debug(f"Invalidated module cache: {path}")
+    logger.debug(f"Invalidated module cache: {log_safe(path)}")
 
 
 async def get_all_module_paths() -> set[str]:
@@ -182,7 +182,9 @@ async def refresh_modules_from_directory(work_dir: Path) -> int:
         content_hash = hashlib.sha256(content_bytes).hexdigest()
         await set_module(rel_path, content_str, content_hash)
         count += 1
-    logger.info(f"Refreshed {count} module(s) in Redis cache from {work_dir}")
+    logger.info(
+        f"Refreshed {count} module(s) in Redis cache from {log_safe(work_dir)}"
+    )
     return count
 
 

--- a/api/src/routers/branding.py
+++ b/api/src/routers/branding.py
@@ -18,6 +18,7 @@ from shared.svg_sanitizer import SvgSanitizationError, sanitize_svg
 from src.models import BrandingSettings, BrandingTerminology, BrandingUpdateRequest, GlobalBranding
 from src.core.auth import Context, CurrentSuperuser
 from src.core.database import AsyncSession, get_db
+from src.core.log_safety import log_safe
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,7 @@ async def update_branding(
     )
 
     await ctx.db.commit()
-    logger.info(f"Branding updated by {user.email}")
+    logger.info(f"Branding updated by {log_safe(user.email)}")
 
     return _branding_response(branding)
 
@@ -184,7 +185,9 @@ async def upload_logo(
         )
 
     await ctx.db.commit()
-    logger.info(f"Logo '{logo_type}' uploaded by {user.email}")
+    logger.info(
+        f"Logo '{log_safe(logo_type)}' uploaded by {log_safe(user.email)}"
+    )
 
     return _branding_response(branding)
 
@@ -278,7 +281,9 @@ async def reset_logo(
         )
 
     await ctx.db.commit()
-    logger.info(f"Logo '{logo_type}' reset to default by {user.email}")
+    logger.info(
+        f"Logo '{log_safe(logo_type)}' reset to default by {log_safe(user.email)}"
+    )
 
     return _branding_response(branding)
 
@@ -302,7 +307,7 @@ async def reset_color(
     branding = await branding_repo.set_branding(primary_color=None)
 
     await ctx.db.commit()
-    logger.info(f"Primary color reset to default by {user.email}")
+    logger.info(f"Primary color reset to default by {log_safe(user.email)}")
 
     return _branding_response(branding)
 
@@ -325,7 +330,7 @@ async def reset_application_name(
     branding = await branding_repo.set_branding(application_name=None)
 
     await ctx.db.commit()
-    logger.info(f"Application name reset to default by {user.email}")
+    logger.info(f"Application name reset to default by {log_safe(user.email)}")
 
     return _branding_response(branding)
 
@@ -349,7 +354,7 @@ async def reset_all_branding(
     await branding_repo.delete_branding()
 
     await ctx.db.commit()
-    logger.info(f"All branding reset to defaults by {user.email}")
+    logger.info(f"All branding reset to defaults by {log_safe(user.email)}")
 
     return BrandingSettings(
         application_name=None,

--- a/api/tests/unit/core/test_module_cache.py
+++ b/api/tests/unit/core/test_module_cache.py
@@ -190,6 +190,24 @@ class TestModuleCacheAsync:
             mock_client.delete.assert_called_once_with("bifrost:module:shared/test.py")
             mock_redis.srem.assert_called_once_with("bifrost:module:index", "shared/test.py")
 
+    async def test_module_paths_are_log_safe(self, mock_redis_client):
+        """Caller-controlled module paths cannot forge additional log lines."""
+        mock_client, _mock_redis = mock_redis_client
+
+        with (
+            patch("src.core.module_cache.get_redis_client", return_value=mock_client),
+            patch("src.core.module_cache.logger.debug") as debug,
+        ):
+            from src.core.module_cache import invalidate_module, set_module
+
+            await set_module("shared/forged\nentry.py", "", "abc123")
+            await invalidate_module("shared/forged\nentry.py")
+
+        messages = [call.args[0] for call in debug.call_args_list]
+        assert len(messages) == 2
+        assert all("\n" not in message for message in messages)
+        assert all("\\n" in message for message in messages)
+
     async def test_get_all_module_paths(self, mock_redis_client):
         """Test getting all cached module paths."""
         mock_client, mock_redis = mock_redis_client

--- a/api/tests/unit/core/test_module_cache.py
+++ b/api/tests/unit/core/test_module_cache.py
@@ -208,6 +208,21 @@ class TestModuleCacheAsync:
         assert all("\n" not in message for message in messages)
         assert all("\\n" in message for message in messages)
 
+    async def test_refresh_directory_log_is_safe(self):
+        """Caller-controlled directory paths cannot forge additional log lines."""
+        work_dir = MagicMock()
+        work_dir.rglob.return_value = []
+        work_dir.__str__.return_value = "workspace\nforged"
+
+        with patch("src.core.module_cache.logger.info") as info:
+            from src.core.module_cache import refresh_modules_from_directory
+
+            assert await refresh_modules_from_directory(work_dir) == 0
+
+        message = info.call_args.args[0]
+        assert "\n" not in message
+        assert "\\n" in message
+
     async def test_get_all_module_paths(self, mock_redis_client):
         """Test getting all cached module paths."""
         mock_client, mock_redis = mock_redis_client

--- a/api/tests/unit/test_role_cache.py
+++ b/api/tests/unit/test_role_cache.py
@@ -183,7 +183,6 @@ class TestGetUserRoles:
 
         message = warning.call_args.args[0]
         assert "\n" not in message
-        assert "\\n" in message
 
     @pytest.mark.asyncio
     async def test_cache_population_failure_log_is_safe(self):

--- a/api/tests/unit/test_role_cache.py
+++ b/api/tests/unit/test_role_cache.py
@@ -184,11 +184,18 @@ class TestInvalidateUser:
         user_id = uuid4()
 
         mock_redis = AsyncMock()
-        mock_redis.delete = AsyncMock(side_effect=Exception("redis down"))
+        mock_redis.delete = AsyncMock(side_effect=Exception("redis down\nforged"))
 
-        with patch("shared.role_cache.get_shared_redis", return_value=mock_redis):
+        with (
+            patch("shared.role_cache.get_shared_redis", return_value=mock_redis),
+            patch("shared.role_cache.logger.warning") as warning,
+        ):
             # Must not raise
             await invalidate_user(user_id)
+
+        message = warning.call_args.args[0]
+        assert "\n" not in message
+        assert "\\n" in message
 
 
 class TestInvalidateRole:

--- a/api/tests/unit/test_role_cache.py
+++ b/api/tests/unit/test_role_cache.py
@@ -147,6 +147,64 @@ class TestGetUserRoles:
         assert role_ids == []
         assert role_names == []
 
+    @pytest.mark.asyncio
+    async def test_read_failure_log_is_safe_and_falls_back_to_db(self):
+        user_id = uuid4()
+        db = _make_db_returning([])
+        populate_redis = AsyncMock()
+
+        with (
+            patch(
+                "shared.role_cache.get_shared_redis",
+                side_effect=[Exception("redis down\nforged"), populate_redis],
+            ),
+            patch("shared.role_cache.logger.warning") as warning,
+        ):
+            assert await get_user_roles(user_id, db) == ([], [])
+
+        message = warning.call_args.args[0]
+        assert "\n" not in message
+        assert "\\n" in message
+
+    @pytest.mark.asyncio
+    async def test_malformed_cache_entry_log_is_safe_and_refetches(self):
+        user_id = uuid4()
+        db = _make_db_returning([])
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = json.dumps(
+            {"role_ids": ["bad\nrole"], "role_names": ["admin"], "v": 1}
+        )
+
+        with (
+            patch("shared.role_cache.get_shared_redis", return_value=mock_redis),
+            patch("shared.role_cache.logger.warning") as warning,
+        ):
+            assert await get_user_roles(user_id, db) == ([], [])
+
+        message = warning.call_args.args[0]
+        assert "\n" not in message
+        assert "\\n" in message
+
+    @pytest.mark.asyncio
+    async def test_cache_population_failure_log_is_safe(self):
+        user_id = uuid4()
+        db = _make_db_returning([])
+        read_redis = AsyncMock()
+        read_redis.get.return_value = None
+
+        with (
+            patch(
+                "shared.role_cache.get_shared_redis",
+                side_effect=[read_redis, Exception("write down\nforged")],
+            ),
+            patch("shared.role_cache.logger.warning") as warning,
+        ):
+            assert await get_user_roles(user_id, db) == ([], [])
+
+        message = warning.call_args.args[0]
+        assert "\n" not in message
+        assert "\\n" in message
+
 
 class TestInvalidateUser:
     """Write path (single user): invalidate clears one entry."""
@@ -272,6 +330,58 @@ class TestInvalidateRole:
         mock_redis = AsyncMock()
         mock_redis.scan_iter = fake_scan_iter
 
-        with patch("shared.role_cache.get_shared_redis", return_value=mock_redis):
+        with (
+            patch("shared.role_cache.get_shared_redis", return_value=mock_redis),
+            patch("shared.role_cache.logger.warning") as warning,
+        ):
             # Must not raise
             await invalidate_role(role_id)
+
+        assert "redis down" in warning.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_invalidate_role_safely_logs_and_drops_malformed_entry(self):
+        role_id = uuid4()
+        cache_key = f"{_ROLE_CACHE_KEY_PREFIX}forged\nuser"
+
+        async def fake_scan_iter(match: str):
+            del match
+            yield cache_key
+
+        mock_redis = AsyncMock()
+        mock_redis.scan_iter = fake_scan_iter
+        mock_redis.get.return_value = "not-json"
+
+        with (
+            patch("shared.role_cache.get_shared_redis", return_value=mock_redis),
+            patch("shared.role_cache.logger.debug") as debug,
+        ):
+            await invalidate_role(role_id)
+
+        mock_redis.delete.assert_awaited_once_with(cache_key)
+        message = debug.call_args_list[0].args[0]
+        assert "\n" not in message
+        assert "\\n" in message
+
+    @pytest.mark.asyncio
+    async def test_invalidate_role_failure_log_is_safe(self):
+        role_id = uuid4()
+
+        async def fake_scan_iter(match: str):
+            del match
+            for key in ():
+                yield key
+            raise Exception("scan down\nforged")
+
+        mock_redis = AsyncMock()
+        mock_redis.scan_iter = fake_scan_iter
+
+        with (
+            patch("shared.role_cache.get_shared_redis", return_value=mock_redis),
+            patch("shared.role_cache.logger.warning") as warning,
+        ):
+            await invalidate_role(role_id)
+
+        message = warning.call_args.args[0]
+        assert "\n" not in message
+        assert "\\n" in message


### PR DESCRIPTION
## Summary

- sanitize caller-controlled module paths and cache exceptions before logging
- sanitize branding actor emails and logo-type values
- sanitize role-cache IDs, keys, and exception details across all log paths
- add regression coverage proving newline payloads cannot forge log entries

## CodeQL alerts

Targets remaining log-injection alerts #610, #611, #676, #677, #686, and #687. The patch also hardens adjacent log calls in the same modules to prevent equivalent findings from recurring.

## Verification

- targeted module-cache and role-cache unit tests plus branding API E2E tests executed against the isolated Linux Docker test stack
- Python compile check for all changed files
- `git diff --check`
- full CI, CodeQL, and SonarCloud are the merge gate

Storage, cache, authorization, and branding behavior are unchanged; only log rendering is sanitized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only sanitization at log callsites; no changes to cache, auth, or branding business logic.
> 
> **Overview**
> Hardens **log output** against injection by routing caller-controlled values and exception text through `log_safe()` before they appear in log messages. **Runtime behavior** of role cache, module cache, and branding APIs is unchanged.
> 
> **Role cache** (`api/shared/role_cache.py`): user IDs, Redis keys, role IDs, and exception details in warning/debug paths on read, populate, and invalidation are sanitized.
> 
> **Module cache** (`api/src/core/module_cache.py`): module paths, work directories, and re-cache errors in debug/info/warning logs are sanitized (some paths were already covered).
> 
> **Branding** (`api/src/routers/branding.py`): superuser **email** and **logo_type** in audit-style info logs are sanitized.
> 
> **Tests** add regression coverage in `test_module_cache.py` and `test_role_cache.py` asserting log lines contain no raw newlines when inputs include `\n`-forged payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d1c2d672bc2a2b57cca81dc6255e84d15eda55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log safety by sanitizing user-controlled values, paths, identifiers, and error messages before they are recorded.
  * Prevented special characters such as newlines from creating misleading or forged log entries.
  * Preserved existing cache, branding, and module-management behavior.

* **Tests**
  * Added coverage confirming that potentially unsafe log content is escaped correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->