### PR TITLE
fix: remove ineffective abstract ellipses

### DIFF
--- a/api/bifrost/webhooks.py
+++ b/api/bifrost/webhooks.py
@@ -217,7 +217,6 @@ class WebhookAdapter(ABC):
         Returns:
             SubscribeResult with external_id, state, and expires_at
         """
-        ...
 
     async def unsubscribe(
         self,
@@ -285,7 +284,6 @@ class WebhookAdapter(ABC):
             - Deliver: To process the event
             - Rejected: To reject the request
         """
-        ...
 
     # ==========================================================================
     # Helper methods for common operations

--- a/api/src/services/embeddings/base.py
+++ b/api/src/services/embeddings/base.py
@@ -44,7 +44,6 @@ class BaseEmbeddingClient(ABC):
         Returns:
             List of embedding vectors (each is a list of floats)
         """
-        ...
 
     @abstractmethod
     async def embed_single(self, text: str) -> list[float]:
@@ -57,7 +56,6 @@ class BaseEmbeddingClient(ABC):
         Returns:
             Embedding vector as a list of floats
         """
-        ...
 
     @property
     def model_name(self) -> str:

--- a/api/src/services/file_backend.py
+++ b/api/src/services/file_backend.py
@@ -30,27 +30,22 @@ class FileBackend(ABC):
     @abstractmethod
     async def read(self, path: str, location: Location, scope: str | None = None) -> bytes:
         """Read file content."""
-        ...
 
     @abstractmethod
     async def write(self, path: str, content: bytes, location: Location, updated_by: str = "system", scope: str | None = None) -> None:
         """Write file content."""
-        ...
 
     @abstractmethod
     async def delete(self, path: str, location: Location, scope: str | None = None) -> None:
         """Delete a file."""
-        ...
 
     @abstractmethod
     async def list(self, directory: str, location: Location, scope: str | None = None) -> list[str]:
         """List files in a directory."""
-        ...
 
     @abstractmethod
     async def exists(self, path: str, location: Location, scope: str | None = None) -> bool:
         """Check if a file exists."""
-        ...
 
 
 class LocalBackend(FileBackend):

--- a/api/src/services/llm/base.py
+++ b/api/src/services/llm/base.py
@@ -128,7 +128,6 @@ class BaseLLMClient(ABC):
         Returns:
             LLMResponse with content and/or tool calls
         """
-        ...
 
     @abstractmethod
     def stream(
@@ -151,13 +150,11 @@ class BaseLLMClient(ABC):
         Yields:
             LLMStreamChunk objects as they arrive
         """
-        ...
 
     @property
     @abstractmethod
     def provider_name(self) -> str:
         """Return the provider name (e.g., 'openai', 'anthropic')."""
-        ...
 
     @property
     def model_name(self) -> str:


### PR DESCRIPTION
## Summary

Remove 12 redundant ellipsis expressions that followed abstract-method docstrings. The docstrings already provide valid function bodies, so the expressions had no effect.

## CodeQL alerts

Resolves `py/ineffectual-statement` alerts #228 through #239 across the LLM, embedding, file-backend, and webhook abstract interfaces.

## Verification

- targeted file-backend, webhook, embedding-factory, and LLM-factory tests executed against the isolated Linux Docker test stack
- Python compile check
- `git diff --check`
- full CI and CodeQL are the merge gate

No interface signatures or runtime behavior changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only edits on abstract interfaces; no logic, signatures, or runtime paths changed.
> 
> **Overview**
> Removes **12 standalone `...` lines** from `@abstractmethod` stubs in webhook, LLM, embedding, and file-backend ABCs. Those expressions sat after docstrings and did nothing at runtime; the docstrings alone already satisfy Python’s body requirement.
> 
> This is a **lint/CodeQL cleanup** for `py/ineffectual-statement` (alerts #228–#239). **No method signatures, contracts, or runtime behavior** change—subclasses still must implement the same abstract APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f621f42141dca227d176d677994c9980f4a2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->