### PR TITLE
fix: clear client CodeQL type comparisons

### DIFF
--- a/client/src/hooks/useBranding.ts
+++ b/client/src/hooks/useBranding.ts
@@ -73,7 +73,7 @@ export async function updateBranding(
 
 	if (error) {
 		throw new Error(
-			typeof error === "object" && error !== null && "message" in error
+			typeof error === "object" && "message" in error
 				? (error as { message?: string }).message ||
 						"Failed to update branding"
 				: "Failed to update branding",
@@ -102,7 +102,6 @@ export async function uploadLogo(
 		throw new Error(
 			`Failed to upload ${type} logo: ${
 				typeof error === "object" &&
-				error !== null &&
 				"message" in error
 					? (error as { message?: string }).message
 					: "Unknown error"
@@ -128,7 +127,6 @@ export async function resetLogo(
 		throw new Error(
 			`Failed to reset ${type} logo: ${
 				typeof error === "object" &&
-				error !== null &&
 				"message" in error
 					? (error as { message?: string }).message
 					: "Unknown error"
@@ -149,7 +147,6 @@ export async function resetColor(): Promise<BrandingSettings_API> {
 		throw new Error(
 			`Failed to reset primary color: ${
 				typeof error === "object" &&
-				error !== null &&
 				"message" in error
 					? (error as { message?: string }).message
 					: "Unknown error"
@@ -173,7 +170,6 @@ export async function resetApplicationName(): Promise<BrandingSettings_API> {
 		throw new Error(
 			`Failed to reset application name: ${
 				typeof error === "object" &&
-				error !== null &&
 				"message" in error
 					? (error as { message?: string }).message
 					: "Unknown error"

--- a/client/src/lib/app-code-platform/useWorkflowMutation.ts
+++ b/client/src/lib/app-code-platform/useWorkflowMutation.ts
@@ -147,7 +147,6 @@ export function useWorkflowMutation<T = unknown>(
 			if (responseError) {
 				const errorMessage =
 					typeof responseError === "object" &&
-					responseError !== null &&
 					"detail" in responseError
 						? String(
 								(responseError as { detail: unknown }).detail,

--- a/client/src/services/filePolicies.ts
+++ b/client/src/services/filePolicies.ts
@@ -52,7 +52,7 @@ async function parseResponse<T>(response: Response): Promise<T> {
 		if (response.status === 204) return undefined as T;
 		return (await response.json()) as T;
 	}
-	let detail = response.statusText;
+	let detail: string;
 	try {
 		const body = (await response.json()) as { detail?: unknown; message?: unknown };
 		const raw = body.detail ?? body.message;

--- a/client/src/services/policyRules.ts
+++ b/client/src/services/policyRules.ts
@@ -64,7 +64,7 @@ export async function deletePolicyRule(domain: string, name: string): Promise<vo
 	if (!error) return;
 
 	// Try to surface a structured in-use payload when the server sends 409.
-	if (typeof error === "object" && error !== null && "detail" in error) {
+	if (typeof error === "object" && "detail" in error) {
 		const detail = (error as { detail: unknown }).detail;
 		if (typeof detail === "object" && detail !== null && "usages" in detail) {
 			const inUse: PolicyRuleInUseError = {


### PR DESCRIPTION
## Summary
- remove redundant null comparisons after truthy API-error guards
- keep unknown-error null protection where it remains required
- avoid the overwritten initial error-detail assignment in file policy responses

## Security findings
Resolves CodeQL alerts #186, #187, #188, #189, #190, #191, #608, and #609 after merge and rescan.

## Verification
- `npm run tsc`
- `npm run lint`
- `npm test -- --run src/services/filePolicies.test.ts src/services/policyRules.test.ts src/lib/app-code-platform/useWorkflowQuery.test.ts` (19 passed)
- full client unit run: 1,627 passed; 2 unrelated `ExecutionHistory.test.tsx` failures caused by the suite attempting localhost:3000 without the stack and retained DOM after the first timeout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors error-message extraction only; runtime behavior is intended to stay the same with no security or data-path changes.
> 
> **Overview**
> Cleans up client-side API error handling to satisfy CodeQL **type comparison** alerts without changing behavior.
> 
> In **`useBranding`**, **`useWorkflowMutation`**, and **`policyRules`**, redundant **`error !== null`** checks are removed after guards that already treat `error` as truthy; narrowing still uses **`typeof error === "object"`** plus **`"message"`** or **`"detail"`** in the object.
> 
> In **`filePolicies.parseResponse`**, error detail is assigned only inside the parse path (**`let detail: string`** with try/catch) instead of initializing to **`response.statusText`** and immediately overwriting it on the success path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4fbbd02dc540ca2ca288fe93b194eb0828f7fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->