### PR TITLE
test: clear unused CodeQL locals

### DIFF
--- a/api/tests/e2e/api/test_websocket.py
+++ b/api/tests/e2e/api/test_websocket.py
@@ -422,6 +422,7 @@ class TestWebSocketEdgeCases:
             try:
                 await ws.send(json.dumps({"type": "ping"}))
                 msg = await asyncio.wait_for(ws.recv(), timeout=2)
+                assert json.loads(msg)["type"] == "pong"
                 # If we get here, server ignored the invalid JSON
                 logger.info("Server gracefully ignored invalid JSON")
             except ConnectionClosedError:

--- a/api/tests/unit/repositories/test_ai_usage_repository.py
+++ b/api/tests/unit/repositories/test_ai_usage_repository.py
@@ -148,7 +148,7 @@ class TestAIPricingRepository:
         """Test create_pricing adds new pricing record."""
         mock_session.refresh = AsyncMock()
 
-        _result = await repository.create_pricing(
+        await repository.create_pricing(
             provider="openai",
             model="gpt-4o-mini",
             input_price_per_million=Decimal("0.15"),
@@ -172,7 +172,7 @@ class TestAIPricingRepository:
         mock_session.execute.return_value = mock_result
         mock_session.refresh = AsyncMock()
 
-        _result = await repository.update_pricing(
+        await repository.update_pricing(
             pricing_id=1,
             input_price_per_million=Decimal("6.00"),
         )
@@ -235,7 +235,7 @@ class TestAIUsageRepository:
         execution_id = uuid4()
         mock_session.refresh = AsyncMock()
 
-        _result = await repository.create_usage(
+        await repository.create_usage(
             provider="openai",
             model="gpt-4o",
             input_tokens=1000,

--- a/api/tests/unit/services/test_notification_service.py
+++ b/api/tests/unit/services/test_notification_service.py
@@ -162,7 +162,7 @@ class TestNotificationService:
         )
 
         with patch("src.services.notification_service.pubsub_manager", mock_pubsub):
-            _notification = await service.create_notification(
+            await service.create_notification(
                 user_id="user-123",
                 request=request,
                 for_admins=True,

--- a/api/tests/unit/test_cli_watch.py
+++ b/api/tests/unit/test_cli_watch.py
@@ -359,28 +359,6 @@ def test_watch_handler_dropped_events_do_not_call_post(tmp_path, monkeypatch):
     assert not changes
     assert not deletes
 
-    # If a caller naively iterated drained sets and posted per file, no posts
-    # would happen because both sets are empty. This documents the contract.
-    posted: list[tuple[str, dict]] = []
-
-    async def fake_post(url, json=None, **kwargs):  # type: ignore[no-untyped-def]
-        posted.append((url, json or {}))
-
-        class _Resp:
-            status_code = 204
-
-        return _Resp()
-
-    # Iterate as the watch batch would (no asyncio needed since we never await)
-    for _ in changes:
-        # Would have called fake_post; we never get here.
-        pass
-    for _ in deletes:
-        pass
-
-    assert posted == []
-
-
 def test_watch_refuses_in_solution_workspace(tmp_path, capsys):
     """`bifrost watch` must refuse inside a Solution workspace (D1): watch only
     syncs to the global _repo/, so running it where a bifrost.solution.yaml is

--- a/api/tests/unit/test_execution_pinning.py
+++ b/api/tests/unit/test_execution_pinning.py
@@ -35,6 +35,7 @@ def test_content_hash_none_skips_validation():
     """When content_hash is None, validation should be skipped (no error)."""
     content_hash = None
     workflow_code = "print('hello')"
+    assert workflow_code
     # Simulates the worker logic: if content_hash is None, skip validation
     if content_hash and workflow_code:
         actual_hash = hashlib.sha256(workflow_code.encode("utf-8")).hexdigest()

--- a/api/tests/unit/test_worker_s3_code_loading.py
+++ b/api/tests/unit/test_worker_s3_code_loading.py
@@ -187,6 +187,10 @@ class TestWorkerCodeLoadingBranches:
         file_path = None
         reached_else = False
 
+        assert workflow_code is None
+        assert function_name is None
+        assert file_path is None
+
         if workflow_code and function_name and file_path:
             pytest.fail("Should not take the workflow_code branch")
         elif function_name and file_path:


### PR DESCRIPTION
## Summary
- remove unused awaited-return assignments and a dead watch-test helper
- make execution/S3 branch fixture values explicit assertions
- assert the websocket response received after invalid JSON

Closes CodeQL alerts #196, #197, #198, #199, #200, #201, #211, and #212 after the next scan.

## Verification
- python compileall on all six changed test files
- git diff --check
- isolated Linux test stack: 75 targeted unit tests passed
- websocket e2e remains covered by PR CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to tests and static-analysis hygiene; no production paths or runtime semantics are modified.
> 
> **Overview**
> Resolves CodeQL **unused local** findings in tests only—no application or runtime behavior changes.
> 
> **Unused assignments removed:** Repository and notification unit tests no longer bind awaited return values when only side effects are asserted (`create_pricing`, `update_pricing`, `create_usage`, admin `create_notification`).
> 
> **Dead code removed:** The CLI watch test drops a redundant `fake_post` / empty-loop block that duplicated the “drained `.bifrost/` events mean zero posts” contract already covered by `drain()` assertions.
> 
> **Stronger assertions:** After invalid JSON on the websocket e2e path, a successful follow-up ping now asserts the reply is **`pong`**. Execution-pinning and worker S3 branch fixtures add explicit asserts on fixture values (`workflow_code`, `workflow_code` / `function_name` / `file_path`) so setup is visible to static analysis without changing branch logic under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff7d4481f5694363644354367d15a6bfe6dc73a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened WebSocket coverage to confirm connections remain usable after invalid messages.
  * Clarified validation for workflow content, missing execution fields, and excluded file events.
  * Simplified repository and notification service test assertions while preserving existing behavior checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->