### PR TITLE
fix(security): contain agentic file paths

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -4144,6 +4144,15 @@ Options:
     changed = [r for r in all_results if r.changed]
     apps_touched = {app_for_result[r.path] for r in changed}
 
+    for result in changed:
+        app_dir = app_for_result[result.path].resolve()
+        if not result.path.resolve().is_relative_to(app_dir):
+            print(
+                f"Error: migration result escapes app directory: {result.path}",
+                file=sys.stderr,
+            )
+            return 1
+
     if not changed:
         print("No changes needed.")
         return 0

--- a/api/bifrost/migrate_imports.py
+++ b/api/bifrost/migrate_imports.py
@@ -831,11 +831,21 @@ def migrate_app(
     lucide_names: AbstractSet[str],
 ) -> list[FileMigrationResult]:
     """Run migration on every TSX/TS file in an app, return results (changed + unchanged)."""
-    user_components = list_user_components(app_dir)
+    resolved_app_dir = app_dir.resolve()
+    user_components = list_user_components(resolved_app_dir)
     results: list[FileMigrationResult] = []
-    for src_file in find_source_files(app_dir):
+    for src_file in find_source_files(resolved_app_dir):
+        resolved_source = src_file.resolve()
+        if not resolved_source.is_relative_to(resolved_app_dir):
+            raise ValueError(f"Source file escapes app directory: {src_file}")
         results.append(
-            migrate_file(src_file, app_dir, user_components, platform_names, lucide_names)
+            migrate_file(
+                resolved_source,
+                resolved_app_dir,
+                user_components,
+                platform_names,
+                lucide_names,
+            )
         )
     return results
 

--- a/api/src/services/app_bundler/__init__.py
+++ b/api/src/services/app_bundler/__init__.py
@@ -161,6 +161,7 @@ class BundlerService:
             src_dir = tmp_path / "src"
             out_dir = tmp_path / "dist"
             src_dir.mkdir()
+            out_dir.mkdir()
 
             # 1. Materialize app source from _repo to tempdir
             sources = await self._materialize_source(src_dir, repo_prefix)

--- a/api/src/services/app_bundler/bundle.js
+++ b/api/src/services/app_bundler/bundle.js
@@ -96,7 +96,7 @@ async function main() {
   const buildRoot = fs.realpathSync(path.dirname(sourceDir));
   const expectedOutDir = path.join(buildRoot, "dist");
   const entryPath = path.resolve(sourceDir, entry);
-  const existingOutDir = fs.existsSync(outDir) ? fs.realpathSync(outDir) : outDir;
+  const existingOutDir = fs.existsSync(outDir) ? fs.realpathSync(outDir) : null;
 
   if (
     !isWithin(tempRoot, buildRoot)
@@ -112,8 +112,6 @@ async function main() {
     }));
     return;
   }
-
-  fs.mkdirSync(outDir, { recursive: true }); // NOSONAR -- validated isolated tempdir above
 
   const t0 = Date.now();
 

--- a/api/src/services/app_bundler/bundle.js
+++ b/api/src/services/app_bundler/bundle.js
@@ -31,7 +31,7 @@
 const esbuild = require("esbuild");
 const path = require("path");
 const fs = require("fs");
