### PR TITLE
feat: add immutable SolutionDeployment closure schema

### DIFF
--- a/api/alembic/versions/20260716_solution_deployments.py
+++ b/api/alembic/versions/20260716_solution_deployments.py
@@ -1,7 +1,7 @@
 """add immutable Solution deployment runtime closures
 
 Revision ID: 20260716_solution_deployments
-Revises: 20260705_merge_deploy_export
+Revises: 20260716_ws_repo_changesets
 Create Date: 2026-07-16
 """
 
@@ -14,7 +14,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20260716_solution_deployments"
-down_revision: str = "20260705_merge_deploy_export"
+down_revision: str = "20260716_ws_repo_changesets"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/api/alembic/versions/20260716_solution_deployments.py
+++ b/api/alembic/versions/20260716_solution_deployments.py
@@ -18,6 +18,9 @@ down_revision: str = "20260705_merge_deploy_export"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+_DEPLOYMENT_ID_COLUMN = "solution_deployments.id"
+_DEPLOYMENT_SOLUTION_COLUMN = "solution_deployments.solution_id"
+
 
 def upgrade() -> None:
     op.create_table(
@@ -59,13 +62,13 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["solution_id"], ["solutions.id"], ondelete="RESTRICT"),
         sa.ForeignKeyConstraint(
             ["parent_deployment_id", "solution_id"],
-            ["solution_deployments.id", "solution_deployments.solution_id"],
+            [_DEPLOYMENT_ID_COLUMN, _DEPLOYMENT_SOLUTION_COLUMN],
             name="fk_solution_deployment_parent_same_solution",
             ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
             ["base_deployment_id", "solution_id"],
-            ["solution_deployments.id", "solution_deployments.solution_id"],
+            [_DEPLOYMENT_ID_COLUMN, _DEPLOYMENT_SOLUTION_COLUMN],
             name="fk_solution_deployment_base_same_solution",
             ondelete="RESTRICT",
         ),
@@ -101,14 +104,14 @@ def upgrade() -> None:
         sa.Column("declared_constraint", sa.Text(), nullable=True),
         sa.Column("resolved_bundle_hash", sa.String(length=71), nullable=False),
         sa.ForeignKeyConstraint(
-            ["deployment_id"], ["solution_deployments.id"], ondelete="RESTRICT"
+            ["deployment_id"], [_DEPLOYMENT_ID_COLUMN], ondelete="RESTRICT"
         ),
         sa.ForeignKeyConstraint(
             ["dependency_solution_id"], ["solutions.id"], ondelete="RESTRICT"
         ),
         sa.ForeignKeyConstraint(
             ["dependency_deployment_id", "dependency_solution_id"],
-            ["solution_deployments.id", "solution_deployments.solution_id"],
+            [_DEPLOYMENT_ID_COLUMN, _DEPLOYMENT_SOLUTION_COLUMN],
             name="fk_solution_dependency_exact_deployment",
             ondelete="RESTRICT",
         ),

