### PR TITLE
Harden SVG logo sanitization

### DIFF
--- a/api/shared/svg_sanitizer.py
+++ b/api/shared/svg_sanitizer.py
@@ -1,9 +1,4 @@
-"""SVG sanitizer.
-
-Parses SVG bytes with defusedxml (blocking XXE / billion-laughs), strips
-script elements, event-handler attributes, and javascript: hrefs. Returns
-sanitized bytes ready to store and serve.
-"""
+"""Allowlist-based sanitization for SVG images served from Bifrost origins."""
 
 from __future__ import annotations
 
@@ -12,50 +7,295 @@ from xml.etree.ElementTree import Element, register_namespace, tostring
 
 from defusedxml import ElementTree as DefusedET
 
-_SVG_NS = "http://www.w3.org/2000/svg"  # NOSONAR - W3C namespace URI, not a transport endpoint.
-_XLINK_NS = "http://www.w3.org/1999/xlink"  # NOSONAR - W3C namespace URI, not a transport endpoint.
-_JS_URI = re.compile(r"^\s*javascript:", re.IGNORECASE)
+_SVG_NS = "http://www.w3.org/2000/svg"  # NOSONAR - W3C namespace identifier.
+_XLINK_NS = "http://www.w3.org/1999/xlink"  # NOSONAR - W3C namespace identifier.
+_XML_NS = "http://www.w3.org/XML/1998/namespace"  # NOSONAR - W3C namespace identifier.
 
-# Register common SVG namespaces so tostring() emits clean tag names
-# (e.g. <svg> instead of <ns0:svg>).
+# These cover ordinary vector logos, gradients, clipping, masks, patterns, and
+# embedded raster artwork. Active SVG features (scripts, animation, foreign
+# content, filters, and external resources) are deliberately absent.
+_ALLOWED_ELEMENTS = frozenset(
+    {
+        "a",
+        "circle",
+        "clipPath",
+        "defs",
+        "desc",
+        "ellipse",
+        "g",
+        "image",
+        "line",
+        "linearGradient",
+        "marker",
+        "mask",
+        "path",
+        "pattern",
+        "polygon",
+        "polyline",
+        "radialGradient",
+        "rect",
+        "stop",
+        "svg",
+        "symbol",
+        "text",
+        "title",
+        "tspan",
+        "use",
+    }
+)
+
+_ALLOWED_ATTRIBUTES = frozenset(
+    {
+        "aria-label",
+        "class",
+        "clip-path",
+        "clip-rule",
+        "color",
+        "color-interpolation",
+        "cx",
+        "cy",
+        "d",
+        "display",
+        "dominant-baseline",
+        "dx",
+        "dy",
+        "fill",
+        "fill-opacity",
+        "fill-rule",
+        "focusable",
+        "font-family",
+        "font-size",
+        "font-style",
+        "font-weight",
+        "gradientTransform",
+        "gradientUnits",
+        "height",
+        "id",
+        "lengthAdjust",
+        "marker-end",
+        "marker-mid",
+        "marker-start",
+        "markerHeight",
+        "markerUnits",
+        "markerWidth",
+        "mask",
+        "maskContentUnits",
+        "maskUnits",
+        "offset",
+        "opacity",
+        "orient",
+        "overflow",
+        "pathLength",
+        "patternContentUnits",
+        "patternTransform",
+        "patternUnits",
+        "points",
+        "preserveAspectRatio",
+        "r",
+        "refX",
+        "refY",
+        "role",
+        "rotate",
+        "rx",
+        "ry",
+        "shape-rendering",
+        "spreadMethod",
+        "stop-color",
+        "stop-opacity",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linecap",
+        "stroke-linejoin",
+        "stroke-miterlimit",
+        "stroke-opacity",
+        "stroke-width",
+        "style",
+        "text-anchor",
+        "text-rendering",
+        "textLength",
+        "transform",
+        "vector-effect",
+        "viewBox",
+        "visibility",
+        "width",
+        "x",
+        "x1",
+        "x2",
+        "y",
+        "y1",
+        "y2",
+    }
+)
+
+_ALLOWED_STYLE_PROPERTIES = frozenset(
+    {
+        "clip-path",
+        "clip-rule",
+        "color",
+        "display",
+        "dominant-baseline",
+        "fill",
+        "fill-opacity",
+        "fill-rule",
+        "font-family",
+        "font-size",
+        "font-style",
+        "font-weight",
+        "marker-end",
+        "marker-mid",
+        "marker-start",
+        "mask",
+        "opacity",
+        "overflow",
+        "shape-rendering",
+        "stop-color",
+        "stop-opacity",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linecap",
+        "stroke-linejoin",
+        "stroke-miterlimit",
+        "stroke-opacity",
+        "stroke-width",
+        "text-anchor",
+        "text-rendering",
+        "vector-effect",
+        "visibility",
+    }
+)
+
+_REFERENCE_ATTRIBUTES = frozenset(
+    {
+        "clip-path",
+        "marker-end",
+        "marker-mid",
+        "marker-start",
+        "mask",
+    }
+)
+_PAINT_ATTRIBUTES = frozenset({"fill", "stroke"})
+_COLOR_ATTRIBUTES = _PAINT_ATTRIBUTES | {"color", "stop-color"}
+_FRAGMENT = r"#[A-Za-z_][A-Za-z0-9_.:-]*"
+_FRAGMENT_HREF = re.compile(rf"^{_FRAGMENT}$")
+_LOCAL_REFERENCE = re.compile(rf"^url\(\s*{_FRAGMENT}\s*\)$", re.IGNORECASE)
+_LOCAL_PAINT = re.compile(
+    rf"^url\(\s*{_FRAGMENT}\s*\)(?:\s+(?:none|currentColor|#[0-9a-f]{{3,8}}|[a-z]+))?$",
+    re.IGNORECASE,
+)
+_SAFE_COLOR = re.compile(
+    r"^(?:none|currentColor|context-fill|context-stroke|transparent|#[0-9a-f]{3,8}|[a-z]+|(?:rgb|rgba|hsl|hsla)\([0-9.,%+\-\s]+\))$",
+    re.IGNORECASE,
+)
+_RASTER_DATA_URL = re.compile(
+    r"^data:image/(?:png|jpeg|gif|webp);base64,[A-Za-z0-9+/]+={0,2}$",
+    re.IGNORECASE,
+)
+_UNSAFE_CSS = re.compile(
+    r"(?:\\|/\*|\*/|@|expression\s*\(|javascript\s*:|data\s*:|https?\s*:|file\s*:)",
+    re.IGNORECASE,
+)
+
 register_namespace("", _SVG_NS)
 register_namespace("xlink", _XLINK_NS)
 
 
 class SvgSanitizationError(ValueError):
