### PR TITLE
test: remove ineffective CodeQL patterns

### DIFF
--- a/api/tests/unit/services/solutions/test_deploy_coverage_slice.py
+++ b/api/tests/unit/services/solutions/test_deploy_coverage_slice.py
@@ -1,6 +1,7 @@
 """Focused branch coverage for solution deploy helpers."""
 
 import base64
+from copy import deepcopy
 from enum import Enum
 from types import SimpleNamespace
 from uuid import UUID, uuid4
@@ -84,12 +85,13 @@ def test_remap_form_field_providers_maps_only_dict_fields_with_provider_ids():
 
 @pytest.mark.parametrize("form", [{"form_schema": None}, {"form_schema": []}, {}])
 def test_remap_form_field_providers_ignores_non_dict_schema(form):
+    original = deepcopy(form)
     deploy.SolutionDeployer._remap_form_field_providers(
         form,
         {WORKFLOW_ID: MAPPED_WORKFLOW_ID},
     )
 
-    assert form == form
+    assert form == original
 
 
 def test_validate_access_level_returns_valid_value_and_rejects_unknown_value():

--- a/api/tests/unit/services/test_deactivation_protection.py
+++ b/api/tests/unit/services/test_deactivation_protection.py
@@ -257,22 +257,6 @@ class TestDetectPendingDeactivationsLogic:
             )
             assert info.decorator_type == decorator_type
 
-    def test_similarity_threshold_concept(self):
-        """Test that similarity threshold (0.2) is documented for filtering."""
-        # The service uses 0.2 as the threshold for including replacements
-        # Scores >= 0.2 are included, < 0.2 are filtered out
-        threshold = 0.2
-
-        # These should be included
-        assert 0.85 >= threshold
-        assert 0.5 >= threshold
-        assert 0.2 >= threshold
-
-        # These should be filtered
-        assert 0.19 < threshold
-        assert 0.0 < threshold
-
-
 class TestApplyWorkflowReplacements:
     """Tests for _apply_workflow_replacements function.
 

--- a/api/tests/unit/test_main_app.py
+++ b/api/tests/unit/test_main_app.py
@@ -233,7 +233,7 @@ async def test_combined_lifespan_yields_without_mcp_lifespan(monkeypatch):
         yield
 
     monkeypatch.setattr(main, "app_lifespan", fake_app_lifespan)
-    monkeypatch.setattr(main, "_get_mcp_asgi_app", lambda: SimpleNamespace())
+    monkeypatch.setattr(main, "_get_mcp_asgi_app", SimpleNamespace)
 
     async with main.lifespan(SimpleNamespace()):
         yielded = True

--- a/api/tests/unit/test_nginx_security_headers.py
+++ b/api/tests/unit/test_nginx_security_headers.py
@@ -8,7 +8,7 @@ def _repo_file(*parts: str) -> Path:
         candidate = parent.joinpath(*parts)
         if candidate.exists():
             return candidate
-    pytest.skip(
+    return pytest.skip(
         f"{Path(*parts)} is not available in this packaged test environment",
         allow_module_level=True,
     )


### PR DESCRIPTION
## Summary
- preserve module-level skip behavior while making the helper return explicit
- remove a constant-vs-constant threshold test that exercised no production behavior
- compare untouched form inputs against a pre-call copy
- replace an unnecessary zero-argument lambda with the callable constructor

Expected to close CodeQL alerts #331, #333, #674, and #675 after the next main scan.

## Verification
- 62 targeted tests passed in the Linux test image
- Python compileall
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to unit tests and static-analysis hygiene; no runtime or security-sensitive production paths are modified.
> 
> **Overview**
> **Test-only cleanup** aimed at closing CodeQL findings (#331, #333, #674, #675). No production behavior changes.
> 
> In **`test_remap_form_field_providers_ignores_non_dict_schema`**, the post-call check now compares the form to a **`deepcopy` taken before** `_remap_form_field_providers`, replacing the useless `assert form == form`.
> 
> **`test_similarity_threshold_concept`** was removed from deactivation protection tests—it only asserted constants against the documented `0.2` threshold and never exercised `FileStorageService`.
> 
> **`test_combined_lifespan_yields_without_mcp_lifespan`** patches `_get_mcp_asgi_app` with **`SimpleNamespace`** instead of `lambda: SimpleNamespace()`.
> 
> **`_repo_file`** in the nginx security headers tests now **`return pytest.skip(...)`** when `client/nginx.conf` is missing, keeping module-level skip behavior while making control flow explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42ec624e6f0328969685a15d7087bb619724a52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->