-const os = require("os");
+const os = require("node:os");
 
 async function readStdin() {
   return new Promise((resolve, reject) => {
@@ -113,7 +113,7 @@ async function main() {
     return;
   }
 
-  fs.mkdirSync(outDir, { recursive: true });
+  fs.mkdirSync(outDir, { recursive: true }); // NOSONAR -- validated isolated tempdir above
 
   const t0 = Date.now();
 

--- a/api/src/services/app_bundler/bundle.js
+++ b/api/src/services/app_bundler/bundle.js
@@ -71,6 +71,11 @@ function shapeMessages(messages, source_dir) {
   });
 }
 
+function isWithin(base, candidate) {
+  const relative = path.relative(base, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
 async function main() {
   const raw = await readStdin();
   const cfg = JSON.parse(raw);
@@ -84,15 +89,28 @@ async function main() {
     return;
   }
 
-  fs.mkdirSync(out_dir, { recursive: true });
+  const sourceDir = path.resolve(source_dir);
+  const outDir = path.resolve(out_dir);
+  const buildRoot = path.dirname(sourceDir);
+  const entryPath = path.resolve(sourceDir, entry);
+
+  if (!isWithin(sourceDir, entryPath) || !isWithin(buildRoot, outDir) || outDir === buildRoot) {
+    console.log(JSON.stringify({
+      success: false,
+      errors: [{ text: "Build paths must stay within the isolated build directory", file: null, line: null, column: null, line_text: null }],
+    }));
+    return;
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
 
   const t0 = Date.now();
 
   let result;
   try {
     result = await esbuild.build({
-      entryPoints: [path.join(source_dir, entry)],
-      outdir: out_dir,
+      entryPoints: [entryPath],
+      outdir: outDir,
       bundle: true,
       format: "esm",
       target: "es2020",
@@ -117,10 +135,10 @@ async function main() {
   } catch (buildErr) {
     // esbuild throws BuildFailure with .errors[] on syntax / resolve errors.
     const errs = Array.isArray(buildErr.errors) && buildErr.errors.length
-      ? shapeMessages(buildErr.errors, source_dir)
+      ? shapeMessages(buildErr.errors, sourceDir)
       : [{ text: buildErr.message || String(buildErr), file: null, line: null, column: null, line_text: null }];
     const warns = Array.isArray(buildErr.warnings)
-      ? shapeMessages(buildErr.warnings, source_dir)
+      ? shapeMessages(buildErr.warnings, sourceDir)
       : [];
     console.log(JSON.stringify({
       success: false,
@@ -138,7 +156,7 @@ async function main() {
   let css_file = null;
 
   for (const [abs, meta] of Object.entries(result.metafile.outputs)) {
-    const rel = path.relative(out_dir, abs);
+    const rel = path.relative(outDir, abs);
     const bytes = meta.bytes;
     outputs.push({ path: rel, bytes });
     if (meta.entryPoint) {
@@ -159,7 +177,7 @@ async function main() {
     entry_file,
     css_file,
     duration_ms,
-    warnings: shapeMessages(result.warnings, source_dir),
+    warnings: shapeMessages(result.warnings, sourceDir),
   }));
 }
 

--- a/api/src/services/app_bundler/bundle.js
+++ b/api/src/services/app_bundler/bundle.js
@@ -31,6 +31,7 @@
 const esbuild = require("esbuild");
 const path = require("path");
 const fs = require("fs");
+const os = require("os");
 
 async function readStdin() {
   return new Promise((resolve, reject) => {
@@ -89,12 +90,22 @@ async function main() {
     return;
   }
 
-  const sourceDir = path.resolve(source_dir);
+  const tempRoot = fs.realpathSync(os.tmpdir());
+  const sourceDir = fs.realpathSync(path.resolve(source_dir));
   const outDir = path.resolve(out_dir);
-  const buildRoot = path.dirname(sourceDir);
+  const buildRoot = fs.realpathSync(path.dirname(sourceDir));
+  const expectedOutDir = path.join(buildRoot, "dist");
   const entryPath = path.resolve(sourceDir, entry);
+  const existingOutDir = fs.existsSync(outDir) ? fs.realpathSync(outDir) : outDir;
 
-  if (!isWithin(sourceDir, entryPath) || !isWithin(buildRoot, outDir) || outDir === buildRoot) {
+  if (
+    !isWithin(tempRoot, buildRoot)
+    || !path.basename(buildRoot).startsWith("bifrost-bundle-")
+    || path.basename(sourceDir) !== "src"
+    || !isWithin(sourceDir, entryPath)
+    || outDir !== expectedOutDir
+    || existingOutDir !== expectedOutDir
+  ) {
     console.log(JSON.stringify({
       success: false,
       errors: [{ text: "Build paths must stay within the isolated build directory", file: null, line: null, column: null, line_text: null }],

--- a/api/tests/unit/test_app_bundler.py
+++ b/api/tests/unit/test_app_bundler.py
@@ -451,7 +451,7 @@ async def test_build_uploads_live_outputs_and_manifest(
 
     async def fake_run_esbuild(cfg: dict) -> dict:
         out_dir = pathlib.Path(cfg["out_dir"])
-        out_dir.mkdir()
+        out_dir.mkdir(exist_ok=True)
         (out_dir / "entry-live.js").write_bytes(b"// live bundle\n")
         (out_dir / "entry-live.css").write_bytes(b".live{}\n")
         return {

--- a/api/tests/unit/test_cli_migrate_imports.py
+++ b/api/tests/unit/test_cli_migrate_imports.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import pathlib
 import sys
 
+import pytest
+
 # Ensure the standalone bifrost CLI package is importable.
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
@@ -39,6 +41,19 @@ def _make_app(tmp_path: pathlib.Path, components: dict[str, str] | None = None) 
     for name, body in (components or {}).items():
         _write(app_dir / "components" / f"{name}.tsx", body)
     return app_dir
+
+
+def test_migrate_app_rejects_source_outside_app(tmp_path, monkeypatch) -> None:
+    app = _make_app(tmp_path)
+    outside = tmp_path / "outside.tsx"
+    _write(outside, "export default () => null;\n")
+    monkeypatch.setattr(
+        "bifrost.migrate_imports.find_source_files",
+        lambda _app_dir: [outside],
+    )
+
+    with pytest.raises(ValueError, match="escapes app directory"):
+        migrate_app(app, PLATFORM, LUCIDE)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- resolve and validate esbuild entry/output paths inside its isolated build directory before filesystem access
- reject migrate-imports source paths that resolve outside the selected app directory
- revalidate migration result paths at the CLI write boundary
- add a traversal regression test

Expected to close CodeQL/Sonar alerts #539 and #541 after the next main scan.

## Verification
- 22 migrate-imports tests passed in the Linux test image
- exercised bundle.js with traversal config and verified structured rejection
- node --check
- Python compileall
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds security boundaries around bundler and migrate-imports filesystem access; behavior change is mostly rejecting bad paths, but a mis-tuned validation rule could block legitimate builds in edge temp-dir setups.
> 
> **Overview**
> Hardens **path containment** for tooling that reads or writes the filesystem on behalf of apps, so resolved paths cannot escape their intended directories.
> 
> **`migrate-imports`** now resolves the app directory and each source file before migration, raises if a discovered source resolves outside the app tree, and the CLI **re-checks** every changed result path before writing (aborts with a clear error if a result would escape the app).
> 
> **App bundling** pre-creates the temp `dist` directory in Python and, in **`bundle.js`**, resolves and validates `source_dir`, entry, and `out_dir` against the expected `bifrost-bundle-*` temp layout (under the system temp root, `src` sibling to `dist`) before running esbuild; invalid configs return a structured failure instead of touching arbitrary paths.
> 
> A **unit test** covers migrate-imports rejection when `find_source_files` returns a path outside the app; the bundler test tolerates an already-created `out_dir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9f8d475e747469786a97cc6fa6a3798030b766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->