-    """Raised when the SVG cannot be safely parsed or sanitized."""
+    """Raised when SVG input cannot be parsed into a safe SVG document."""
 
 
-def _strip(element: Element) -> None:
-    # Remove disallowed attributes
-    for attr in list(element.attrib.keys()):
-        local = attr.split("}")[-1].lower()
-        if local.startswith("on"):
-            del element.attrib[attr]
+def _qualified_name(name: str) -> tuple[str | None, str]:
+    if name.startswith("{") and "}" in name:
+        namespace, local_name = name[1:].split("}", 1)
+        return namespace, local_name
+    return None, name
+
+
+def _sanitize_url_value(element_name: str, attribute: str, value: str) -> str | None:
+    value = value.strip()
+    if attribute == "href":
+        if element_name in {"use", "linearGradient", "radialGradient", "pattern"}:
+            return value if _FRAGMENT_HREF.fullmatch(value) else None
+        if element_name == "image":
+            return value if _RASTER_DATA_URL.fullmatch(value) else None
+        return None
+    if attribute in _REFERENCE_ATTRIBUTES:
+        return value if _LOCAL_REFERENCE.fullmatch(value) else None
+    if attribute in _COLOR_ATTRIBUTES:
+        if attribute in _PAINT_ATTRIBUTES and _LOCAL_PAINT.fullmatch(value):
+            return value
+        return value if _SAFE_COLOR.fullmatch(value) else None
+    return value
+
+
+def _sanitize_style(value: str) -> str | None:
+    declarations: list[str] = []
+    for declaration in value.split(";"):
+        if not declaration.strip() or ":" not in declaration:
             continue
