### PR TITLE
fix(security): bound agent stats windows

### DIFF
--- a/api/src/services/agent_stats.py
+++ b/api/src/services/agent_stats.py
@@ -12,6 +12,17 @@ from src.models.orm.agents import Agent, Conversation
 from src.models.orm.ai_usage import AIUsage
 
 
+MAX_STATS_WINDOW_DAYS = 90
+
+
+def _validated_window_days(window_days: int) -> int:
+    if not 1 <= window_days <= MAX_STATS_WINDOW_DAYS:
+        raise ValueError(
+            f"window_days must be between 1 and {MAX_STATS_WINDOW_DAYS}"
+        )
+    return window_days
+
+
 def _to_decimal(value: Decimal | int | None) -> Decimal:
     if value is None:
         return Decimal("0")
@@ -34,6 +45,7 @@ def _build_runs_by_day(
     window_days: int,
     now: datetime,
 ) -> list[int]:
+    window_days = _validated_window_days(window_days)
     buckets = [0] * window_days
     for run in runs:
         day_offset = (now - run.created_at).days
@@ -98,6 +110,7 @@ async def get_agent_stats(
     ``AgentRun`` only — the deferred "tuning + chat conversations"
     follow-up will revisit those.
     """
+    window_days = _validated_window_days(window_days)
     cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
     runs_q = select(AgentRun).where(
         AgentRun.agent_id == agent_id,
@@ -168,6 +181,7 @@ async def get_fleet_stats(
     fleet spend. ``avg_success_rate`` stays keyed on ``AgentRun`` only —
     there is no "success" concept on a chat conversation.
     """
+    window_days = _validated_window_days(window_days)
     cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
 
     agent_filter = []

--- a/api/tests/unit/test_agent_stats_service.py
+++ b/api/tests/unit/test_agent_stats_service.py
@@ -11,7 +11,28 @@ from src.models.enums import AgentAccessLevel
 from src.models.orm.agent_runs import AgentRun
 from src.models.orm.agents import Agent, Conversation
 from src.models.orm.ai_usage import AIUsage
-from src.services.agent_stats import get_agent_stats, get_fleet_stats
+from src.services.agent_stats import (
+    MAX_STATS_WINDOW_DAYS,
+    _build_runs_by_day,
+    get_agent_stats,
+    get_fleet_stats,
+)
+
+
+@pytest.mark.parametrize("window_days", [0, -1, MAX_STATS_WINDOW_DAYS + 1, 10_000_000])
+def test_runs_by_day_rejects_unbounded_windows(window_days):
+    with pytest.raises(ValueError, match="window_days must be between"):
+        _build_runs_by_day([], window_days=window_days, now=datetime.now(timezone.utc))
+
+
+def test_runs_by_day_accepts_maximum_window():
+    buckets = _build_runs_by_day(
+        [],
+        window_days=MAX_STATS_WINDOW_DAYS,
+        now=datetime.now(timezone.utc),
+    )
+
+    assert len(buckets) == MAX_STATS_WINDOW_DAYS
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary
- enforce the API's 1-90 day stats window inside the service boundary
- validate again at the allocation helper before constructing per-day buckets
- cover zero, negative, over-limit, and extreme allocation requests

Expected to close security alert #111 after the next main scan.

## Verification
- 5 focused Linux tests passed
- Python compileall
- git diff --check
- remaining DB-backed tests require the normal test stack and are covered by PR CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation change with no auth or data-model changes; behavior for valid API inputs stays the same.
> 
> **Overview**
> Adds a **service-layer guard** so agent stats cannot use an unbounded `window_days`, matching the API’s 1–90 day limit even when callers bypass the router.
> 
> Introduces `MAX_STATS_WINDOW_DAYS` (90) and `_validated_window_days`, which raises `ValueError` for out-of-range values. Validation runs in `get_agent_stats`, `get_fleet_stats`, and `_build_runs_by_day` before allocating the per-day bucket list—blocking extreme values (e.g. millions of days) that could cause large memory use.
> 
> Unit tests cover rejected windows (0, negative, over max, very large) and confirm the maximum window produces a bucket list of length 90.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f320770ae94b8b8011be90dd0b437e473849892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->