### PR TITLE
fix: update vulnerable Python dependency surfaces

### DIFF
--- a/.clusterfuzzlite/requirements.txt
+++ b/.clusterfuzzlite/requirements.txt
@@ -2,12 +2,12 @@ croniter==6.2.2
 regex==2026.5.9
 sqlalchemy==2.0.49
 greenlet==3.4.0
-starlette==1.0.0
+starlette==1.3.1
 pydantic==2.13.3
 pydantic-core==2.46.3
 annotated-types==0.7.0
 dnspython==2.8.0
 email-validator==2.3.0
-idna==3.13
+idna==3.18
 typing-extensions==4.15.0
 typing-inspection==0.4.2

--- a/doc_renderer_service/requirements.txt
+++ b/doc_renderer_service/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.115,<1.0
-uvicorn[standard]>=0.34,<1.0
-weasyprint>=62,<70
-pydantic>=2.10,<3.0
+fastapi==0.139.0
+uvicorn[standard]==0.51.0
+weasyprint==69.0
+pydantic==2.13.4

--- a/requirements.lock
+++ b/requirements.lock
@@ -894,9 +894,9 @@ exceptiongroup==1.3.1 \
     --hash=sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219 \
     --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
     # via fastmcp
-fastapi==0.136.1 \
-    --hash=sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f \
-    --hash=sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f
+fastapi==0.139.0 \
+    --hash=sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145 \
+    --hash=sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189
     # via
     #   bifrost-api (pyproject.toml)
     #   sentry-sdk
@@ -1288,9 +1288,9 @@ hypothesis==6.156.1 \
     --hash=sha256:f1e1fecee9c79956ac5e7c38cb1d1374bf22fd4066ff6a9664d45d13a09251b1 \
     --hash=sha256:f8385703ba1a03a09f2b2cbbf418344a82beef51b397101933a67535da7d0e19
     # via bifrost-api (pyproject.toml)
-idna==3.13 \
-    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
-    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
+idna==3.18 \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
+    --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
     # via
     #   anyio
     #   email-validator
@@ -2872,9 +2872,9 @@ sse-starlette==3.3.4 \
     --hash=sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1 \
     --hash=sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1
     # via mcp
-starlette==1.0.0 \
-    --hash=sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149 \
-    --hash=sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
     # via
     #   fastapi
     #   mcp


### PR DESCRIPTION
Summary:
- update root lock to FastAPI 0.139.0, Starlette 1.3.1, and idna 3.18 with resolver-backed SHA-256 hashes
- update ClusterFuzzLite copies to Starlette 1.3.1 and idna 3.18
- replace renderer ranges with exact current pins: FastAPI 0.139.0, Pydantic 2.13.4, Uvicorn 0.51.0, and WeasyPrint 69.0
- preserve the existing root lock graph and avoid unrelated platform-specific resolver churn

These updates address current and historical OSV findings represented by the Scorecard Vulnerabilities check across every manifest Scorecard reported.

Verification:
- targeted pip-compile resolution for FastAPI, Starlette, and idna
- root required-hash dry-run accepted updated packages and hashes before the expected Windows-only uvloop rejection
- isolated Linux venv install and import smoke for renderer resolved 0.139.0 / 2.13.4 / 0.51.0 / 69.0 / Starlette 1.3.1 / idna 3.18
- isolated Linux venv install and import smoke for ClusterFuzzLite resolved Starlette 1.3.1 / idna 3.18 / Pydantic 2.13.3
- git diff --check
- full Linux tests delegated to required GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bumps with no application code changes; main API behavior should be unchanged aside from transitive framework fixes.
> 
> **Overview**
> Bumps vulnerable Python packages across the **root lock**, **ClusterFuzzLite** requirements, and **doc renderer** manifest so OpenSSF Scorecard / OSV checks pass on every pinned surface.
> 
> **`requirements.lock`**: **FastAPI** `0.136.1` → `0.139.0`, **Starlette** `1.0.0` → `1.3.1`, **idna** `3.13` → `3.18` (hashes updated; rest of the lock graph unchanged).
> 
> **`.clusterfuzzlite/requirements.txt`**: same **Starlette** and **idna** pins for fuzz CI.
> 
> **`doc_renderer_service/requirements.txt`**: replaces open ranges with exact pins—**FastAPI** `0.139.0`, **Uvicorn** `0.51.0`, **WeasyPrint** `69.0`, **Pydantic** `2.13.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f4d5a1dfd50553e17b2f8771ca96ecc2eacb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->