### PR TITLE
fix(security): contain CLI API body paths

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -32,7 +32,7 @@ import webbrowser
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TextIO
 from urllib.parse import parse_qs, urlparse, urlsplit, urlunsplit
 
 if TYPE_CHECKING:
@@ -3970,7 +3970,7 @@ Examples:
         # Support @filename for reading body from file
         if raw.startswith("@"):
             try:
-                with open(_safe_api_body_path(raw[1:]), encoding="utf-8") as body_file:
+                with _open_api_body_file(raw[1:]) as body_file:
                     body = json.load(body_file)
             except Exception as e:
                 print(f"Error reading file: {e}", file=sys.stderr)
@@ -4001,13 +4001,129 @@ Examples:
     return asyncio.run(_api_request(method, endpoint, body, client=client))
 
 
-def _safe_api_body_path(filename: str) -> str:
-    """Resolve an ``@file`` API body without escaping the invocation directory."""
+def _safe_api_body_path(filename: str) -> tuple[str, str]:
+    """Resolve an ``@file`` API body within the invocation directory."""
     base_dir = os.path.realpath(os.getcwd())
     resolved = os.path.realpath(filename)
-    if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+    if resolved == base_dir or not _path_is_within(base_dir, resolved):
         raise ValueError(f"path {filename!r} is outside the current working directory")
-    return resolved
+    return base_dir, resolved
+
+
+def _path_is_within(base_dir: str, candidate: str) -> bool:
+    """Return whether two canonical paths share the same path-aware root."""
+    try:
+        common = os.path.commonpath((base_dir, candidate))
+    except ValueError:
+        return False
+    return os.path.normcase(common) == os.path.normcase(base_dir)
+
+
+def _open_api_body_file(filename: str) -> TextIO:
+    """Open a validated API body without re-resolving an attacker-swappable path."""
+    base_dir, resolved = _safe_api_body_path(filename)
+
+    if os.name == "nt":
+        return _open_api_body_file_windows(filename, base_dir, resolved)
+
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if os.open in os.supports_dir_fd and hasattr(os, "O_DIRECTORY") and nofollow:
+        parts = pathlib.Path(os.path.relpath(resolved, base_dir)).parts
+        directory_fd = os.open(base_dir, os.O_RDONLY | os.O_DIRECTORY | nofollow)
+        try:
+            opened_base = os.fstat(directory_fd)
+            current_base = os.stat(".")
+            if (opened_base.st_dev, opened_base.st_ino) != (current_base.st_dev, current_base.st_ino):
+                raise ValueError("current working directory changed while opening API body")
+            for component in parts[:-1]:
+                next_fd = os.open(
+                    component,
+                    os.O_RDONLY | os.O_DIRECTORY | nofollow,
+                    dir_fd=directory_fd,
+                )
+                os.close(directory_fd)
+                directory_fd = next_fd
+            file_fd = os.open(parts[-1], os.O_RDONLY | nofollow, dir_fd=directory_fd)
+        finally:
+            os.close(directory_fd)
+        return os.fdopen(file_fd, encoding="utf-8")
+
+    raise OSError("secure API body file reads are not supported on this platform")
+
+
+def _open_api_body_file_windows(filename: str, base_dir: str, resolved: str) -> TextIO:
+    """Open a Windows path and validate containment from the resulting handle."""
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    get_final_path = kernel32.GetFinalPathNameByHandleW
+    get_final_path.argtypes = (wintypes.HANDLE, wintypes.LPWSTR, wintypes.DWORD, wintypes.DWORD)
+    get_final_path.restype = wintypes.DWORD
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+
+    generic_read = 0x80000000
+    share_read_write_delete = 0x00000001 | 0x00000002 | 0x00000004
+    open_existing = 3
+    file_attribute_normal = 0x00000080
+    invalid_handle = ctypes.c_void_p(-1).value
+
+    handle = create_file(
+        resolved,
+        generic_read,
+        share_read_write_delete,
+        None,
+        open_existing,
+        file_attribute_normal,
+        None,
+    )
+    if handle == invalid_handle:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    try:
+        capacity = 1024
+        while True:
+            buffer = ctypes.create_unicode_buffer(capacity)
+            length = get_final_path(handle, buffer, capacity, 0)
+            if length == 0:
+                raise ctypes.WinError(ctypes.get_last_error())
+            if length < capacity:
+                break
+            capacity = length + 1
+
+        final_path = buffer.value
+        if final_path.startswith("\\\\?\\UNC\\"):
+            final_path = "\\\\" + final_path[8:]
+        elif final_path.startswith("\\\\?\\"):
+            final_path = final_path[4:]
+        final_path = os.path.realpath(final_path)
+        if not _path_is_within(base_dir, final_path):
+            raise ValueError(f"path {filename!r} changed while opening")
+
+        file_fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)
+        handle = None  # The Python file descriptor now owns the OS handle.
+        try:
+            return os.fdopen(file_fd, encoding="utf-8")
+        except Exception:
+            os.close(file_fd)
+            raise
+    finally:
+        if handle is not None:
+            close_handle(handle)
 
 
 def _validate_api_endpoint(endpoint: str) -> str | None:

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -4054,8 +4054,8 @@ def _open_api_body_file(filename: str) -> TextIO:
 def _open_api_body_file_windows(filename: str, base_dir: str, resolved: str) -> TextIO:
     """Open a Windows path and validate containment from the resulting handle."""
     import ctypes