-        if local == "href" or attr == f"{{{_XLINK_NS}}}href":
-            if _JS_URI.match(element.attrib[attr]):
-                del element.attrib[attr]
+        property_name, property_value = declaration.split(":", 1)
+        property_name = property_name.strip().lower()
+        property_value = property_value.strip()
+        if property_name not in _ALLOWED_STYLE_PROPERTIES or not property_value:
+            continue
+        if _UNSAFE_CSS.search(property_value):
+            continue
+        sanitized = _sanitize_url_value("", property_name, property_value)
+        if sanitized is None or (
+            "url" in sanitized.lower()
+            and property_name not in _REFERENCE_ATTRIBUTES | _PAINT_ATTRIBUTES
+        ):
+            continue
+        declarations.append(f"{property_name}:{sanitized}")
+    return ";".join(declarations) or None
 
-    # Recurse, removing forbidden children in place
+
+def _sanitize_attributes(element: Element, element_name: str) -> None:
+    sanitized: dict[str, str] = {}
+    for qualified_attribute, value in element.attrib.items():
+        namespace, attribute = _qualified_name(qualified_attribute)
+        if namespace == _XML_NS and attribute == "space":
+            sanitized[qualified_attribute] = value
+            continue
+        if namespace not in {None, _XLINK_NS}:
+            continue
+        if namespace == _XLINK_NS:
+            if attribute != "href":
+                continue
+            output_attribute = qualified_attribute
+        else:
+            if attribute == "href":
+                output_attribute = attribute
+            elif attribute not in _ALLOWED_ATTRIBUTES:
+                continue
+            else:
+                output_attribute = attribute
+
+        if attribute == "style":
+            safe_value = _sanitize_style(value)
+        else:
+            safe_value = _sanitize_url_value(element_name, attribute, value)
+        if safe_value is not None:
+            sanitized[output_attribute] = safe_value
+    element.attrib.clear()
+    element.attrib.update(sanitized)
+
+
+def _sanitize_element(element: Element) -> None:
+    _, element_name = _qualified_name(element.tag)
+    _sanitize_attributes(element, element_name)
     for child in list(element):
-        tag = child.tag.split("}")[-1].lower()
-        if tag in ("script",):
+        namespace, child_name = _qualified_name(child.tag)
+        if namespace not in {None, _SVG_NS} or child_name not in _ALLOWED_ELEMENTS:
             element.remove(child)
             continue
-        _strip(child)
+        _sanitize_element(child)
 
 
 def sanitize_svg(data: bytes) -> bytes:
-    """Return a sanitized copy of the SVG bytes.
-
-    Raises SvgSanitizationError if the input can't be safely parsed.
-    """
+    """Return SVG bytes containing only inert, allowlisted SVG constructs."""
     try:
-        # Allow a benign top-level DOCTYPE (Inkscape/Illustrator emit one
-        # referencing the SVG 1.1 DTD), but reject entity declarations and
-        # external resolution — those are the actual XXE / billion-laughs
-        # attack vectors.
         root = DefusedET.fromstring(
             data,
             forbid_dtd=False,
@@ -65,7 +305,9 @@ def sanitize_svg(data: bytes) -> bytes:
     except Exception as exc:
         raise SvgSanitizationError(f"unparseable svg: {exc}") from exc
 
-    _strip(root)
+    namespace, root_name = _qualified_name(root.tag)
+    if root_name != "svg" or namespace not in {None, _SVG_NS}:
+        raise SvgSanitizationError("root element must be svg")
 
-    # Re-serialize using stdlib tostring (defusedxml doesn't provide its own).
+    _sanitize_element(root)
     return tostring(root, encoding="unicode").encode("utf-8")

--- a/api/shared/svg_sanitizer.py
+++ b/api/shared/svg_sanitizer.py
@@ -185,11 +185,11 @@ _LOCAL_PAINT = re.compile(
     re.IGNORECASE,
 )
 _SAFE_COLOR = re.compile(
-    r"^(?:none|currentColor|context-fill|context-stroke|transparent|#[0-9a-f]{3,8}|[a-z]+|(?:rgb|rgba|hsl|hsla)\([0-9.,%+\-\s]+\))$",
+    r"^(?:context-fill|context-stroke|#[0-9a-f]{3,8}|[a-z]+|(?:rgb|hsl)a?\([0-9.,%+\-\s]+\))$",
     re.IGNORECASE,
 )
 _RASTER_DATA_URL = re.compile(
-    r"^data:image/(?:png|jpeg|gif|webp);base64,[A-Za-z0-9+/]+={0,2}$",
+    r"^data:image/(?:png|jpeg|gif|webp);base64,[A-Z0-9+/]+={0,2}$",
     re.IGNORECASE,
 )
 _UNSAFE_CSS = re.compile(

--- a/api/src/routers/agents.py
+++ b/api/src/routers/agents.py
@@ -1102,6 +1102,14 @@ async def upload_agent_logo(
             detail=f"Agent {agent_id} not found",
         )
     assert_not_solution_managed(agent)
+    if not user.is_platform_admin and (
+        agent.owner_user_id != user.user_id
+        or agent.access_level != AgentAccessLevel.PRIVATE
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only edit your own private agents",
+        )
 
     if file.content_type not in LOGO_ALLOWED_CONTENT_TYPES:
         raise HTTPException(

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from src.core.auth import Context, CurrentUser
+from src.core.auth import Context, CurrentSuperuser, CurrentUser
 from src.core.log_safety import log_safe
 from src.core.org_filter import resolve_org_filter
 from src.core.pubsub import publish_app_draft_update, publish_app_published
@@ -979,11 +979,13 @@ async def rollback_application(
 async def upload_application_logo(
     app_id: UUID,
     ctx: Context,
+    user: CurrentSuperuser,
     file: UploadFile = File(..., description="Logo image (PNG/JPEG/SVG, ≤5MB)"),
 ) -> dict:
     """Upload a square logo for an application.
 
-    Requires the same permissions as updating the application.
+    Platform-admin authorization is required because SVG logos are served from
+    the application origin.
     """
     await assert_entity_id_not_solution_managed(ctx.db, Application, app_id)
     application = await get_application_by_id_or_404(ctx, app_id)

--- a/api/tests/e2e/api/test_entity_logos.py
+++ b/api/tests/e2e/api/test_entity_logos.py
@@ -94,6 +94,19 @@ class TestApplicationLogo:
         finally:
             _delete_app(e2e_client, platform_admin.headers, app["id"])
 
+    def test_upload_requires_platform_admin(self, e2e_client, platform_admin, org1_user):
+        slug = f"logo-app-auth-{uuid.uuid4().hex[:8]}"
+        app = _create_app(e2e_client, platform_admin.headers, slug)
+        try:
+            response = e2e_client.post(
+                f"/api/applications/{app['id']}/logo",
+                headers=_upload_headers(org1_user.headers),
+                files={"file": ("logo.png", CLEAN_PNG, "image/png")},
+            )
+            assert response.status_code == 403
+        finally:
+            _delete_app(e2e_client, platform_admin.headers, app["id"])
+
     def test_svg_sanitized(self, e2e_client, platform_admin):
         slug = f"logo-app-svg-{uuid.uuid4().hex[:8]}"
         app = _create_app(e2e_client, platform_admin.headers, slug)
@@ -115,16 +128,19 @@ class TestApplicationLogo:
             _delete_app(e2e_client, platform_admin.headers, app["id"])
 
 
-def _create_agent(e2e_client, headers, name):
+def _create_agent(e2e_client, headers, name, organization_id=None):
+    payload = {
+        "name": name,
+        "system_prompt": "You are a helper.",
+        "channels": ["chat"],
+        "access_level": "authenticated",
+    }
+    if organization_id is not None:
+        payload["organization_id"] = organization_id
     resp = e2e_client.post(
         "/api/agents",
         headers=headers,
-        json={
-            "name": name,
-            "system_prompt": "You are a helper.",
-            "channels": ["chat"],
-            "access_level": "authenticated",
-        },
+        json=payload,
     )
     assert resp.status_code == 201, f"create agent failed: {resp.text}"
     return resp.json()
@@ -181,6 +197,48 @@ class TestAgentLogo:
             assert resp.status_code == 400
         finally:
             _delete_agent(e2e_client, platform_admin.headers, agent["id"])
+
+    def test_view_access_does_not_grant_upload_access(
+        self, e2e_client, platform_admin, org1_user, org1
+    ):
+        agent = _create_agent(
+            e2e_client,
+            platform_admin.headers,
+            f"logo-bot-auth-{uuid.uuid4().hex[:8]}",
+            organization_id=org1["id"],
+        )
+        try:
+            response = e2e_client.post(
+                f"/api/agents/{agent['id']}/logo",
+                headers=_upload_headers(org1_user.headers),
+                files={"file": ("logo.png", CLEAN_PNG, "image/png")},
+            )
+            assert response.status_code == 403
+        finally:
+            _delete_agent(e2e_client, platform_admin.headers, agent["id"])
+
+    def test_owner_can_upload_to_private_agent(self, e2e_client, org1_user):
+        response = e2e_client.post(
+            "/api/agents",
+            headers=org1_user.headers,
+            json={
+                "name": f"private-logo-bot-{uuid.uuid4().hex[:8]}",
+                "system_prompt": "You are a helper.",
+                "channels": ["chat"],
+                "access_level": "private",
+            },
+        )
+        assert response.status_code == 201, response.text
+        agent = response.json()
+        try:
+            upload = e2e_client.post(
+                f"/api/agents/{agent['id']}/logo",
+                headers=_upload_headers(org1_user.headers),
+                files={"file": ("logo.png", CLEAN_PNG, "image/png")},
+            )
+            assert upload.status_code == 200, upload.text
+        finally:
+            _delete_agent(e2e_client, org1_user.headers, agent["id"])
 
     def test_svg_sanitized(self, e2e_client, platform_admin):
         agent = _create_agent(e2e_client, platform_admin.headers, f"logo-bot-svg-{uuid.uuid4().hex[:8]}")

--- a/api/tests/unit/test_svg_sanitizer.py
+++ b/api/tests/unit/test_svg_sanitizer.py
@@ -29,6 +29,34 @@ def test_event_handler_attribute_removed():
     assert b"<circle" in out
 
 
+def test_allowlisted_logo_features_are_preserved():
+    payload = b"""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <defs><linearGradient id="brand"><stop offset="0" stop-color="#123456"/></linearGradient></defs>
+      <g transform="translate(1 1)" style="fill:url(#brand);stroke:#fff;stroke-width:2">
+        <path d="M0 0h10v10z"/><text x="2" y="8">Bifrost</text>
+      </g>
+    </svg>"""
+    out = sanitize_svg(payload)
+
+    assert b"linearGradient" in out
+    assert b"fill:url(#brand)" in out
+    assert b"stroke:#fff" in out
+    assert b"<path" in out
+    assert b"<text" in out
+
+
+def test_local_references_and_embedded_raster_image_are_preserved():
+    payload = b"""<svg xmlns="http://www.w3.org/2000/svg">
+      <defs><path id="shape" d="M0 0h1v1z"/></defs>
+      <use href="#shape"/>
+      <image href="data:image/png;base64,iVBORw0KGgo=" width="1" height="1"/>
+    </svg>"""
+    out = sanitize_svg(payload)
+
+    assert b'href="#shape"' in out
+    assert b"data:image/png;base64,iVBORw0KGgo=" in out
+
+
 def test_javascript_href_removed():
     payload = b'<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><circle r="1"/></a></svg>'
     out = sanitize_svg(payload)
@@ -42,6 +70,63 @@ def test_xlink_javascript_href_removed():
     )
     out = sanitize_svg(payload)
     assert b"javascript:" not in out.lower()
+
+
+def test_foreign_object_and_active_elements_are_removed_with_their_content():
+    payload = b"""<svg xmlns="http://www.w3.org/2000/svg">
+      <foreignObject><div xmlns="http://www.w3.org/1999/xhtml"><script>alert(1)</script></div></foreignObject>
+      <animate attributeName="href" values="safe;javascript:alert(1)"/>
+      <set attributeName="onload" to="alert(1)"/>
+      <rect width="10" height="10"/>
+    </svg>"""
+    out = sanitize_svg(payload)
+
+    assert b"foreignObject" not in out
+    assert b"script" not in out.lower()
+    assert b"animate" not in out.lower()
+    assert b"<set" not in out.lower()
+    assert b"<rect" in out
+
+
+def test_active_urls_events_and_unsafe_css_are_removed():
+    payload = b"""<svg xmlns="http://www.w3.org/2000/svg">
+      <a href="javascript&#x3a;alert(1)" target="_top"><rect onload="alert(1)"/></a>
+      <use href="https://attacker.example/payload.svg#x"/>
+      <image href="data:image/svg+xml;base64,PHN2Zy8+"/>
+      <path fill="url(https://attacker.example/p.svg#x)"
+            clip-path="url(javascript:alert(1))"
+            style="stroke:url(#safe);fill:url(javascript:alert(1));background:url(https://attacker.example/x)"/>
+    </svg>"""
+    out = sanitize_svg(payload)
+
+    assert b"javascript" not in out.lower()
+    assert b"attacker.example" not in out
+    assert b"data:image/svg+xml" not in out
+    assert b"onload" not in out.lower()
+    assert b"target=" not in out
+    assert b"stroke:url(#safe)" in out
+
+
+def test_css_escape_and_comment_url_obfuscation_are_removed():
+    payload = rb"""<svg xmlns="http://www.w3.org/2000/svg">
+      <path fill="u\72l(javascript:alert(1))"
+            stroke="u/**/rl(https://attacker.example/x)"
+            style="fill:u\72l(javascript:alert(1));stroke:u/**/rl(https://attacker.example/x);color:#123"/>
+    </svg>"""
+    out = sanitize_svg(payload)
+
+    assert b"javascript" not in out.lower()
+    assert b"attacker.example" not in out
+    assert b"fill=" not in out
+    assert b"stroke=" not in out
+    assert b"color:#123" in out
+
+
+def test_non_svg_and_foreign_namespace_roots_are_rejected():
+    with pytest.raises(SvgSanitizationError):
+        sanitize_svg(b'<html xmlns="http://www.w3.org/1999/xhtml"/>')
+    with pytest.raises(SvgSanitizationError):
+        sanitize_svg(b'<svg xmlns="https://attacker.example/svg"/>')
 
 
 def test_xxe_blocked():
@@ -78,10 +163,10 @@ def test_inkscape_style_doctype_accepted():
 def test_billion_laughs_blocked():
     payload = (
         b'<?xml version="1.0"?>'
-        b'<!DOCTYPE lolz ['
+        b"<!DOCTYPE lolz ["
         b'<!ENTITY lol "lol">'
         b'<!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
-        b']>'
+        b"]>"
         b'<svg xmlns="http://www.w3.org/2000/svg"><text>&lol2;</text></svg>'
     )
     with pytest.raises(SvgSanitizationError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     # =========================================================================
     "PyYAML",
     "croniter",  # CRON expression parsing
-    "defusedxml>=0.7.1",  # Safe XML/SVG parsing — strips scripts/event-handlers from uploads
+    "defusedxml>=0.7.1",  # Safe XML parsing for the SVG allowlist sanitizer
 
     # =========================================================================
     # Code Transformation


### PR DESCRIPTION
## Summary
- replace denylist SVG cleanup with explicit element, attribute, CSS property, and URL allowlists
- require platform-admin authorization for application logo uploads and owner/private write authorization for agent logo uploads
- add adversarial coverage for foreignObject, active elements, event handlers, external/data SVG URLs, and CSS obfuscation while preserving normal vector and embedded-raster logos

## Verification
- uff check api/shared/svg_sanitizer.py api/src/routers/applications.py api/src/routers/agents.py api/tests/unit/test_svg_sanitizer.py api/tests/e2e/api/test_entity_logos.py
- python -m compileall -q on the changed Python files
- ./test.sh tests/unit/test_svg_sanitizer.py tests/unit/test_solution_logo.py::TestDecodeLogo tests/e2e/api/test_entity_logos.py -q (29 passed on pve-t340 VM 101)
- ./test.sh tests/e2e/api/test_misc.py -q -k logo (7 passed on pve-t340 VM 101)

## Security Notes
The sanitizer intentionally rejects active SVG features and external resources. Existing SVGs already stored before this patch are not rewritten; deployments should assess whether historical logo rows need a one-time re-sanitization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-critical SVG handling and upload authorization for user-controlled content served from app origins; stricter rules may reject some previously accepted SVGs or block non-admin app logo uploads.
> 
> **Overview**
> Replaces **denylist-based** SVG cleanup with an **explicit allowlist** for elements, attributes, inline `style` properties, and URL values (local fragment refs, safe colors, raster `data:` images only). Active SVG features (`foreignObject`, animation, external/`javascript:`/`data:image/svg+xml` URLs, obfuscated CSS) are stripped or rejected; the root must be a standard SVG namespace.
> 
> **Authorization** for logo uploads is tightened: application logo upload now requires **platform admin** (`CurrentSuperuser`); agent logo upload requires **platform admin** or **owner of a private** agent (view access alone is no longer enough).
> 
> Unit and e2e tests cover adversarial SVG cases and the new upload rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6253e9e644a98960e4247ec1e4bb3c6fb7d4143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->