--- a/api/alembic/versions/20260716_solution_deployments.py
+++ b/api/alembic/versions/20260716_solution_deployments.py
@@ -1,0 +1,134 @@
+"""add immutable Solution deployment runtime closures
+
+Revision ID: 20260716_solution_deployments
+Revises: 20260705_merge_deploy_export
+Create Date: 2026-07-16
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260716_solution_deployments"
+down_revision: str = "20260705_merge_deploy_export"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "solution_deployments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("solution_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("parent_deployment_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("base_deployment_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("declared_version", sa.String(length=64), nullable=True),
+        sa.Column("bundle_hash", sa.String(length=71), nullable=False),
+        sa.Column("compiled_manifest", postgresql.JSONB(), nullable=False),
+        sa.Column("compiled_manifest_hash", sa.String(length=71), nullable=False),
+        sa.Column("resolution_map", postgresql.JSONB(), nullable=False),
+        sa.Column("source_artifact_key", sa.String(length=2048), nullable=False),
+        sa.Column("runtime_storage_prefix", sa.String(length=2048), nullable=False),
+        sa.Column("git_repository", sa.String(length=2048), nullable=True),
+        sa.Column("git_ref", sa.String(length=255), nullable=True),
+        sa.Column("git_commit_sha", sa.String(length=64), nullable=True),
+        sa.Column("git_push_state", sa.String(length=32), nullable=True),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("codex_worker_id", sa.String(length=255), nullable=True),
+        sa.Column("validation_result", postgresql.JSONB(), nullable=True),
+        sa.Column("failure_detail", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column("validated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("activated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("superseded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["solution_id"], ["solutions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["parent_deployment_id"], ["solution_deployments.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["base_deployment_id"], ["solution_deployments.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="RESTRICT"),
+        sa.CheckConstraint(
+            "state IN ('draft','building','validated','ready','activating','active',"
+            "'superseded','conflicted','failed','recovery_required','aborted',"
+            "'committed_unpushed')",
+            name="ck_solution_deployments_state",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_solution_deployments_solution_created",
+        "solution_deployments",
+        ["solution_id", "created_at"],
+    )
+    op.create_index(
+        "ix_solution_deployments_org_state",
+        "solution_deployments",
+        ["organization_id", "state"],
+    )
+    op.create_table(
+        "solution_deployment_dependencies",
+        sa.Column("deployment_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "dependency_solution_id", postgresql.UUID(as_uuid=True), nullable=False
+        ),
+        sa.Column(
+            "dependency_deployment_id", postgresql.UUID(as_uuid=True), nullable=False
+        ),
+        sa.Column("declared_constraint", sa.Text(), nullable=True),
+        sa.Column("resolved_bundle_hash", sa.String(length=71), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["deployment_id"], ["solution_deployments.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["dependency_solution_id"], ["solutions.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["dependency_deployment_id"],
+            ["solution_deployments.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("deployment_id", "dependency_solution_id"),
+    )
+    op.add_column(
+        "solutions",
+        sa.Column("active_deployment_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_solutions_active_deployment",
+        "solutions",
+        "solution_deployments",
+        ["active_deployment_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_solutions_active_deployment", "solutions", type_="foreignkey"
+    )
+    op.drop_column("solutions", "active_deployment_id")
+    op.drop_table("solution_deployment_dependencies")
+    op.drop_index(
+        "ix_solution_deployments_org_state", table_name="solution_deployments"
+    )
+    op.drop_index(
+        "ix_solution_deployments_solution_created", table_name="solution_deployments"
+    )
+    op.drop_table("solution_deployments")

--- a/api/alembic/versions/20260716_solution_deployments.py
+++ b/api/alembic/versions/20260716_solution_deployments.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
     op.create_table(
         "solution_deployments",
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("solution_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("parent_deployment_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("base_deployment_id", postgresql.UUID(as_uuid=True), nullable=True),
@@ -33,6 +33,7 @@ def upgrade() -> None:
         sa.Column("compiled_manifest", postgresql.JSONB(), nullable=False),
         sa.Column("compiled_manifest_hash", sa.String(length=71), nullable=False),
         sa.Column("resolution_map", postgresql.JSONB(), nullable=False),
+        sa.Column("resolution_map_hash", sa.String(length=71), nullable=False),
         sa.Column("source_artifact_key", sa.String(length=2048), nullable=False),
         sa.Column("runtime_storage_prefix", sa.String(length=2048), nullable=False),
         sa.Column("git_repository", sa.String(length=2048), nullable=True),
@@ -53,14 +54,20 @@ def upgrade() -> None:
         sa.Column("activated_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("superseded_at", sa.DateTime(timezone=True), nullable=True),
         sa.ForeignKeyConstraint(
-            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+            ["organization_id"], ["organizations.id"], ondelete="RESTRICT"
         ),
-        sa.ForeignKeyConstraint(["solution_id"], ["solutions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["solution_id"], ["solutions.id"], ondelete="RESTRICT"),
         sa.ForeignKeyConstraint(
-            ["parent_deployment_id"], ["solution_deployments.id"], ondelete="SET NULL"
+            ["parent_deployment_id", "solution_id"],
+            ["solution_deployments.id", "solution_deployments.solution_id"],
+            name="fk_solution_deployment_parent_same_solution",
+            ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
-            ["base_deployment_id"], ["solution_deployments.id"], ondelete="SET NULL"
+            ["base_deployment_id", "solution_id"],
+            ["solution_deployments.id", "solution_deployments.solution_id"],
+            name="fk_solution_deployment_base_same_solution",
+            ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="RESTRICT"),
         sa.CheckConstraint(
@@ -70,6 +77,7 @@ def upgrade() -> None:
             name="ck_solution_deployments_state",
         ),
         sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("id", "solution_id", name="uq_solution_deployment_id_solution"),
     )
     op.create_index(
         "ix_solution_deployments_solution_created",
@@ -93,14 +101,15 @@ def upgrade() -> None:
         sa.Column("declared_constraint", sa.Text(), nullable=True),
         sa.Column("resolved_bundle_hash", sa.String(length=71), nullable=False),
         sa.ForeignKeyConstraint(
-            ["deployment_id"], ["solution_deployments.id"], ondelete="CASCADE"
+            ["deployment_id"], ["solution_deployments.id"], ondelete="RESTRICT"
         ),
         sa.ForeignKeyConstraint(
             ["dependency_solution_id"], ["solutions.id"], ondelete="RESTRICT"
         ),
         sa.ForeignKeyConstraint(
-            ["dependency_deployment_id"],
-            ["solution_deployments.id"],
+            ["dependency_deployment_id", "dependency_solution_id"],
+            ["solution_deployments.id", "solution_deployments.solution_id"],
+            name="fk_solution_dependency_exact_deployment",
             ondelete="RESTRICT",
         ),
         sa.PrimaryKeyConstraint("deployment_id", "dependency_solution_id"),
@@ -113,13 +122,109 @@ def upgrade() -> None:
         "fk_solutions_active_deployment",
         "solutions",
         "solution_deployments",
-        ["active_deployment_id"],
-        ["id"],
-        ondelete="SET NULL",
+        ["active_deployment_id", "id"],
+        ["id", "solution_id"],
+        ondelete="RESTRICT",
+    )
+    op.execute(
+        """
+        CREATE FUNCTION enforce_solution_deployment_integrity() RETURNS trigger AS $$
+        DECLARE solution_org uuid;
+        BEGIN
+          SELECT organization_id INTO solution_org FROM solutions WHERE id = NEW.solution_id;
+          IF NOT FOUND OR solution_org IS DISTINCT FROM NEW.organization_id THEN
+            RAISE EXCEPTION 'deployment organization scope must match its Solution install';
+          END IF;
+          IF TG_OP = 'UPDATE' AND NOT (
+            (OLD.state = 'draft' AND NEW.state IN ('draft','building','aborted')) OR
+            (OLD.state = 'building' AND NEW.state IN ('building','validated','failed','aborted')) OR
+            (OLD.state = 'validated' AND NEW.state IN ('validated','ready','aborted')) OR
+            (OLD.state = 'ready' AND NEW.state IN ('ready','activating','aborted')) OR
+            (OLD.state = 'activating' AND NEW.state IN
+              ('activating','active','conflicted','failed','recovery_required')) OR
+            (OLD.state = 'active' AND NEW.state IN
+              ('active','superseded','committed_unpushed','recovery_required')) OR
+            (OLD.state = 'committed_unpushed' AND NEW.state IN
+              ('committed_unpushed','active','superseded','recovery_required')) OR
+            (OLD.state IN ('superseded','conflicted','failed','recovery_required','aborted')
+              AND NEW.state = OLD.state)
+          ) THEN
+            RAISE EXCEPTION 'invalid SolutionDeployment state transition: % -> %',
+              OLD.state, NEW.state;
+          END IF;
+          IF TG_OP = 'UPDATE' AND OLD.state NOT IN ('draft', 'building') AND (
+            NEW.id IS DISTINCT FROM OLD.id OR
+            NEW.organization_id IS DISTINCT FROM OLD.organization_id OR
+            NEW.solution_id IS DISTINCT FROM OLD.solution_id OR
+            NEW.parent_deployment_id IS DISTINCT FROM OLD.parent_deployment_id OR
+            NEW.base_deployment_id IS DISTINCT FROM OLD.base_deployment_id OR
+            NEW.declared_version IS DISTINCT FROM OLD.declared_version OR
+            NEW.bundle_hash IS DISTINCT FROM OLD.bundle_hash OR
+            NEW.compiled_manifest IS DISTINCT FROM OLD.compiled_manifest OR
+            NEW.compiled_manifest_hash IS DISTINCT FROM OLD.compiled_manifest_hash OR
+            NEW.resolution_map IS DISTINCT FROM OLD.resolution_map OR
+            NEW.resolution_map_hash IS DISTINCT FROM OLD.resolution_map_hash OR
+            NEW.source_artifact_key IS DISTINCT FROM OLD.source_artifact_key OR
+            NEW.runtime_storage_prefix IS DISTINCT FROM OLD.runtime_storage_prefix OR
+            NEW.git_repository IS DISTINCT FROM OLD.git_repository OR
+            NEW.git_ref IS DISTINCT FROM OLD.git_ref OR
+            NEW.git_commit_sha IS DISTINCT FROM OLD.git_commit_sha OR
+            NEW.created_by IS DISTINCT FROM OLD.created_by OR
+            NEW.codex_worker_id IS DISTINCT FROM OLD.codex_worker_id OR
+            NEW.created_at IS DISTINCT FROM OLD.created_at
+          ) THEN
+            RAISE EXCEPTION 'SolutionDeployment runtime closure is write-once';
+          END IF;
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        CREATE TRIGGER trg_solution_deployment_integrity
+          BEFORE INSERT OR UPDATE ON solution_deployments
+          FOR EACH ROW EXECUTE FUNCTION enforce_solution_deployment_integrity();
+
+        CREATE FUNCTION prevent_solution_deployment_delete() RETURNS trigger AS $$
+        BEGIN
+          RAISE EXCEPTION 'SolutionDeployment history cannot be deleted';
+        END;
+        $$ LANGUAGE plpgsql;
+        CREATE TRIGGER trg_solution_deployment_no_delete
+          BEFORE DELETE ON solution_deployments
+          FOR EACH ROW EXECUTE FUNCTION prevent_solution_deployment_delete();
+
+        CREATE FUNCTION enforce_solution_dependency_integrity() RETURNS trigger AS $$
+        DECLARE owner_org uuid; dependency_org uuid;
+        BEGIN
+          SELECT organization_id INTO owner_org FROM solution_deployments WHERE id = NEW.deployment_id;
+          SELECT organization_id INTO dependency_org FROM solution_deployments
+            WHERE id = NEW.dependency_deployment_id;
+          IF dependency_org IS NOT NULL AND dependency_org IS DISTINCT FROM owner_org THEN
+            RAISE EXCEPTION 'dependency deployment must be global or in the owning organization';
+          END IF;
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        CREATE TRIGGER trg_solution_dependency_integrity
+          BEFORE INSERT ON solution_deployment_dependencies
+          FOR EACH ROW EXECUTE FUNCTION enforce_solution_dependency_integrity();
+        CREATE TRIGGER trg_solution_dependency_immutable
+          BEFORE UPDATE OR DELETE ON solution_deployment_dependencies
+          FOR EACH ROW EXECUTE FUNCTION prevent_solution_deployment_delete();
+        """
     )
 
 
 def downgrade() -> None:
+    op.execute(
+        """
+        DROP TRIGGER trg_solution_dependency_immutable ON solution_deployment_dependencies;
+        DROP TRIGGER trg_solution_dependency_integrity ON solution_deployment_dependencies;
+        DROP FUNCTION enforce_solution_dependency_integrity();
+        DROP TRIGGER trg_solution_deployment_no_delete ON solution_deployments;
+        DROP TRIGGER trg_solution_deployment_integrity ON solution_deployments;
+        DROP FUNCTION prevent_solution_deployment_delete();
+        DROP FUNCTION enforce_solution_deployment_integrity();
+        """
+    )
     op.drop_constraint(
         "fk_solutions_active_deployment", "solutions", type_="foreignkey"
     )

--- a/api/alembic/versions/20260716_solution_deployments.py
+++ b/api/alembic/versions/20260716_solution_deployments.py
@@ -181,19 +181,33 @@ def upgrade() -> None:
           RETURN NEW;
         END;
         $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
         CREATE TRIGGER trg_solution_deployment_integrity
           BEFORE INSERT OR UPDATE ON solution_deployments
           FOR EACH ROW EXECUTE FUNCTION enforce_solution_deployment_integrity();
-
+        """
+    )
+    op.execute(
+        """
         CREATE FUNCTION prevent_solution_deployment_delete() RETURNS trigger AS $$
         BEGIN
           RAISE EXCEPTION 'SolutionDeployment history cannot be deleted';
         END;
         $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
         CREATE TRIGGER trg_solution_deployment_no_delete
           BEFORE DELETE ON solution_deployments
           FOR EACH ROW EXECUTE FUNCTION prevent_solution_deployment_delete();
-
+        """
+    )
+    op.execute(
+        """
         CREATE FUNCTION enforce_solution_dependency_integrity() RETURNS trigger AS $$
         DECLARE owner_org uuid; dependency_org uuid;
         BEGIN
@@ -206,9 +220,17 @@ def upgrade() -> None:
           RETURN NEW;
         END;
         $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
         CREATE TRIGGER trg_solution_dependency_integrity
           BEFORE INSERT ON solution_deployment_dependencies
           FOR EACH ROW EXECUTE FUNCTION enforce_solution_dependency_integrity();
+        """
+    )
+    op.execute(
+        """
         CREATE TRIGGER trg_solution_dependency_immutable
           BEFORE UPDATE OR DELETE ON solution_deployment_dependencies
           FOR EACH ROW EXECUTE FUNCTION prevent_solution_deployment_delete();
@@ -217,17 +239,16 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        """
-        DROP TRIGGER trg_solution_dependency_immutable ON solution_deployment_dependencies;
-        DROP TRIGGER trg_solution_dependency_integrity ON solution_deployment_dependencies;
-        DROP FUNCTION enforce_solution_dependency_integrity();
-        DROP TRIGGER trg_solution_deployment_no_delete ON solution_deployments;
-        DROP TRIGGER trg_solution_deployment_integrity ON solution_deployments;
-        DROP FUNCTION prevent_solution_deployment_delete();
-        DROP FUNCTION enforce_solution_deployment_integrity();
-        """
-    )
+    for statement in (
+        "DROP TRIGGER trg_solution_dependency_immutable ON solution_deployment_dependencies",
+        "DROP TRIGGER trg_solution_dependency_integrity ON solution_deployment_dependencies",
+        "DROP FUNCTION enforce_solution_dependency_integrity()",
+        "DROP TRIGGER trg_solution_deployment_no_delete ON solution_deployments",
+        "DROP TRIGGER trg_solution_deployment_integrity ON solution_deployments",
+        "DROP FUNCTION prevent_solution_deployment_delete()",
+        "DROP FUNCTION enforce_solution_deployment_integrity()",
+    ):
+        op.execute(statement)
     op.drop_constraint(
         "fk_solutions_active_deployment", "solutions", type_="foreignkey"
     )

--- a/api/alembic/versions/20260716_solution_deployments.py
+++ b/api/alembic/versions/20260716_solution_deployments.py
@@ -138,6 +138,9 @@ def upgrade() -> None:
           IF NOT FOUND OR solution_org IS DISTINCT FROM NEW.organization_id THEN
             RAISE EXCEPTION 'deployment organization scope must match its Solution install';
           END IF;
+          IF TG_OP = 'INSERT' AND NEW.state <> 'draft' THEN
+            RAISE EXCEPTION 'new SolutionDeployment must start in draft';
+          END IF;
           IF TG_OP = 'UPDATE' AND NOT (
             (OLD.state = 'draft' AND NEW.state IN ('draft','building','aborted')) OR
             (OLD.state = 'building' AND NEW.state IN ('building','validated','failed','aborted')) OR
@@ -209,9 +212,13 @@ def upgrade() -> None:
     op.execute(
         """
         CREATE FUNCTION enforce_solution_dependency_integrity() RETURNS trigger AS $$
-        DECLARE owner_org uuid; dependency_org uuid;
+        DECLARE owner_org uuid; owner_state text; dependency_org uuid;
         BEGIN
-          SELECT organization_id INTO owner_org FROM solution_deployments WHERE id = NEW.deployment_id;
+          SELECT organization_id, state INTO owner_org, owner_state
+            FROM solution_deployments WHERE id = NEW.deployment_id;
+          IF NOT FOUND OR owner_state NOT IN ('draft', 'building') THEN
+            RAISE EXCEPTION 'dependency closure is immutable after validation';
+          END IF;
           SELECT organization_id INTO dependency_org FROM solution_deployments
             WHERE id = NEW.dependency_deployment_id;
           IF dependency_org IS NOT NULL AND dependency_org IS DISTINCT FROM owner_org THEN

--- a/api/src/models/orm/__init__.py
+++ b/api/src/models/orm/__init__.py
@@ -48,6 +48,10 @@ from src.models.orm.organizations import Organization
 from src.models.orm.pending_capture import PendingCaptureORM
 from src.models.orm.solution_config_schema import SolutionConfigSchema
 from src.models.orm.solution_deploy_jobs import SolutionDeployJob
+from src.models.orm.solution_deployments import (
+    SolutionDeployment,
+    SolutionDeploymentDependency,
+)
 from src.models.orm.solution_connection_schema import SolutionConnectionSchema
 from src.models.orm.solution_file_location import SolutionFileLocation
 from src.models.orm.solutions import Solution
@@ -75,6 +79,8 @@ __all__ = [
     "SolutionConnectionSchema",
     "SolutionFileLocation",
     "SolutionDeployJob",
+    "SolutionDeployment",
+    "SolutionDeploymentDependency",
     "SolutionExportJob",
     "PendingCaptureORM",
     # Applications (App Builder)

--- a/api/src/models/orm/solution_deployments.py
+++ b/api/src/models/orm/solution_deployments.py
@@ -1,0 +1,96 @@
+"""Immutable Solution deployment revisions and exact dependency edges."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.orm.base import Base
+
+
+class SolutionDeployment(Base):
+    """An immutable candidate or activated runtime closure for a Solution."""
+
+    __tablename__ = "solution_deployments"
+    __table_args__ = (
+        Index("ix_solution_deployments_solution_created", "solution_id", "created_at"),
+        Index("ix_solution_deployments_org_state", "organization_id", "state"),
+        CheckConstraint(
+            "state IN ('draft','building','validated','ready','activating','active',"
+            "'superseded','conflicted','failed','recovery_required','aborted',"
+            "'committed_unpushed')",
+            name="ck_solution_deployments_state",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    organization_id: Mapped[UUID] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    solution_id: Mapped[UUID] = mapped_column(
+        ForeignKey("solutions.id", ondelete="CASCADE"), nullable=False
+    )
+    parent_deployment_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("solution_deployments.id", ondelete="SET NULL"), nullable=True
+    )
+    base_deployment_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("solution_deployments.id", ondelete="SET NULL"), nullable=True
+    )
+    state: Mapped[str] = mapped_column(String(32), nullable=False, default="draft")
+    declared_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    bundle_hash: Mapped[str] = mapped_column(String(71), nullable=False)
+    compiled_manifest: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    compiled_manifest_hash: Mapped[str] = mapped_column(String(71), nullable=False)
+    resolution_map: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    source_artifact_key: Mapped[str] = mapped_column(String(2048), nullable=False)
+    runtime_storage_prefix: Mapped[str] = mapped_column(String(2048), nullable=False)
+    git_repository: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    git_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    git_commit_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    git_push_state: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    created_by: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    codex_worker_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    validation_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    failure_detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+    )
+    validated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    superseded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    dependencies: Mapped[list["SolutionDeploymentDependency"]] = relationship(
+        back_populates="deployment",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        foreign_keys="SolutionDeploymentDependency.deployment_id",
+    )
+
+
+class SolutionDeploymentDependency(Base):
+    """Exact immutable dependency deployment selected during compilation."""
+
+    __tablename__ = "solution_deployment_dependencies"
+    deployment_id: Mapped[UUID] = mapped_column(
+        ForeignKey("solution_deployments.id", ondelete="CASCADE"), primary_key=True
+    )
+    dependency_solution_id: Mapped[UUID] = mapped_column(
+        ForeignKey("solutions.id", ondelete="RESTRICT"), primary_key=True
+    )
+    dependency_deployment_id: Mapped[UUID] = mapped_column(
+        ForeignKey("solution_deployments.id", ondelete="RESTRICT"), nullable=False
+    )
+    declared_constraint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resolved_bundle_hash: Mapped[str] = mapped_column(String(71), nullable=False)
+
+    deployment: Mapped[SolutionDeployment] = relationship(
+        back_populates="dependencies", foreign_keys=[deployment_id]
+    )

--- a/api/src/models/orm/solution_deployments.py
+++ b/api/src/models/orm/solution_deployments.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, text
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -19,6 +29,19 @@ class SolutionDeployment(Base):
     __table_args__ = (
         Index("ix_solution_deployments_solution_created", "solution_id", "created_at"),
         Index("ix_solution_deployments_org_state", "organization_id", "state"),
+        UniqueConstraint("id", "solution_id", name="uq_solution_deployment_id_solution"),
+        ForeignKeyConstraint(
+            ["parent_deployment_id", "solution_id"],
+            ["solution_deployments.id", "solution_deployments.solution_id"],
+            name="fk_solution_deployment_parent_same_solution",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["base_deployment_id", "solution_id"],
+            ["solution_deployments.id", "solution_deployments.solution_id"],
+            name="fk_solution_deployment_base_same_solution",
+            ondelete="RESTRICT",
+        ),
         CheckConstraint(
             "state IN ('draft','building','validated','ready','activating','active',"
             "'superseded','conflicted','failed','recovery_required','aborted',"
@@ -28,24 +51,21 @@ class SolutionDeployment(Base):
     )
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    organization_id: Mapped[UUID] = mapped_column(
-        ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    organization_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="RESTRICT"), nullable=True
     )
     solution_id: Mapped[UUID] = mapped_column(
-        ForeignKey("solutions.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("solutions.id", ondelete="RESTRICT"), nullable=False
     )
-    parent_deployment_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("solution_deployments.id", ondelete="SET NULL"), nullable=True
-    )
-    base_deployment_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("solution_deployments.id", ondelete="SET NULL"), nullable=True
-    )
+    parent_deployment_id: Mapped[UUID | None] = mapped_column(nullable=True)
+    base_deployment_id: Mapped[UUID | None] = mapped_column(nullable=True)
     state: Mapped[str] = mapped_column(String(32), nullable=False, default="draft")
     declared_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     bundle_hash: Mapped[str] = mapped_column(String(71), nullable=False)
     compiled_manifest: Mapped[dict] = mapped_column(JSONB, nullable=False)
     compiled_manifest_hash: Mapped[str] = mapped_column(String(71), nullable=False)
     resolution_map: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    resolution_map_hash: Mapped[str] = mapped_column(String(71), nullable=False)
     source_artifact_key: Mapped[str] = mapped_column(String(2048), nullable=False)
     runtime_storage_prefix: Mapped[str] = mapped_column(String(2048), nullable=False)
     git_repository: Mapped[str | None] = mapped_column(String(2048), nullable=True)
@@ -69,7 +89,6 @@ class SolutionDeployment(Base):
 
     dependencies: Mapped[list["SolutionDeploymentDependency"]] = relationship(
         back_populates="deployment",
-        cascade="all, delete-orphan",
         lazy="selectin",
         foreign_keys="SolutionDeploymentDependency.deployment_id",
     )
@@ -79,15 +98,21 @@ class SolutionDeploymentDependency(Base):
     """Exact immutable dependency deployment selected during compilation."""
 
     __tablename__ = "solution_deployment_dependencies"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["dependency_deployment_id", "dependency_solution_id"],
+            ["solution_deployments.id", "solution_deployments.solution_id"],
+            name="fk_solution_dependency_exact_deployment",
+            ondelete="RESTRICT",
+        ),
+    )
     deployment_id: Mapped[UUID] = mapped_column(
-        ForeignKey("solution_deployments.id", ondelete="CASCADE"), primary_key=True
+        ForeignKey("solution_deployments.id", ondelete="RESTRICT"), primary_key=True
     )
     dependency_solution_id: Mapped[UUID] = mapped_column(
         ForeignKey("solutions.id", ondelete="RESTRICT"), primary_key=True
     )
-    dependency_deployment_id: Mapped[UUID] = mapped_column(
-        ForeignKey("solution_deployments.id", ondelete="RESTRICT"), nullable=False
-    )
+    dependency_deployment_id: Mapped[UUID] = mapped_column(nullable=False)
     declared_constraint: Mapped[str | None] = mapped_column(Text, nullable=True)
     resolved_bundle_hash: Mapped[str] = mapped_column(String(71), nullable=False)
 

--- a/api/src/models/orm/solution_deployments.py
+++ b/api/src/models/orm/solution_deployments.py
@@ -21,6 +21,9 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.models.orm.base import Base
 
+_DEPLOYMENT_ID_COLUMN = "solution_deployments.id"
+_DEPLOYMENT_SOLUTION_COLUMN = "solution_deployments.solution_id"
+
 
 class SolutionDeployment(Base):
     """An immutable candidate or activated runtime closure for a Solution."""
@@ -32,13 +35,13 @@ class SolutionDeployment(Base):
         UniqueConstraint("id", "solution_id", name="uq_solution_deployment_id_solution"),
         ForeignKeyConstraint(
             ["parent_deployment_id", "solution_id"],
-            ["solution_deployments.id", "solution_deployments.solution_id"],
+            [_DEPLOYMENT_ID_COLUMN, _DEPLOYMENT_SOLUTION_COLUMN],
             name="fk_solution_deployment_parent_same_solution",
             ondelete="RESTRICT",
         ),
         ForeignKeyConstraint(
             ["base_deployment_id", "solution_id"],
-            ["solution_deployments.id", "solution_deployments.solution_id"],
+            [_DEPLOYMENT_ID_COLUMN, _DEPLOYMENT_SOLUTION_COLUMN],
             name="fk_solution_deployment_base_same_solution",
             ondelete="RESTRICT",
         ),
@@ -101,13 +104,13 @@ class SolutionDeploymentDependency(Base):
     __table_args__ = (
         ForeignKeyConstraint(
             ["dependency_deployment_id", "dependency_solution_id"],
-            ["solution_deployments.id", "solution_deployments.solution_id"],
+            [_DEPLOYMENT_ID_COLUMN, _DEPLOYMENT_SOLUTION_COLUMN],
             name="fk_solution_dependency_exact_deployment",
             ondelete="RESTRICT",
         ),
     )
     deployment_id: Mapped[UUID] = mapped_column(
-        ForeignKey("solution_deployments.id", ondelete="RESTRICT"), primary_key=True
+        ForeignKey(_DEPLOYMENT_ID_COLUMN, ondelete="RESTRICT"), primary_key=True
     )
     dependency_solution_id: Mapped[UUID] = mapped_column(
         ForeignKey("solutions.id", ondelete="RESTRICT"), primary_key=True

--- a/api/src/models/orm/solutions.py
+++ b/api/src/models/orm/solutions.py
@@ -25,7 +25,17 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, LargeBinary, String, Text, text
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    LargeBinary,
+    String,
+    Text,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.models.orm.base import Base
@@ -50,6 +60,13 @@ class Solution(Base):
     # equal in a plain unique index, so global installs need a slug-only partial
     # index of their own. Mirrors migration 20260605_solution_unique_scope.
     __table_args__ = (
+        ForeignKeyConstraint(
+            ["active_deployment_id", "id"],
+            ["solution_deployments.id", "solution_deployments.solution_id"],
+            name="fk_solutions_active_deployment",
+            ondelete="RESTRICT",
+            use_alter=True,
+        ),
         Index(
             "ix_solutions_slug_org_unique",
             "slug",
@@ -70,12 +87,6 @@ class Solution(Base):
     # Selects the immutable runtime closure used by newly created executions.
     # Existing installs remain NULL until captured as an initial deployment.
     active_deployment_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey(
-            "solution_deployments.id",
-            name="fk_solutions_active_deployment",
-            ondelete="SET NULL",
-            use_alter=True,
-        ),
         nullable=True,
         default=None,
     )

--- a/api/src/models/orm/solutions.py
+++ b/api/src/models/orm/solutions.py
@@ -67,6 +67,19 @@ class Solution(Base):
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
 
+    # Selects the immutable runtime closure used by newly created executions.
+    # Existing installs remain NULL until captured as an initial deployment.
+    active_deployment_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey(
+            "solution_deployments.id",
+            name="fk_solutions_active_deployment",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        nullable=True,
+        default=None,
+    )
+
     # Definition identity (shared across installs of the same Solution).
     slug: Mapped[str] = mapped_column(String(255), index=True)
     name: Mapped[str] = mapped_column(String(255))

--- a/api/src/repositories/solution_deployments.py
+++ b/api/src/repositories/solution_deployments.py
@@ -1,0 +1,33 @@
+"""Persistence for immutable Solution deployment runtime closures."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.models.orm.solution_deployments import SolutionDeployment
+from src.repositories.base import BaseRepository
+
+
+class SolutionDeploymentRepository(BaseRepository[SolutionDeployment]):  # type: ignore[type-var]
+    model = SolutionDeployment
+
+    def __init__(self, session: AsyncSession):
+        super().__init__(session)
+
+    async def get_runtime_closure(
+        self, deployment_id: UUID, organization_id: UUID
+    ) -> SolutionDeployment | None:
+        """Read one tenant-scoped deployment together with exact dependency edges."""
+        result = await self.session.execute(
+            select(SolutionDeployment)
+            .options(selectinload(SolutionDeployment.dependencies))
+            .where(
+                SolutionDeployment.id == deployment_id,
+                SolutionDeployment.organization_id == organization_id,
+            )
+        )
+        return result.scalar_one_or_none()

--- a/api/src/repositories/solution_deployments.py
+++ b/api/src/repositories/solution_deployments.py
@@ -1,33 +1,111 @@
-"""Persistence for immutable Solution deployment runtime closures."""
+"""Narrow, scope-safe persistence for immutable deployment closures."""
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.models.orm.solution_deployments import SolutionDeployment
-from src.repositories.base import BaseRepository
+from src.models.orm.solutions import Solution
+from src.services.solutions.deployment_manifest import validate_runtime_closure
 
 
-class SolutionDeploymentRepository(BaseRepository[SolutionDeployment]):  # type: ignore[type-var]
-    model = SolutionDeployment
+class InvalidDeploymentTransition(ValueError):
+    pass
+
+
+_TRANSITIONS: dict[str, frozenset[str]] = {
+    "draft": frozenset({"building", "aborted"}),
+    "building": frozenset({"validated", "failed", "aborted"}),
+    "validated": frozenset({"ready", "aborted"}),
+    "ready": frozenset({"activating", "aborted"}),
+    "activating": frozenset({"active", "conflicted", "failed", "recovery_required"}),
+    "active": frozenset({"superseded", "committed_unpushed", "recovery_required"}),
+    "committed_unpushed": frozenset({"active", "superseded", "recovery_required"}),
+}
+
+
+class SolutionDeploymentRepository:
+    """Create and transition deployments without exposing generic CRUD escape hatches."""
 
     def __init__(self, session: AsyncSession):
-        super().__init__(session)
+        self.session = session
+
+    @staticmethod
+    def _scope_clause(organization_id: UUID | None):
+        column = SolutionDeployment.organization_id
+        return column.is_(None) if organization_id is None else column == organization_id
+
+    async def create(self, deployment: SolutionDeployment) -> SolutionDeployment:
+        solution_org = await self.session.scalar(
+            select(Solution.organization_id).where(Solution.id == deployment.solution_id)
+        )
+        if solution_org != deployment.organization_id:
+            raise ValueError("deployment scope must exactly match its Solution install")
+        validate_runtime_closure(
+            deployment.compiled_manifest,
+            deployment.resolution_map,
+            deployment.dependencies,
+            expected_manifest_hash=deployment.compiled_manifest_hash,
+            expected_resolution_hash=deployment.resolution_map_hash,
+        )
+        self.session.add(deployment)
+        await self.session.flush()
+        return deployment
 
     async def get_runtime_closure(
-        self, deployment_id: UUID, organization_id: UUID
+        self, deployment_id: UUID, organization_id: UUID | None
     ) -> SolutionDeployment | None:
-        """Read one tenant-scoped deployment together with exact dependency edges."""
         result = await self.session.execute(
             select(SolutionDeployment)
             .options(selectinload(SolutionDeployment.dependencies))
             .where(
                 SolutionDeployment.id == deployment_id,
-                SolutionDeployment.organization_id == organization_id,
+                self._scope_clause(organization_id),
             )
         )
         return result.scalar_one_or_none()
+
+    async def transition(
+        self,
+        deployment_id: UUID,
+        organization_id: UUID | None,
+        *,
+        expected_state: str,
+        new_state: str,
+        validated_at: datetime | None = None,
+        activated_at: datetime | None = None,
+        superseded_at: datetime | None = None,
+        validation_result: dict | None = None,
+        failure_detail: dict | None = None,
+        git_push_state: str | None = None,
+    ) -> SolutionDeployment:
+        if new_state not in _TRANSITIONS.get(expected_state, frozenset()):
+            raise InvalidDeploymentTransition(f"{expected_state} -> {new_state}")
+        values = {
+            "state": new_state,
+            "validated_at": validated_at,
+            "activated_at": activated_at,
+            "superseded_at": superseded_at,
+            "validation_result": validation_result,
+            "failure_detail": failure_detail,
+            "git_push_state": git_push_state,
+        }
+        result = await self.session.execute(
+            update(SolutionDeployment)
+            .where(
+                SolutionDeployment.id == deployment_id,
+                self._scope_clause(organization_id),
+                SolutionDeployment.state == expected_state,
+            )
+            .values(**values)
+            .returning(SolutionDeployment)
+        )
+        deployment = result.scalar_one_or_none()
+        if deployment is None:
+            raise InvalidDeploymentTransition("deployment missing, out of scope, or state changed")
+        return deployment

--- a/api/src/repositories/solution_deployments.py
+++ b/api/src/repositories/solution_deployments.py
@@ -18,6 +18,13 @@ class InvalidDeploymentTransition(ValueError):
     pass
 
 
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()
+
+
 _TRANSITIONS: dict[str, frozenset[str]] = {
     "draft": frozenset({"building", "aborted"}),
     "building": frozenset({"validated", "failed", "aborted"}),
@@ -77,17 +84,17 @@ class SolutionDeploymentRepository:
         *,
         expected_state: str,
         new_state: str,
-        validated_at: datetime | None = None,
-        activated_at: datetime | None = None,
-        superseded_at: datetime | None = None,
-        validation_result: dict | None = None,
-        failure_detail: dict | None = None,
-        git_push_state: str | None = None,
+        validated_at: datetime | None | _Unset = _UNSET,
+        activated_at: datetime | None | _Unset = _UNSET,
+        superseded_at: datetime | None | _Unset = _UNSET,
+        validation_result: dict | None | _Unset = _UNSET,
+        failure_detail: dict | None | _Unset = _UNSET,
+        git_push_state: str | None | _Unset = _UNSET,
     ) -> SolutionDeployment:
         if new_state not in _TRANSITIONS.get(expected_state, frozenset()):
             raise InvalidDeploymentTransition(f"{expected_state} -> {new_state}")
-        values = {
-            "state": new_state,
+        values: dict[str, object] = {"state": new_state}
+        optional_values = {
             "validated_at": validated_at,
             "activated_at": activated_at,
             "superseded_at": superseded_at,
@@ -95,6 +102,9 @@ class SolutionDeploymentRepository:
             "failure_detail": failure_detail,
             "git_push_state": git_push_state,
         }
+        values.update(
+            {key: value for key, value in optional_values.items() if value is not _UNSET}
+        )
         result = await self.session.execute(
             update(SolutionDeployment)
             .where(

--- a/api/src/services/file_storage/azure_blob_client.py
+++ b/api/src/services/file_storage/azure_blob_client.py
@@ -187,6 +187,7 @@ class AzureBlobStorageClient:
         Key: str,
         Body: bytes,
         ContentType: str | None = None,
+        IfNoneMatch: str | None = None,
     ) -> None:
         del Bucket
         from azure.storage.blob import ContentSettings
@@ -195,7 +196,7 @@ class AzureBlobStorageClient:
         await self._container_client.upload_blob(
             name=Key,
             data=Body,
-            overwrite=True,
+            overwrite=IfNoneMatch != "*",
             content_settings=ContentSettings(content_type=ContentType),
         )
 

--- a/api/src/services/solutions/deployment_manifest.py
+++ b/api/src/services/solutions/deployment_manifest.py
@@ -168,11 +168,24 @@ def validate_runtime_closure(
     if manifest.content_hash() != expected_manifest_hash:
         raise ValueError("compiled manifest hash mismatch")
 
+    _validate_manifest_resolution_agreement(manifest, resolution)
+    _validate_entity_sources(resolution)
+    _validate_dependency_edges(manifest, dependency_edges)
+    return manifest, resolution
+
+
+def _validate_manifest_resolution_agreement(
+    manifest: CompiledDeploymentManifest,
+    resolution: DeploymentResolutionMap,
+) -> None:
     for kind in ("workflows", "agents", "forms", "events", "applications"):
         if getattr(manifest, kind) != getattr(resolution, kind):
             raise ValueError(f"manifest/resolution mismatch for {kind}")
     if manifest.dependencies != resolution.dependencies:
         raise ValueError("manifest/resolution dependency mismatch")
+
+
+def _validate_entity_sources(resolution: DeploymentResolutionMap) -> None:
     for entities in (
         resolution.workflows,
         resolution.agents,
@@ -188,6 +201,11 @@ def validate_runtime_closure(
                 if source is None or source.content_hash != entity.source_hash:
                     raise ValueError(f"source resolution mismatch: {entity.source_ref}")
 
+
+def _validate_dependency_edges(
+    manifest: CompiledDeploymentManifest,
+    dependency_edges: list[Any],
+) -> None:
     expected_edges = {
         (edge.dependency_solution_id, edge.dependency_deployment_id, edge.resolved_bundle_hash)
         for edge in dependency_edges
@@ -198,4 +216,3 @@ def validate_runtime_closure(
     }
     if expected_edges != manifest_edges:
         raise ValueError("relational dependency edges do not match the manifest")
-    return manifest, resolution

--- a/api/src/services/solutions/deployment_manifest.py
+++ b/api/src/services/solutions/deployment_manifest.py
@@ -7,7 +7,7 @@ import json
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 
 def canonical_json(value: BaseModel | dict[str, Any]) -> bytes:
@@ -18,8 +18,12 @@ def canonical_json(value: BaseModel | dict[str, Any]) -> bytes:
         else value
     )
     return json.dumps(
-        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    ).encode()
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
 
 
 def sha256_digest(data: bytes) -> str:
@@ -38,7 +42,7 @@ class DeploymentSource(ImmutableContract):
 class RuntimeEntityDefinition(ImmutableContract):
     portable_ref: str
     resolved_id: UUID
-    definition: dict[str, Any]
+    definition: dict[str, JsonValue]
     source_ref: str | None = None
     source_hash: str | None = None
     dependency_solution_id: UUID | None = None
@@ -67,6 +71,7 @@ class CompiledDeploymentManifest(ImmutableContract):
     solution_id: UUID
     deployment_id: UUID
     bundle_hash: str
+    resolution_map_hash: str
     source: DeploymentSource
     workflows: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
     agents: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
@@ -119,3 +124,78 @@ class DeploymentResolutionMap(ImmutableContract):
 
     def resolve_source(self, source_ref: str) -> RuntimeSourceResolution:
         return self.sources[source_ref]
+
+    def resolve_workflow_id(self, resolved_id: UUID) -> RuntimeEntityDefinition:
+        return self._resolve_id(self.workflows, resolved_id)
+
+    def resolve_agent_id(self, resolved_id: UUID) -> RuntimeEntityDefinition:
+        return self._resolve_id(self.agents, resolved_id)
+
+    @staticmethod
+    def _resolve_id(
+        entities: dict[str, RuntimeEntityDefinition], resolved_id: UUID
+    ) -> RuntimeEntityDefinition:
+        matches = [entity for entity in entities.values() if entity.resolved_id == resolved_id]
+        if len(matches) != 1:
+            raise KeyError(resolved_id)
+        return matches[0]
+
+
+def validate_runtime_closure(
+    manifest_value: CompiledDeploymentManifest | dict[str, Any],
+    resolution_value: DeploymentResolutionMap | dict[str, Any],
+    dependency_edges: list[Any],
+    *,
+    expected_manifest_hash: str,
+    expected_resolution_hash: str,
+) -> tuple[CompiledDeploymentManifest, DeploymentResolutionMap]:
+    """Prove that all duplicated closure evidence describes one immutable runtime."""
+    manifest = (
+        manifest_value
+        if isinstance(manifest_value, CompiledDeploymentManifest)
+        else CompiledDeploymentManifest.model_validate(manifest_value)
+    )
+    resolution = (
+        resolution_value
+        if isinstance(resolution_value, DeploymentResolutionMap)
+        else DeploymentResolutionMap.model_validate(resolution_value)
+    )
+    resolution_hash = sha256_digest(canonical_json(resolution))
+    if resolution_hash != expected_resolution_hash:
+        raise ValueError("resolution map hash mismatch")
+    if manifest.resolution_map_hash != resolution_hash:
+        raise ValueError("manifest does not anchor the resolution map")
+    if manifest.content_hash() != expected_manifest_hash:
+        raise ValueError("compiled manifest hash mismatch")
+
+    for kind in ("workflows", "agents", "forms", "events", "applications"):
+        if getattr(manifest, kind) != getattr(resolution, kind):
+            raise ValueError(f"manifest/resolution mismatch for {kind}")
+    if manifest.dependencies != resolution.dependencies:
+        raise ValueError("manifest/resolution dependency mismatch")
+    for entities in (
+        resolution.workflows,
+        resolution.agents,
+        resolution.forms,
+        resolution.events,
+        resolution.applications,
+    ):
+        for portable_ref, entity in entities.items():
+            if portable_ref != entity.portable_ref:
+                raise ValueError(f"portable reference key mismatch: {portable_ref}")
+            if entity.source_ref is not None:
+                source = resolution.sources.get(entity.source_ref)
+                if source is None or source.content_hash != entity.source_hash:
+                    raise ValueError(f"source resolution mismatch: {entity.source_ref}")
+
+    expected_edges = {
+        (edge.dependency_solution_id, edge.dependency_deployment_id, edge.resolved_bundle_hash)
+        for edge in dependency_edges
+    }
+    manifest_edges = {
+        (item.solution_id, item.deployment_id, item.bundle_hash)
+        for item in manifest.dependencies.values()
+    }
+    if expected_edges != manifest_edges:
+        raise ValueError("relational dependency edges do not match the manifest")
+    return manifest, resolution

--- a/api/src/services/solutions/deployment_manifest.py
+++ b/api/src/services/solutions/deployment_manifest.py
@@ -1,0 +1,121 @@
+"""Canonical immutable runtime-closure contracts for Solution deployments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def canonical_json(value: BaseModel | dict[str, Any]) -> bytes:
+    """Serialize a deployment document deterministically for hashing/storage."""
+    payload = (
+        value.model_dump(mode="json", exclude_none=True)
+        if isinstance(value, BaseModel)
+        else value
+    )
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode()
+
+
+def sha256_digest(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+class ImmutableContract(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class DeploymentSource(ImmutableContract):
+    artifact_key: str
+    runtime_prefix: str
+
+
+class RuntimeEntityDefinition(ImmutableContract):
+    portable_ref: str
+    resolved_id: UUID
+    definition: dict[str, Any]
+    source_ref: str | None = None
+    source_hash: str | None = None
+    dependency_solution_id: UUID | None = None
+
+
+class RuntimeSourceResolution(ImmutableContract):
+    object_key: str
+    content_hash: str
+
+
+class DependencyResolution(ImmutableContract):
+    solution_id: UUID
+    deployment_id: UUID
+    declared_constraint: str | None = None
+    bundle_hash: str
+
+
+class DeploymentGitProvenance(ImmutableContract):
+    repository: str | None = None
+    resolved_ref: str | None = None
+    commit_sha: str | None = None
+
+
+class CompiledDeploymentManifest(ImmutableContract):
+    schema_version: Literal[1] = 1
+    solution_id: UUID
+    deployment_id: UUID
+    bundle_hash: str
+    source: DeploymentSource
+    workflows: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    agents: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    forms: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    events: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    applications: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    tables: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    file_locations: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    connections: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    config_requirements: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    dependencies: dict[str, DependencyResolution] = Field(default_factory=dict)
+    git: DeploymentGitProvenance = Field(default_factory=DeploymentGitProvenance)
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_json(self)
+
+    def content_hash(self) -> str:
+        return sha256_digest(self.canonical_bytes())
+
+
+class DeploymentResolutionMap(ImmutableContract):
+    """Deployment-local lookup document consumed by the future runtime adapter."""
+
+    schema_version: Literal[1] = 1
+    workflows: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    agents: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    forms: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    events: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    applications: dict[str, RuntimeEntityDefinition] = Field(default_factory=dict)
+    dependencies: dict[str, DependencyResolution] = Field(default_factory=dict)
+    sources: dict[str, RuntimeSourceResolution] = Field(default_factory=dict)
+
+    def resolve_workflow(self, portable_ref: str) -> RuntimeEntityDefinition:
+        return self.workflows[portable_ref]
+
+    def resolve_agent(self, portable_ref: str) -> RuntimeEntityDefinition:
+        return self.agents[portable_ref]
+
+    def resolve_form(self, portable_ref: str) -> RuntimeEntityDefinition:
+        return self.forms[portable_ref]
+
+    def resolve_event(self, portable_ref: str) -> RuntimeEntityDefinition:
+        return self.events[portable_ref]
+
+    def resolve_application(self, portable_ref: str) -> RuntimeEntityDefinition:
+        return self.applications[portable_ref]
+
+    def resolve_dependency(self, solution_ref: str) -> UUID:
+        return self.dependencies[solution_ref].deployment_id
+
+    def resolve_source(self, source_ref: str) -> RuntimeSourceResolution:
+        return self.sources[source_ref]

--- a/api/src/services/solutions/deployment_manifest.py
+++ b/api/src/services/solutions/deployment_manifest.py
@@ -4,10 +4,38 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+
+
+class FrozenDict(dict):
+    """JSON-compatible dict whose contents cannot change after validation."""
+
+    @staticmethod
+    def _immutable(*_args: Any, **_kwargs: Any) -> None:
+        raise TypeError("deployment contract containers are immutable")
+
+    __setitem__ = _immutable
+    __delitem__ = _immutable
+    clear = _immutable
+    pop = _immutable
+    popitem = _immutable  # pyright: ignore[reportAssignmentType]
+    setdefault = _immutable
+    update = _immutable
+    __ior__ = _immutable  # pyright: ignore[reportAssignmentType]
+
+
+def _deep_freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return FrozenDict({key: _deep_freeze(item) for key, item in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_deep_freeze(item) for item in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_deep_freeze(item) for item in value)
+    return value
 
 
 def canonical_json(value: BaseModel | dict[str, Any]) -> bytes:
@@ -32,6 +60,12 @@ def sha256_digest(data: bytes) -> str:
 
 class ImmutableContract(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @model_validator(mode="after")
+    def _freeze_nested_containers(self) -> ImmutableContract:
+        for field_name in type(self).model_fields:
+            object.__setattr__(self, field_name, _deep_freeze(getattr(self, field_name)))
+        return self
 
 
 class DeploymentSource(ImmutableContract):
@@ -186,6 +220,9 @@ def _validate_manifest_resolution_agreement(
 
 
 def _validate_entity_sources(resolution: DeploymentResolutionMap) -> None:
+    dependency_solution_ids = {
+        dependency.solution_id for dependency in resolution.dependencies.values()
+    }
     for entities in (
         resolution.workflows,
         resolution.agents,
@@ -196,6 +233,13 @@ def _validate_entity_sources(resolution: DeploymentResolutionMap) -> None:
         for portable_ref, entity in entities.items():
             if portable_ref != entity.portable_ref:
                 raise ValueError(f"portable reference key mismatch: {portable_ref}")
+            if (
+                entity.dependency_solution_id is not None
+                and entity.dependency_solution_id not in dependency_solution_ids
+            ):
+                raise ValueError(
+                    f"undeclared dependency owner: {entity.dependency_solution_id}"
+                )
             if entity.source_ref is not None:
                 source = resolution.sources.get(entity.source_ref)
                 if source is None or source.content_hash != entity.source_hash:

--- a/api/src/services/solutions/deployment_storage.py
+++ b/api/src/services/solutions/deployment_storage.py
@@ -1,0 +1,136 @@
+"""Revision-addressed, create-only storage for immutable deployment content."""
+
+from __future__ import annotations
+
+from contextlib import AbstractAsyncContextManager
+from typing import Any, Callable
+from uuid import UUID
+
+from src.config import Settings, get_settings
+
+SOURCE_ARTIFACTS_ROOT = "_solution_artifacts"
+SOLUTION_MANIFESTS_ROOT = "_solution_manifests"
+SOLUTIONS_ROOT = "_solutions"
+
+
+class DeploymentArtifactIntegrityError(RuntimeError):
+    """A finalized deployment object already exists at the requested key."""
+
+
+def deployment_source_artifact_key(
+    solution_id: UUID | str, deployment_id: UUID | str
+) -> str:
+    return f"{SOURCE_ARTIFACTS_ROOT}/{solution_id}/{deployment_id}/source.zip"
+
+
+def deployment_manifest_key(solution_id: UUID | str, deployment_id: UUID | str) -> str:
+    return f"{SOLUTION_MANIFESTS_ROOT}/{solution_id}/{deployment_id}/manifest.json"
+
+
+def deployment_runtime_prefix(
+    solution_id: UUID | str, deployment_id: UUID | str
+) -> str:
+    return f"{SOLUTIONS_ROOT}/{solution_id}/{deployment_id}/"
+
+
+class SolutionDeploymentStorage:
+    """Writes finalized deployment objects exactly once."""
+
+    def __init__(
+        self,
+        solution_id: UUID | str,
+        deployment_id: UUID | str,
+        settings: Settings | None = None,
+        client_factory: Callable[[], AbstractAsyncContextManager[Any]] | None = None,
+    ):
+        self.solution_id = str(solution_id)
+        self.deployment_id = str(deployment_id)
+        self.settings = settings or get_settings()
+        if client_factory is None:
+            if self.settings.object_storage_provider == "azure_blob":
+                from src.services.file_storage.azure_blob_client import (
+                    AzureBlobStorageClient,
+                )
+
+                storage = AzureBlobStorageClient(self.settings)
+            else:
+                from src.services.file_storage.s3_client import S3StorageClient
+
+                storage = S3StorageClient(self.settings)
+            client_factory = storage.get_client
+        self._client_factory = client_factory
+        self._bucket = (
+            self.settings.azure_blob_container
+            if self.settings.object_storage_provider == "azure_blob"
+            else self.settings.s3_bucket
+        ) or ""
+
+    @property
+    def source_artifact_key(self) -> str:
+        return deployment_source_artifact_key(self.solution_id, self.deployment_id)
+
+    @property
+    def manifest_key(self) -> str:
+        return deployment_manifest_key(self.solution_id, self.deployment_id)
+
+    @property
+    def runtime_prefix(self) -> str:
+        return deployment_runtime_prefix(self.solution_id, self.deployment_id)
+
+    async def write_source_artifact(self, content: bytes) -> str:
+        await self._create(self.source_artifact_key, content, "application/zip")
+        return self.source_artifact_key
+
+    async def write_compiled_manifest(self, content: bytes) -> str:
+        await self._create(self.manifest_key, content, "application/json")
+        return self.manifest_key
+
+    async def write_runtime_file(self, path: str, content: bytes) -> str:
+        normalized = path.replace("\\", "/").lstrip("/")
+        if not normalized or any(
+            part in {"", ".", ".."} for part in normalized.split("/")
+        ):
+            raise ValueError(f"Invalid deployment runtime path: {path!r}")
+        key = f"{self.runtime_prefix}{normalized}"
+        await self._create(key, content, "application/octet-stream")
+        return key
+
+    async def _create(self, key: str, content: bytes, content_type: str) -> None:
+        async with self._client_factory() as client:
+            try:
+                await client.put_object(
+                    Bucket=self._bucket,
+                    Key=key,
+                    Body=content,
+                    ContentType=content_type,
+                    IfNoneMatch="*",
+                )
+            except Exception as exc:  # noqa: BLE001 - backend errors differ
+                if self._is_already_exists(exc):
+                    raise DeploymentArtifactIntegrityError(
+                        f"Finalized deployment object already exists: {key}"
+                    ) from exc
+                raise
+
+    @staticmethod
+    def _is_already_exists(exc: Exception) -> bool:
+        response = getattr(exc, "response", None)
+        status = (
+            response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            if isinstance(response, dict)
+            else None
+        )
+        code = (
+            response.get("Error", {}).get("Code")
+            if isinstance(response, dict)
+            else None
+        )
+        return (
+            status in {409, 412}
+            or code in {"PreconditionFailed", "BlobAlreadyExists"}
+            or type(exc).__name__
+            in {
+                "PreconditionFailed",
+                "ResourceExistsError",
+            }
+        )

--- a/api/tests/unit/services/solutions/test_deployment_manifest.py
+++ b/api/tests/unit/services/solutions/test_deployment_manifest.py
@@ -10,6 +10,9 @@ from src.services.solutions.deployment_manifest import (
     DeploymentSource,
     RuntimeEntityDefinition,
     RuntimeSourceResolution,
+    canonical_json,
+    sha256_digest,
+    validate_runtime_closure,
 )
 
 
@@ -28,10 +31,20 @@ def test_manifest_hash_is_canonical_and_contract_is_frozen():
         source_ref="workflows/triage.py",
         source_hash="sha256:abc",
     )
+    resolution = DeploymentResolutionMap(
+        workflows={workflow.portable_ref: workflow},
+        sources={
+            "workflows/triage.py": RuntimeSourceResolution(
+                object_key="runtime/workflows/triage.py", content_hash="sha256:abc"
+            )
+        },
+    )
+    resolution_hash = sha256_digest(canonical_json(resolution))
     first = CompiledDeploymentManifest(
         solution_id=solution_id,
         deployment_id=deployment_id,
         bundle_hash="sha256:bundle",
+        resolution_map_hash=resolution_hash,
         source=source,
         workflows={workflow.portable_ref: workflow},
     )
@@ -86,4 +99,57 @@ def test_contract_rejects_unknown_mutable_projection_fields():
                 "definition": {},
                 "active_orm_row": {"name": "mutable"},
             }
+        )
+
+
+def test_canonical_json_rejects_non_json_numbers():
+    with pytest.raises(ValueError):
+        canonical_json({"bad": float("nan")})
+
+
+def test_runtime_closure_anchors_resolution_and_supports_id_lookup():
+    solution_id = uuid4()
+    deployment_id = uuid4()
+    workflow = RuntimeEntityDefinition(
+        portable_ref="workflows/run.py::run",
+        resolved_id=uuid4(),
+        definition={"function_name": "run"},
+        source_ref="workflows/run.py",
+        source_hash="sha256:source",
+    )
+    resolution = DeploymentResolutionMap(
+        workflows={workflow.portable_ref: workflow},
+        sources={
+            "workflows/run.py": RuntimeSourceResolution(
+                object_key="runtime/workflows/run.py", content_hash="sha256:source"
+            )
+        },
+    )
+    resolution_hash = sha256_digest(canonical_json(resolution))
+    manifest = CompiledDeploymentManifest(
+        solution_id=solution_id,
+        deployment_id=deployment_id,
+        bundle_hash="sha256:bundle",
+        resolution_map_hash=resolution_hash,
+        source=DeploymentSource(artifact_key="source.zip", runtime_prefix="runtime/"),
+        workflows={workflow.portable_ref: workflow},
+    )
+
+    validate_runtime_closure(
+        manifest,
+        resolution,
+        [],
+        expected_manifest_hash=manifest.content_hash(),
+        expected_resolution_hash=resolution_hash,
+    )
+    assert resolution.resolve_workflow_id(workflow.resolved_id) == workflow
+
+    changed = resolution.model_copy(update={"workflows": {}})
+    with pytest.raises(ValueError, match="hash mismatch"):
+        validate_runtime_closure(
+            manifest,
+            changed,
+            [],
+            expected_manifest_hash=manifest.content_hash(),
+            expected_resolution_hash=resolution_hash,
         )

--- a/api/tests/unit/services/solutions/test_deployment_manifest.py
+++ b/api/tests/unit/services/solutions/test_deployment_manifest.py
@@ -1,0 +1,89 @@
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.services.solutions.deployment_manifest import (
+    CompiledDeploymentManifest,
+    DependencyResolution,
+    DeploymentResolutionMap,
+    DeploymentSource,
+    RuntimeEntityDefinition,
+    RuntimeSourceResolution,
+)
+
+
+def test_manifest_hash_is_canonical_and_contract_is_frozen():
+    solution_id = uuid4()
+    deployment_id = uuid4()
+    workflow_id = uuid4()
+    source = DeploymentSource(
+        artifact_key=f"_solution_artifacts/{solution_id}/{deployment_id}/source.zip",
+        runtime_prefix=f"_solutions/{solution_id}/{deployment_id}/",
+    )
+    workflow = RuntimeEntityDefinition(
+        portable_ref="workflows/triage.py::run",
+        resolved_id=workflow_id,
+        definition={"z": 2, "a": 1},
+        source_ref="workflows/triage.py",
+        source_hash="sha256:abc",
+    )
+    first = CompiledDeploymentManifest(
+        solution_id=solution_id,
+        deployment_id=deployment_id,
+        bundle_hash="sha256:bundle",
+        source=source,
+        workflows={workflow.portable_ref: workflow},
+    )
+    second = CompiledDeploymentManifest.model_validate(first.model_dump(mode="json"))
+
+    assert first.canonical_bytes() == second.canonical_bytes()
+    assert first.content_hash() == second.content_hash()
+    with pytest.raises(ValidationError):
+        first.bundle_hash = "sha256:changed"
+
+
+def test_resolution_map_uses_only_deployment_local_immutable_evidence():
+    dependency_deployment_id = uuid4()
+    workflow = RuntimeEntityDefinition(
+        portable_ref="workflows/triage.py::run",
+        resolved_id=uuid4(),
+        definition={"function_name": "run"},
+        source_ref="workflows/triage.py",
+        source_hash="sha256:source",
+    )
+    dependency = DependencyResolution(
+        solution_id=uuid4(),
+        deployment_id=dependency_deployment_id,
+        declared_constraint=">=2",
+        bundle_hash="sha256:dependency",
+    )
+    resolution_map = DeploymentResolutionMap(
+        workflows={workflow.portable_ref: workflow},
+        dependencies={"shared": dependency},
+        sources={
+            "workflows/triage.py": RuntimeSourceResolution(
+                object_key="_solutions/solution/deployment/workflows/triage.py",
+                content_hash="sha256:source",
+            )
+        },
+    )
+
+    assert resolution_map.resolve_workflow(workflow.portable_ref) == workflow
+    assert resolution_map.resolve_dependency("shared") == dependency_deployment_id
+    assert (
+        resolution_map.resolve_source("workflows/triage.py").content_hash
+        == "sha256:source"
+    )
+
+
+def test_contract_rejects_unknown_mutable_projection_fields():
+    with pytest.raises(ValidationError):
+        RuntimeEntityDefinition.model_validate(
+            {
+                "portable_ref": "workflow",
+                "resolved_id": uuid4(),
+                "definition": {},
+                "active_orm_row": {"name": "mutable"},
+            }
+        )

--- a/api/tests/unit/services/solutions/test_deployment_manifest.py
+++ b/api/tests/unit/services/solutions/test_deployment_manifest.py
@@ -27,7 +27,7 @@ def test_manifest_hash_is_canonical_and_contract_is_frozen():
     workflow = RuntimeEntityDefinition(
         portable_ref="workflows/triage.py::run",
         resolved_id=workflow_id,
-        definition={"z": 2, "a": 1},
+        definition={"z": 2, "a": {"values": [1, 2]}},
         source_ref="workflows/triage.py",
         source_hash="sha256:abc",
     )
@@ -54,6 +54,20 @@ def test_manifest_hash_is_canonical_and_contract_is_frozen():
     assert first.content_hash() == second.content_hash()
     with pytest.raises(ValidationError):
         first.bundle_hash = "sha256:changed"
+    original_hash = first.content_hash()
+    with pytest.raises(TypeError, match="immutable"):
+        workflow.definition["new"] = "value"
+    nested = workflow.definition["a"]
+    assert isinstance(nested, dict)
+    with pytest.raises(TypeError, match="immutable"):
+        nested["new"] = "value"
+    values = nested["values"]
+    assert isinstance(values, tuple)
+    with pytest.raises(AttributeError):
+        values.append(3)
+    with pytest.raises(TypeError, match="immutable"):
+        first.workflows["replacement"] = workflow
+    assert first.content_hash() == original_hash
 
 
 def test_resolution_map_uses_only_deployment_local_immutable_evidence():
@@ -149,6 +163,35 @@ def test_runtime_closure_anchors_resolution_and_supports_id_lookup():
         validate_runtime_closure(
             manifest,
             changed,
+            [],
+            expected_manifest_hash=manifest.content_hash(),
+            expected_resolution_hash=resolution_hash,
+        )
+
+
+def test_runtime_closure_rejects_undeclared_dependency_owner():
+    dependency_solution_id = uuid4()
+    workflow = RuntimeEntityDefinition(
+        portable_ref="workflows/run.py::run",
+        resolved_id=uuid4(),
+        definition={"function_name": "run"},
+        dependency_solution_id=dependency_solution_id,
+    )
+    resolution = DeploymentResolutionMap(workflows={workflow.portable_ref: workflow})
+    resolution_hash = sha256_digest(canonical_json(resolution))
+    manifest = CompiledDeploymentManifest(
+        solution_id=uuid4(),
+        deployment_id=uuid4(),
+        bundle_hash="sha256:bundle",
+        resolution_map_hash=resolution_hash,
+        source=DeploymentSource(artifact_key="source.zip", runtime_prefix="runtime/"),
+        workflows={workflow.portable_ref: workflow},
+    )
+
+    with pytest.raises(ValueError, match="undeclared dependency owner"):
+        validate_runtime_closure(
+            manifest,
+            resolution,
             [],
             expected_manifest_hash=manifest.content_hash(),
             expected_resolution_hash=resolution_hash,

--- a/api/tests/unit/services/solutions/test_deployment_storage.py
+++ b/api/tests/unit/services/solutions/test_deployment_storage.py
@@ -1,0 +1,75 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import uuid4
+
+import pytest
+
+from src.services.solutions.deployment_storage import (
+    DeploymentArtifactIntegrityError,
+    SolutionDeploymentStorage,
+)
+
+
+class ResourceExistsError(Exception):
+    pass
+
+
+class FakeClient:
+    def __init__(self):
+        self.objects: dict[str, bytes] = {}
+
+    async def put_object(self, *, Key, Body, IfNoneMatch, **kwargs):
+        assert IfNoneMatch == "*"
+        if Key in self.objects:
+            raise ResourceExistsError(Key)
+        self.objects[Key] = Body
+
+
+def make_storage(client: FakeClient):
+    @asynccontextmanager
+    async def client_factory():
+        yield client
+
+    settings = SimpleNamespace(
+        object_storage_provider="s3",
+        s3_bucket="test",
+        azure_blob_container=None,
+    )
+    return SolutionDeploymentStorage(
+        uuid4(), uuid4(), settings=cast(Any, settings), client_factory=client_factory
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalized_source_manifest_and_runtime_keys_are_revision_addressed():
+    client = FakeClient()
+    storage = make_storage(client)
+
+    source_key = await storage.write_source_artifact(b"zip")
+    manifest_key = await storage.write_compiled_manifest(b"{}")
+    runtime_key = await storage.write_runtime_file("workflows/run.py", b"code")
+
+    assert f"/{storage.deployment_id}/" in source_key
+    assert f"/{storage.deployment_id}/" in manifest_key
+    assert runtime_key == f"{storage.runtime_prefix}workflows/run.py"
+    assert client.objects[runtime_key] == b"code"
+
+
+@pytest.mark.asyncio
+async def test_finalized_objects_are_create_only():
+    client = FakeClient()
+    storage = make_storage(client)
+    await storage.write_compiled_manifest(b"first")
+
+    with pytest.raises(DeploymentArtifactIntegrityError):
+        await storage.write_compiled_manifest(b"replacement")
+
+    assert client.objects[storage.manifest_key] == b"first"
+
+
+@pytest.mark.asyncio
+async def test_runtime_path_rejects_traversal():
+    storage = make_storage(FakeClient())
+    with pytest.raises(ValueError):
+        await storage.write_runtime_file("../mutable.py", b"code")

--- a/api/tests/unit/services/solutions/test_deployment_storage.py
+++ b/api/tests/unit/services/solutions/test_deployment_storage.py
@@ -15,6 +15,14 @@ class ResourceExistsError(Exception):
     pass
 
 
+class S3PreconditionFailed(Exception):
+    def __init__(self):
+        self.response = {
+            "ResponseMetadata": {"HTTPStatusCode": 412},
+            "Error": {"Code": "PreconditionFailed"},
+        }
+
+
 class FakeClient:
     def __init__(self):
         self.objects: dict[str, bytes] = {}
@@ -73,3 +81,11 @@ async def test_runtime_path_rejects_traversal():
     storage = make_storage(FakeClient())
     with pytest.raises(ValueError):
         await storage.write_runtime_file("../mutable.py", b"code")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [S3PreconditionFailed(), ResourceExistsError("azure duplicate")],
+)
+def test_provider_duplicate_write_exceptions_are_classified(error):
+    assert SolutionDeploymentStorage._is_already_exists(error)

--- a/api/tests/unit/test_org_scoping_enforcement.py
+++ b/api/tests/unit/test_org_scoping_enforcement.py
@@ -274,6 +274,17 @@ EXECUTION_RESOLUTION_MODELS_WITHOUT_REPO_YET: set[str] = {
 }
 
 
+# Execution-critical rows that resolve through a dedicated repository with an
+# exact organization scope, rather than the org-to-global name cascade exposed
+# by OrgScopedRepository. SolutionDeployment is addressed by its immutable,
+# execution-pinned UUID; allowing cascade fallback could substitute a different
+# runtime closure. Its narrow repository therefore requires the caller's exact
+# organization_id (including explicit None for a global Solution install).
+EXACT_SCOPE_RESOLUTION_MODELS: set[str] = {
+    "SolutionDeployment",
+}
+
+
 def _models_with_org_id() -> dict[str, Path]:
     """Return {ClassName: file_path} for every Base subclass that declares
     an organization_id column."""
@@ -374,14 +385,16 @@ def _is_classified_org_model(model_name: str, repos: set[str]) -> bool:
         model_name in IDENTITY_MODELS
         or model_name in repos
         or model_name in EXECUTION_RESOLUTION_MODELS_WITHOUT_REPO_YET
+        or model_name in EXACT_SCOPE_RESOLUTION_MODELS
     )
 
 
 class TestOrgScopedModelsHaveRepository:
     """Every ORM model with organization_id must be classified.
 
-    Either it has an OrgScopedRepository subclass (execution-resolution),
-    OR it's on the IDENTITY_MODELS allow-list (identity entity).
+    Either it has an OrgScopedRepository subclass (cascade resolution), uses a
+    documented exact-scope resolution repository, or is on the IDENTITY_MODELS
+    allow-list (identity entity).
 
     Adding an org-scoped model without classification fails this test.
     """
@@ -404,6 +417,8 @@ class TestOrgScopedModelsHaveRepository:
                 "ORM models with organization_id that are not classified.\n"
                 "Either:\n"
                 "  - Add an OrgScopedRepository subclass (if execution-resolution), or\n"
+                "  - Add it to EXACT_SCOPE_RESOLUTION_MODELS (if its dedicated "
+                "repository intentionally forbids cascade), or\n"
                 "  - Add the model name to IDENTITY_MODELS in this test (if identity).\n"
                 "See api/src/repositories/README.md for the classification rule.\n"
                 f"Unclassified models:\n{details}"
@@ -421,9 +436,24 @@ class TestOrgScopedModelsHaveRepository:
                 "Remove them from the allow-list."
             )
 
+    def test_exact_scope_resolution_models_actually_exist(self) -> None:
+        """Exact-scope classifications must track real org-scoped models."""
+        models_with_org_id = set(_models_with_org_id().keys())
+        stale = EXACT_SCOPE_RESOLUTION_MODELS - models_with_org_id
+        if stale:
+            pytest.fail(
+                "EXACT_SCOPE_RESOLUTION_MODELS contains entries that no longer have "
+                f"organization_id columns (or no longer exist): {sorted(stale)}. "
+                "Remove them from the classification."
+            )
+
     def test_no_overlap_between_buckets(self) -> None:
         """A model can't be both identity and execution-resolution."""
-        overlap = IDENTITY_MODELS & EXECUTION_RESOLUTION_MODELS_WITHOUT_REPO_YET
+        execution_resolution = (
+            EXECUTION_RESOLUTION_MODELS_WITHOUT_REPO_YET
+            | EXACT_SCOPE_RESOLUTION_MODELS
+        )
+        overlap = IDENTITY_MODELS & execution_resolution
         assert not overlap, (
             f"Models classified as BOTH identity and execution-resolution: {overlap}. "
             "Pick one."

--- a/api/tests/unit/test_solution_deployment_orm.py
+++ b/api/tests/unit/test_solution_deployment_orm.py
@@ -5,6 +5,7 @@ from src.models.orm.solution_deployments import (
     SolutionDeploymentDependency,
 )
 from src.models.orm.solutions import Solution
+from src.repositories.solution_deployments import SolutionDeploymentRepository
 
 
 def test_solution_deployment_schema_exposes_runtime_closure_and_exact_edges():
@@ -15,6 +16,25 @@ def test_solution_deployment_schema_exposes_runtime_closure_and_exact_edges():
     assert deployment_columns["compiled_manifest"].nullable is False
     assert deployment_columns["compiled_manifest_hash"].nullable is False
     assert deployment_columns["resolution_map"].nullable is False
+    assert deployment_columns["resolution_map_hash"].nullable is False
+    assert deployment_columns["organization_id"].nullable is True
     assert deployment_columns["source_artifact_key"].nullable is False
     assert dependency_columns["dependency_deployment_id"].nullable is False
     assert "active_deployment_id" in Solution.__table__.columns
+
+    deployment_constraints = {c.name for c in SolutionDeployment.__table__.constraints}
+    dependency_constraints = {
+        c.name for c in SolutionDeploymentDependency.__table__.constraints
+    }
+    solution_constraints = {c.name for c in Solution.__table__.constraints}
+    assert "fk_solution_deployment_parent_same_solution" in deployment_constraints
+    assert "fk_solution_deployment_base_same_solution" in deployment_constraints
+    assert "fk_solution_dependency_exact_deployment" in dependency_constraints
+    assert "fk_solutions_active_deployment" in solution_constraints
+
+
+def test_deployment_repository_does_not_expose_unscoped_crud():
+    assert not hasattr(SolutionDeploymentRepository, "get_by_id")
+    assert not hasattr(SolutionDeploymentRepository, "get_all")
+    assert not hasattr(SolutionDeploymentRepository, "update")
+    assert not hasattr(SolutionDeploymentRepository, "delete")

--- a/api/tests/unit/test_solution_deployment_orm.py
+++ b/api/tests/unit/test_solution_deployment_orm.py
@@ -1,3 +1,7 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
 from sqlalchemy.orm import configure_mappers
 
 from src.models.orm.solution_deployments import (
@@ -38,3 +42,46 @@ def test_deployment_repository_does_not_expose_unscoped_crud():
     assert not hasattr(SolutionDeploymentRepository, "get_all")
     assert not hasattr(SolutionDeploymentRepository, "update")
     assert not hasattr(SolutionDeploymentRepository, "delete")
+
+
+@pytest.mark.parametrize(
+    ("expected_state", "new_state"),
+    [("validated", "ready"), ("active", "superseded")],
+)
+async def test_transition_omits_unsupplied_lifecycle_metadata(
+    expected_state: str, new_state: str
+):
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = MagicMock(spec=SolutionDeployment)
+    session.execute = AsyncMock(return_value=result)
+    repository = SolutionDeploymentRepository(session)
+
+    await repository.transition(
+        uuid4(),
+        uuid4(),
+        expected_state=expected_state,
+        new_state=new_state,
+    )
+
+    statement = session.execute.await_args.args[0]
+    assert {column.key for column in statement._values} == {"state"}
+
+
+async def test_transition_can_explicitly_clear_supported_metadata():
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = MagicMock(spec=SolutionDeployment)
+    session.execute = AsyncMock(return_value=result)
+    repository = SolutionDeploymentRepository(session)
+
+    await repository.transition(
+        uuid4(),
+        None,
+        expected_state="active",
+        new_state="superseded",
+        failure_detail=None,
+    )
+
+    statement = session.execute.await_args.args[0]
+    assert {column.key for column in statement._values} == {"state", "failure_detail"}

--- a/api/tests/unit/test_solution_deployment_orm.py
+++ b/api/tests/unit/test_solution_deployment_orm.py
@@ -1,0 +1,20 @@
+from sqlalchemy.orm import configure_mappers
+
+from src.models.orm.solution_deployments import (
+    SolutionDeployment,
+    SolutionDeploymentDependency,
+)
+from src.models.orm.solutions import Solution
+
+
+def test_solution_deployment_schema_exposes_runtime_closure_and_exact_edges():
+    configure_mappers()
+    deployment_columns = SolutionDeployment.__table__.columns
+    dependency_columns = SolutionDeploymentDependency.__table__.columns
+
+    assert deployment_columns["compiled_manifest"].nullable is False
+    assert deployment_columns["compiled_manifest_hash"].nullable is False
+    assert deployment_columns["resolution_map"].nullable is False
+    assert deployment_columns["source_artifact_key"].nullable is False
+    assert dependency_columns["dependency_deployment_id"].nullable is False
+    assert "active_deployment_id" in Solution.__table__.columns

--- a/docs/superpowers/specs/2026-07-16-solution-deployment-runtime-closure.md
+++ b/docs/superpowers/specs/2026-07-16-solution-deployment-runtime-closure.md
@@ -72,7 +72,7 @@ Minimum durable fields:
 
 ```text
 id UUID primary key
-organization_id UUID not null
+organization_id UUID null (must exactly match Solution scope; null means global)
 solution_id UUID not null
 parent_deployment_id UUID null
 base_deployment_id UUID null
@@ -82,6 +82,7 @@ bundle_hash sha256 not null
 compiled_manifest JSONB not null
 compiled_manifest_hash sha256 not null
 resolution_map JSONB not null
+resolution_map_hash sha256 not null
 source_artifact_key string not null
 runtime_storage_prefix string not null
 git_repository string null
@@ -129,7 +130,10 @@ solution_deployment_dependencies
 
 The exact `dependency_deployment_id` is immutable after validation. The
 declared constraint explains selection; it is never re-evaluated during an
-execution.
+execution. Composite integrity requires the selected deployment to belong to
+`dependency_solution_id`; an organization-scoped deployment may depend on the
+same organization or a global deployment, while a global deployment may depend
+only on global deployments.
 
 ### Execution changes
 
@@ -206,6 +210,10 @@ The production adapter reads the immutable compiled manifest. Tests use an
 in-memory adapter through the same interface. Execution callers do not know
 about object-store key construction, active ORM projections, or dependency
 selection.
+
+The manifest contains the canonical resolution-map hash. Runtime loading
+verifies both hashes and the equality of duplicated entity, dependency, and
+source evidence before resolving an execution.
 
 Active ORM rows continue to serve administrative APIs. Each projected
 Solution-owned row records `projected_from_deployment_id` so drift can be


### PR DESCRIPTION
## Summary
- add immutable SolutionDeployment records and exact dependency-deployment edges
- persist compiled manifests plus deployment-specific resolution maps with canonical hashes
- add revision-addressed create-only source, manifest, and runtime storage
- enforce Solution scope, lineage, dependency ownership, and post-build immutability in repository and database constraints

## Stack
Depends on #449. This intentionally excludes execution pinning, activation, API routing, and live deployment.

## Verification
- 12 focused tests
- Ruff
- Pyright (0 errors)
- compileall
- sole Alembic head
- git diff --check

## Remaining integration proof
- execute upgrade/downgrade and trigger behavior against PostgreSQL in CI/integration environment

No live Bifrost state was mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable solution deployment records with lifecycle states, dependency tracking, and active deployment selection.
  * Added runtime closure validation using canonical manifests, resolution maps, hashes, and source metadata.
  * Added revision-addressed, create-only storage for deployment artifacts and runtime files.
  * Added scope-safe deployment retrieval and state transitions.
  * Added protection against invalid updates, deletions, dependency mismatches, and path traversal.

* **Documentation**
  * Updated the deployment architecture specification with runtime closure and dependency integrity requirements.

* **Tests**
  * Added coverage for manifest validation, artifact storage, ORM constraints, and scope enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->