+    import ctypes.wintypes as wintypes
     import msvcrt
-    from ctypes import wintypes
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     create_file = kernel32.CreateFileW

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -4053,9 +4053,10 @@ def _open_api_body_file(filename: str) -> TextIO:
 
 def _open_api_body_file_windows(filename: str, base_dir: str, resolved: str) -> TextIO:
     """Open a Windows path and validate containment from the resulting handle."""
-    import ctypes
-    import ctypes.wintypes as wintypes
+    import ctypes.wintypes
     import msvcrt
+
+    wintypes = ctypes.wintypes
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     create_file = kernel32.CreateFileW

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -3966,12 +3966,12 @@ Examples:
     body = None
 
     if len(args) > 2:
-        import pathlib
         raw = args[2]
         # Support @filename for reading body from file
         if raw.startswith("@"):
             try:
-                body = json.loads(pathlib.Path(raw[1:]).read_text())
+                with open(_safe_api_body_path(raw[1:]), encoding="utf-8") as body_file:
+                    body = json.load(body_file)
             except Exception as e:
                 print(f"Error reading file: {e}", file=sys.stderr)
                 return 1
@@ -3999,6 +3999,15 @@ Examples:
         return 1
 
     return asyncio.run(_api_request(method, endpoint, body, client=client))
+
+
+def _safe_api_body_path(filename: str) -> str:
+    """Resolve an ``@file`` API body without escaping the invocation directory."""
+    base_dir = os.path.realpath(os.getcwd())
+    resolved = os.path.realpath(filename)
+    if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+        raise ValueError(f"path {filename!r} is outside the current working directory")
+    return resolved
 
 
 def _validate_api_endpoint(endpoint: str) -> str | None:

--- a/api/tests/unit/test_cli_helpers_coverage.py
+++ b/api/tests/unit/test_cli_helpers_coverage.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import subprocess
 import sys
 from types import SimpleNamespace
 
