### PR TITLE
fix(security): contain files gallery demo uploads

### DIFF
--- a/docs/demo/files-gallery/setup.mjs
+++ b/docs/demo/files-gallery/setup.mjs
@@ -4,6 +4,10 @@ const BASE = "http://localhost:34212";
 const SLUG = "gallery";
 const NAME = "Shared Gallery";
 const log = (...a) => console.log("[setup]", ...a);
+const BASE_URL = new URL(BASE);
+if (!["localhost", "127.0.0.1"].includes(BASE_URL.hostname)) {
+	throw new Error(`files gallery demo setup only uploads fixtures to localhost, got ${BASE_URL.origin}`);
+}
 
 async function login(username, password = "password") {
 	const r = await fetch(`${BASE}/api/auth/login`, {
@@ -20,7 +24,10 @@ if (!tok) throw new Error("admin login failed");
 const H = (t = tok) => ({ Authorization: `Bearer ${t}`, "Content-Type": "application/json" });
 
 async function api(method, path, body, t = tok) {
-	const r = await fetch(`${BASE}${path}`, { method, headers: H(t), body: body ? JSON.stringify(body) : undefined });
+	const url = new URL(path, BASE_URL);
+	if (url.origin !== BASE_URL.origin) throw new Error(`refusing cross-origin demo request: ${url.href}`);
+	const payload = body ? JSON.stringify(body) : undefined;
+	const r = await fetch(url, { method, headers: H(t), body: payload }); // codeql[js/file-access-to-http] Fixed demo fixtures are uploaded only to the guarded localhost Bifrost API.
 	const txt = await r.text();
 	let json; try { json = JSON.parse(txt); } catch { json = txt; }
 	return { ok: r.ok, status: r.status, json };


### PR DESCRIPTION
## Summary
- restore the files-gallery demo's explicit localhost-only destination guard
- reject any API path that resolves outside the configured localhost origin
- retain a narrow CodeQL suppression at the contained demo fixture upload sink

## Security disposition
Closes CodeQL alert #607 after the next main-branch scan. The script uploads only two repository-owned demo fixture files and now fails closed unless the target is localhost/127.0.0.1 and same-origin.

## Verification
- `node --check docs/demo/files-gallery/setup.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect only a local demo setup script, not production services; behavior fails closed on non-localhost targets.
> 
> **Overview**
> Hardens **`docs/demo/files-gallery/setup.mjs`** so demo fixture uploads cannot be aimed at arbitrary hosts.
> 
> At startup it now parses `BASE` as a URL and **throws** unless the hostname is `localhost` or `127.0.0.1`. The shared `api()` helper resolves each path against that base and **rejects** any request whose resolved origin differs, instead of concatenating `BASE` and `path` blindly.
> 
> A **CodeQL** suppression documents that the remaining `fetch` with request bodies is intentional: only fixed demo fixtures go to the guarded local Bifrost API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ad0d38078fa51b8f755549c8df67289c4aa1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->