@@ -379,6 +380,48 @@ def test_handle_api_body_file_rejects_canonicalized_symlink_escape(tmp_path, mon
 
     assert cli.handle_api(["POST", "/api/workflows", "@body.json"]) == 1
     assert "outside the current working directory" in capsys.readouterr().err
+
+
+def test_safe_api_body_path_supports_root_working_directory(monkeypatch):
+    monkeypatch.setattr(cli.os, "getcwd", lambda: "/")
+    monkeypatch.setattr(cli.os.path, "realpath", lambda path: path)
+
+    assert cli._safe_api_body_path("/body.json") == ("/", "/body.json")
+
+
+def test_open_api_body_file_rejects_path_swapped_to_symlink(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "body.json").write_text('{"secret": true}', encoding="utf-8")
+    swapped = workspace / "swapped"
+    if os.name == "nt":
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(swapped), str(outside)],
+            check=True,
+            capture_output=True,
+        )
+    else:
+        swapped.symlink_to(outside, target_is_directory=True)
+    candidate = swapped / "body.json"
+
+    # Model a swap after canonical validation: the opener receives the path
+    # that was valid before the attacker replaced it with an escaping symlink.
+    monkeypatch.setattr(
+        cli,
+        "_safe_api_body_path",
+        lambda _filename: (str(workspace), str(candidate)),
+    )
+
+    try:
+        with pytest.raises((OSError, ValueError)):
+            cli._open_api_body_file("body.json")
+    finally:
+        if os.name == "nt":
+            os.rmdir(swapped)
+        else:
+            swapped.unlink()
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/test_cli_helpers_coverage.py
+++ b/api/tests/unit/test_cli_helpers_coverage.py
@@ -339,6 +339,7 @@ def test_validate_api_endpoint_and_handle_api_input_errors(tmp_path, monkeypatch
 
     body_file = tmp_path / "body.json"
     body_file.write_text('{"ok": true}', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
 
     class ClientFactory:
         @staticmethod
@@ -346,10 +347,38 @@ def test_validate_api_endpoint_and_handle_api_input_errors(tmp_path, monkeypatch
             raise RuntimeError("not logged in")
 
     monkeypatch.setattr(cli, "BifrostClient", ClientFactory)
-    assert cli.handle_api(["POST", "/api/workflows", f"@{body_file}"]) == 1
+    assert cli.handle_api(["POST", "/api/workflows", "@body.json"]) == 1
     assert "not logged in" in capsys.readouterr().err
     assert cli.handle_api(["POST", "/api/workflows", "@missing.json"]) == 1
     assert "Error reading file" in capsys.readouterr().err
+
+
+def test_handle_api_body_file_cannot_escape_invocation_directory(tmp_path, monkeypatch, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"secret": true}', encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    assert cli.handle_api(["POST", "/api/workflows", "@../outside.json"]) == 1
+    assert "outside the current working directory" in capsys.readouterr().err
+
+
+def test_handle_api_body_file_rejects_canonicalized_symlink_escape(tmp_path, monkeypatch, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"secret": true}', encoding="utf-8")
+    monkeypatch.chdir(workspace)
+    realpath = cli.os.path.realpath
+    monkeypatch.setattr(
+        cli.os.path,
+        "realpath",
+        lambda path: str(outside) if path == "body.json" else realpath(path),
+    )
+
+    assert cli.handle_api(["POST", "/api/workflows", "@body.json"]) == 1
+    assert "outside the current working directory" in capsys.readouterr().err
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- canonicalize `@file` API request bodies against the CLI invocation directory
- reject parent traversal and symlink escapes before reading JSON
- preserve normal relative `@body.json` usage

Resolves the actionable sink behind code-scanning alert #541. Alert #539 needs no code in this PR: Sonar issue `AZ7XTqrCgeKcjgv0PO3C` is already `CLOSED/FIXED` in analysis `28197e30-d224-4547-9e61-678192937fed`; GitHub has not yet synchronized that closure.

## Verification
- `python -m py_compile bifrost/cli.py tests/unit/test_cli_helpers_coverage.py`
- `git diff --check`
- targeted `./test.sh` attempted under WSL, but this machine's WSL distro has no Docker integration; GitHub Actions is the authoritative platform test environment

## Security notes
- `@file` inputs are now limited to canonical paths beneath the current working directory, including separator-bounded containment
- canonicalization prevents symlink-based escapes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated CLI file I/O with platform-specific open logic; mistakes could break `@file` on some OSes or leave a read bypass, but scope is narrow and well-tested.
> 
> **Overview**
> **Hardens `bifrost api` when the JSON body comes from `@file`**, so reads are limited to paths under the current working directory instead of arbitrary filesystem locations.
> 
> `handle_api` now loads bodies through `_open_api_body_file` (with `json.load`) rather than reading the path string directly. New helpers canonicalize paths against `getcwd()`, reject `..` escapes and the cwd itself, and open files in a way that resists symlink swaps: on Unix via `O_NOFOLLOW` and `dir_fd` traversal from the validated base; on Windows via `CreateFileW` plus `GetFinalPathNameByHandleW` containment checks.
> 
> Unit tests cover parent traversal, spoofed `realpath`, root working directory, and post-validation symlink/junction swaps; existing `@body.json` usage from within the workspace is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3588e67f7adec13540539d6c815e69b90ad17b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection for JSON request bodies loaded from files.
  * File paths that escape the current working directory, including via symlinks, are now rejected with a clear error message.

* **Bug Fixes**
  * Improved handling and validation of relative request-body file paths.
  * Added coverage for missing files and unauthorized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->