### PR TITLE
feat: add CAS SolutionDeployment activation and rollback

### DIFF
--- a/api/alembic/versions/20260716_deployment_activation.py
+++ b/api/alembic/versions/20260716_deployment_activation.py
@@ -1,0 +1,90 @@
+"""allow immutable deployment rollback activation
+
+Revision ID: 20260716_deploy_activation
+Revises: 20260716_exec_deploy_pin
+Create Date: 2026-07-16
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260716_deploy_activation"
+down_revision: str = "20260716_exec_deploy_pin"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _install_integrity_function(*, allow_rollback: bool) -> None:
+    rollback_transition = (
+        "OR (OLD.state = 'superseded' AND NEW.state IN ('superseded','activating'))"
+        if allow_rollback
+        else "OR (OLD.state = 'superseded' AND NEW.state = OLD.state)"
+    )
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION enforce_solution_deployment_integrity()
+        RETURNS trigger AS $$
+        DECLARE solution_org uuid;
+        BEGIN
+          SELECT organization_id INTO solution_org FROM solutions WHERE id = NEW.solution_id;
+          IF NOT FOUND OR solution_org IS DISTINCT FROM NEW.organization_id THEN
+            RAISE EXCEPTION 'deployment organization scope must match its Solution install';
+          END IF;
+          IF TG_OP = 'INSERT' AND NEW.state <> 'draft' THEN
+            RAISE EXCEPTION 'new SolutionDeployment must start in draft';
+          END IF;
+          IF TG_OP = 'UPDATE' AND NOT (
+            (OLD.state = 'draft' AND NEW.state IN ('draft','building','aborted')) OR
+            (OLD.state = 'building' AND NEW.state IN ('building','validated','failed','aborted')) OR
+            (OLD.state = 'validated' AND NEW.state IN ('validated','ready','aborted')) OR
+            (OLD.state = 'ready' AND NEW.state IN ('ready','activating','aborted')) OR
+            (OLD.state = 'activating' AND NEW.state IN
+              ('activating','active','conflicted','failed','recovery_required')) OR
+            (OLD.state = 'active' AND NEW.state IN
+              ('active','superseded','committed_unpushed','recovery_required')) OR
+            (OLD.state = 'committed_unpushed' AND NEW.state IN
+              ('committed_unpushed','active','superseded','recovery_required')) OR
+            (OLD.state IN ('conflicted','failed','recovery_required','aborted')
+              AND NEW.state = OLD.state)
+            {rollback_transition}
+          ) THEN
+            RAISE EXCEPTION 'invalid SolutionDeployment state transition: % -> %',
+              OLD.state, NEW.state;
+          END IF;
+          IF TG_OP = 'UPDATE' AND OLD.state NOT IN ('draft', 'building') AND (
+            NEW.id IS DISTINCT FROM OLD.id OR
+            NEW.organization_id IS DISTINCT FROM OLD.organization_id OR
+            NEW.solution_id IS DISTINCT FROM OLD.solution_id OR
+            NEW.parent_deployment_id IS DISTINCT FROM OLD.parent_deployment_id OR
+            NEW.base_deployment_id IS DISTINCT FROM OLD.base_deployment_id OR
+            NEW.declared_version IS DISTINCT FROM OLD.declared_version OR
+            NEW.bundle_hash IS DISTINCT FROM OLD.bundle_hash OR
+            NEW.compiled_manifest IS DISTINCT FROM OLD.compiled_manifest OR
+            NEW.compiled_manifest_hash IS DISTINCT FROM OLD.compiled_manifest_hash OR
+            NEW.resolution_map IS DISTINCT FROM OLD.resolution_map OR
+            NEW.resolution_map_hash IS DISTINCT FROM OLD.resolution_map_hash OR
+            NEW.source_artifact_key IS DISTINCT FROM OLD.source_artifact_key OR
+            NEW.runtime_storage_prefix IS DISTINCT FROM OLD.runtime_storage_prefix OR
+            NEW.git_repository IS DISTINCT FROM OLD.git_repository OR
+            NEW.git_ref IS DISTINCT FROM OLD.git_ref OR
+            NEW.git_commit_sha IS DISTINCT FROM OLD.git_commit_sha OR
+            NEW.created_by IS DISTINCT FROM OLD.created_by OR
+            NEW.codex_worker_id IS DISTINCT FROM OLD.codex_worker_id OR
+            NEW.created_at IS DISTINCT FROM OLD.created_at
+          ) THEN
+            RAISE EXCEPTION 'SolutionDeployment runtime closure is write-once';
+          END IF;
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def upgrade() -> None:
+    _install_integrity_function(allow_rollback=True)
+
+
+def downgrade() -> None:
+    _install_integrity_function(allow_rollback=False)

--- a/api/src/repositories/solution_deployments.py
+++ b/api/src/repositories/solution_deployments.py
@@ -33,6 +33,7 @@ _TRANSITIONS: dict[str, frozenset[str]] = {
     "activating": frozenset({"active", "conflicted", "failed", "recovery_required"}),
     "active": frozenset({"superseded", "committed_unpushed", "recovery_required"}),
     "committed_unpushed": frozenset({"active", "superseded", "recovery_required"}),
+    "superseded": frozenset({"activating"}),
 }
 
 
@@ -130,3 +131,46 @@ class SolutionDeploymentRepository:
         if deployment is None:
             raise InvalidDeploymentTransition("deployment missing, out of scope, or state changed")
         return deployment
+
+    async def get_solution_active_deployment(
+        self, solution_id: UUID, organization_id: UUID | None
+    ) -> UUID | None:
+        scope_clause = (
+            Solution.organization_id.is_(None)
+            if organization_id is None
+            else Solution.organization_id == organization_id
+        )
+        result = await self.session.execute(
+            select(Solution.active_deployment_id).where(
+                Solution.id == solution_id,
+                scope_clause,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def compare_and_set_active_deployment(
+        self,
+        solution_id: UUID,
+        organization_id: UUID | None,
+        *,
+        expected_active_deployment_id: UUID | None,
+        new_active_deployment_id: UUID,
+    ) -> bool:
+        """Atomically move the active pointer only when the expected base still wins."""
+        scope_clause = (
+            Solution.organization_id.is_(None)
+            if organization_id is None
+            else Solution.organization_id == organization_id
+        )
+        active_clause = (
+            Solution.active_deployment_id.is_(None)
+            if expected_active_deployment_id is None
+            else Solution.active_deployment_id == expected_active_deployment_id
+        )
+        result = await self.session.execute(
+            update(Solution)
+            .where(Solution.id == solution_id, scope_clause, active_clause)
+            .values(active_deployment_id=new_active_deployment_id)
+            .returning(Solution.id)
+        )
+        return result.scalar_one_or_none() is not None

--- a/api/src/repositories/solution_deployments.py
+++ b/api/src/repositories/solution_deployments.py
@@ -170,7 +170,10 @@ class SolutionDeploymentRepository:
         result = await self.session.execute(
             update(Solution)
             .where(Solution.id == solution_id, scope_clause, active_clause)
-            .values(active_deployment_id=new_active_deployment_id)
+            .values(
+                active_deployment_id=new_active_deployment_id,
+                execution_runtime_mode="deployment-v1",
+            )
             .returning(Solution.id)
         )
         return result.scalar_one_or_none() is not None

--- a/api/src/services/solutions/deployment_activation.py
+++ b/api/src/services/solutions/deployment_activation.py
@@ -1,0 +1,237 @@
+"""Compare-and-swap activation and rollback for immutable Solution deployments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+from uuid import UUID
+
+from src.models.orm.solution_deployments import SolutionDeployment
+from src.repositories.solution_deployments import SolutionDeploymentRepository
+
+
+class DeploymentActivationHooks(Protocol):
+    """External artifact/projection work required before pointer movement."""
+
+    async def verify_finalized(self, deployment: SolutionDeployment) -> None: ...
+
+    async def rebuild_projections(self, deployment: SolutionDeployment) -> None: ...
+
+
+@dataclass(frozen=True)
+class ActivationResult:
+    deployment_id: UUID
+    solution_id: UUID
+    state: str
+    previous_active_deployment_id: UUID | None
+    active_deployment_id: UUID | None
+    conflict: dict | None = None
+    recovery: dict | None = None
+
+
+class SolutionDeploymentActivationService:
+    """Own state transitions and active-pointer CAS without touching execution paths."""
+
+    def __init__(
+        self,
+        repository: SolutionDeploymentRepository,
+        hooks: DeploymentActivationHooks,
+    ):
+        self.repository = repository
+        self.hooks = hooks
+
+    async def activate(
+        self,
+        deployment_id: UUID,
+        organization_id: UUID | None,
+        *,
+        expected_active_deployment_id: UUID | None,
+    ) -> ActivationResult:
+        deployment = await self._require_deployment(deployment_id, organization_id)
+        if deployment.base_deployment_id != expected_active_deployment_id:
+            raise ValueError(
+                "expected active deployment must match the draft base deployment"
+            )
+        return await self._move_pointer(
+            deployment,
+            organization_id,
+            expected_active_deployment_id=expected_active_deployment_id,
+            expected_target_state="ready",
+            operation="activate",
+        )
+
+    async def rollback(
+        self,
+        target_deployment_id: UUID,
+        organization_id: UUID | None,
+        *,
+        expected_active_deployment_id: UUID,
+    ) -> ActivationResult:
+        deployment = await self._require_deployment(
+            target_deployment_id, organization_id
+        )
+        if deployment.id == expected_active_deployment_id:
+            raise ValueError("rollback target is already active")
+        return await self._move_pointer(
+            deployment,
+            organization_id,
+            expected_active_deployment_id=expected_active_deployment_id,
+            expected_target_state="superseded",
+            operation="rollback",
+        )
+
+    async def _move_pointer(
+        self,
+        deployment: SolutionDeployment,
+        organization_id: UUID | None,
+        *,
+        expected_active_deployment_id: UUID | None,
+        expected_target_state: str,
+        operation: str,
+    ) -> ActivationResult:
+        now = datetime.now(timezone.utc)
+        deployment = await self.repository.transition(
+            deployment.id,
+            organization_id,
+            expected_state=expected_target_state,
+            new_state="activating",
+        )
+
+        try:
+            await self.hooks.verify_finalized(deployment)
+        except Exception as exc:  # noqa: BLE001 - adapters expose backend-specific failures
+            recovery = {
+                "operation": operation,
+                "stage": "artifact_finalization",
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+                "expected_active_deployment_id": str(expected_active_deployment_id)
+                if expected_active_deployment_id
+                else None,
+                "target_deployment_id": str(deployment.id),
+                "next_action": "verify immutable artifacts before retry",
+            }
+            await self.repository.transition(
+                deployment.id,
+                organization_id,
+                expected_state="activating",
+                new_state="recovery_required",
+                failure_detail=recovery,
+            )
+            current = await self.repository.get_solution_active_deployment(
+                deployment.solution_id, organization_id
+            )
+            return ActivationResult(
+                deployment_id=deployment.id,
+                solution_id=deployment.solution_id,
+                state="recovery_required",
+                previous_active_deployment_id=expected_active_deployment_id,
+                active_deployment_id=current,
+                recovery=recovery,
+            )
+
+        moved = await self.repository.compare_and_set_active_deployment(
+            deployment.solution_id,
+            organization_id,
+            expected_active_deployment_id=expected_active_deployment_id,
+            new_active_deployment_id=deployment.id,
+        )
+        if not moved:
+            current = await self.repository.get_solution_active_deployment(
+                deployment.solution_id, organization_id
+            )
+            conflict = {
+                "operation": operation,
+                "solution_id": str(deployment.solution_id),
+                "target_deployment_id": str(deployment.id),
+                "expected_active_deployment_id": str(expected_active_deployment_id)
+                if expected_active_deployment_id
+                else None,
+                "actual_active_deployment_id": str(current) if current else None,
+            }
+            await self.repository.transition(
+                deployment.id,
+                organization_id,
+                expected_state="activating",
+                new_state="conflicted",
+                failure_detail=conflict,
+            )
+            return ActivationResult(
+                deployment_id=deployment.id,
+                solution_id=deployment.solution_id,
+                state="conflicted",
+                previous_active_deployment_id=expected_active_deployment_id,
+                active_deployment_id=current,
+                conflict=conflict,
+            )
+
+        try:
+            await self.hooks.rebuild_projections(deployment)
+            if expected_active_deployment_id is not None:
+                previous = await self.repository.get_runtime_closure(
+                    expected_active_deployment_id, organization_id
+                )
+                if previous is not None and previous.state in {
+                    "active",
+                    "committed_unpushed",
+                }:
+                    await self.repository.transition(
+                        previous.id,
+                        organization_id,
+                        expected_state=previous.state,
+                        new_state="superseded",
+                        superseded_at=now,
+                    )
+            await self.repository.transition(
+                deployment.id,
+                organization_id,
+                expected_state="activating",
+                new_state="active",
+                activated_at=now,
+            )
+        except Exception as exc:  # noqa: BLE001 - persist cross-system recovery evidence
+            recovery = {
+                "operation": operation,
+                "stage": "projection_or_pointer_finalization",
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+                "expected_active_deployment_id": str(expected_active_deployment_id)
+                if expected_active_deployment_id
+                else None,
+                "target_deployment_id": str(deployment.id),
+                "pointer_moved": True,
+                "next_action": "repair projections and deployment states before enabling execution",
+            }
+            await self.repository.transition(
+                deployment.id,
+                organization_id,
+                expected_state="activating",
+                new_state="recovery_required",
+                failure_detail=recovery,
+            )
+            return ActivationResult(
+                deployment_id=deployment.id,
+                solution_id=deployment.solution_id,
+                state="recovery_required",
+                previous_active_deployment_id=expected_active_deployment_id,
+                active_deployment_id=deployment.id,
+                recovery=recovery,
+            )
+        return ActivationResult(
+            deployment_id=deployment.id,
+            solution_id=deployment.solution_id,
+            state="active",
+            previous_active_deployment_id=expected_active_deployment_id,
+            active_deployment_id=deployment.id,
+        )
+
+    async def _require_deployment(
+        self, deployment_id: UUID, organization_id: UUID | None
+    ) -> SolutionDeployment:
+        deployment = await self.repository.get_runtime_closure(
+            deployment_id, organization_id
+        )
+        if deployment is None:
+            raise ValueError("deployment missing or out of scope")
+        return deployment

--- a/api/tests/unit/services/solutions/test_deployment_activation.py
+++ b/api/tests/unit/services/solutions/test_deployment_activation.py
@@ -216,3 +216,25 @@ async def test_repository_transition_rules_allow_rollback_but_not_ready_to_activ
         await repository.transition(
             deployment_id, None, expected_state="ready", new_state="active"
         )
+
+
+@pytest.mark.asyncio
+async def test_pointer_cas_marks_solution_as_deployment_runtime():
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = uuid4()
+    session.execute = AsyncMock(return_value=result)
+    repository = SolutionDeploymentRepository(cast(Any, session))
+
+    moved = await repository.compare_and_set_active_deployment(
+        uuid4(),
+        None,
+        expected_active_deployment_id=None,
+        new_active_deployment_id=uuid4(),
+    )
+
+    assert moved is True
+    statement = session.execute.await_args.args[0]
+    values = {column.key: value.value for column, value in statement._values.items()}
+    assert values["execution_runtime_mode"] == "deployment-v1"
+    assert "active_deployment_id" in values

--- a/api/tests/unit/services/solutions/test_deployment_activation.py
+++ b/api/tests/unit/services/solutions/test_deployment_activation.py
@@ -1,0 +1,215 @@
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.orm.solution_deployments import SolutionDeployment
+from src.repositories.solution_deployments import (
+    InvalidDeploymentTransition,
+    SolutionDeploymentRepository,
+)
+from src.services.solutions.deployment_activation import (
+    SolutionDeploymentActivationService,
+)
+
+
+def deployment(
+    solution_id: UUID, state: str, base: UUID | None = None
+) -> SolutionDeployment:
+    return SolutionDeployment(
+        id=uuid4(),
+        organization_id=None,
+        solution_id=solution_id,
+        state=state,
+        base_deployment_id=base,
+        bundle_hash="sha256:bundle",
+        compiled_manifest={},
+        compiled_manifest_hash="sha256:manifest",
+        resolution_map={},
+        resolution_map_hash="sha256:resolution",
+        source_artifact_key="source.zip",
+        runtime_storage_prefix="runtime/",
+        created_by=uuid4(),
+    )
+
+
+class FakeRepository:
+    def __init__(self, deployments: list[SolutionDeployment], active: UUID | None):
+        self.deployments = {item.id: item for item in deployments}
+        self.active = active
+
+    async def get_runtime_closure(self, deployment_id, organization_id):
+        item = self.deployments.get(deployment_id)
+        return (
+            item
+            if item is not None and item.organization_id == organization_id
+            else None
+        )
+
+    async def transition(
+        self, deployment_id, organization_id, *, expected_state, new_state, **values
+    ):
+        item = await self.get_runtime_closure(deployment_id, organization_id)
+        if item is None or item.state != expected_state:
+            raise ValueError("state changed")
+        item.state = new_state
+        for key, value in values.items():
+            if value is not None:
+                setattr(item, key, value)
+        return item
+
+    async def get_solution_active_deployment(self, solution_id, organization_id):
+        return self.active
+
+    async def compare_and_set_active_deployment(
+        self,
+        solution_id,
+        organization_id,
+        *,
+        expected_active_deployment_id,
+        new_active_deployment_id,
+    ):
+        if self.active != expected_active_deployment_id:
+            return False
+        self.active = new_active_deployment_id
+        return True
+
+
+class FakeHooks:
+    def __init__(self, *, fail_verify: bool = False, fail_projection: bool = False):
+        self.fail_verify = fail_verify
+        self.fail_projection = fail_projection
+        self.verified: list[UUID] = []
+        self.projected: list[UUID] = []
+
+    async def verify_finalized(self, item):
+        self.verified.append(item.id)
+        if self.fail_verify:
+            raise OSError("artifact unavailable")
+
+    async def rebuild_projections(self, item):
+        self.projected.append(item.id)
+        if self.fail_projection:
+            raise RuntimeError("projection failed")
+
+
+def service(repository: FakeRepository, hooks: FakeHooks):
+    return SolutionDeploymentActivationService(
+        cast(SolutionDeploymentRepository, cast(Any, repository)), hooks
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_drafts_from_one_base_have_deterministic_cas_conflict():
+    solution_id = uuid4()
+    current = deployment(solution_id, "active")
+    first = deployment(solution_id, "ready", current.id)
+    second = deployment(solution_id, "ready", current.id)
+    repository = FakeRepository([current, first, second], current.id)
+    hooks = FakeHooks()
+    activation = service(repository, hooks)
+
+    winner = await activation.activate(
+        first.id, None, expected_active_deployment_id=current.id
+    )
+    loser = await activation.activate(
+        second.id, None, expected_active_deployment_id=current.id
+    )
+
+    assert winner.state == "active"
+    assert repository.active == first.id
+    assert current.state == "superseded"
+    assert loser.state == "conflicted"
+    assert loser.conflict == {
+        "operation": "activate",
+        "solution_id": str(solution_id),
+        "target_deployment_id": str(second.id),
+        "expected_active_deployment_id": str(current.id),
+        "actual_active_deployment_id": str(first.id),
+    }
+    assert hooks.projected == [first.id]
+
+
+@pytest.mark.asyncio
+async def test_rollback_reactivates_prior_immutable_deployment_by_cas():
+    solution_id = uuid4()
+    prior = deployment(solution_id, "superseded")
+    current = deployment(solution_id, "active", prior.id)
+    repository = FakeRepository([prior, current], current.id)
+    activation = service(repository, FakeHooks())
+
+    result = await activation.rollback(
+        prior.id, None, expected_active_deployment_id=current.id
+    )
+
+    assert result.state == "active"
+    assert repository.active == prior.id
+    assert prior.state == "active"
+    assert current.state == "superseded"
+    assert prior.bundle_hash == "sha256:bundle"
+
+
+@pytest.mark.asyncio
+async def test_artifact_failure_records_recovery_without_moving_pointer():
+    solution_id = uuid4()
+    current = deployment(solution_id, "active")
+    candidate = deployment(solution_id, "ready", current.id)
+    repository = FakeRepository([current, candidate], current.id)
+    activation = service(repository, FakeHooks(fail_verify=True))
+
+    result = await activation.activate(
+        candidate.id, None, expected_active_deployment_id=current.id
+    )
+
+    assert result.state == "recovery_required"
+    assert repository.active == current.id
+    assert result.recovery["stage"] == "artifact_finalization"
+    assert result.recovery["target_deployment_id"] == str(candidate.id)
+
+
+@pytest.mark.asyncio
+async def test_projection_failure_records_pointer_moved_recovery_evidence():
+    solution_id = uuid4()
+    current = deployment(solution_id, "active")
+    candidate = deployment(solution_id, "ready", current.id)
+    repository = FakeRepository([current, candidate], current.id)
+    activation = service(repository, FakeHooks(fail_projection=True))
+
+    result = await activation.activate(
+        candidate.id, None, expected_active_deployment_id=current.id
+    )
+
+    assert result.state == "recovery_required"
+    assert repository.active == candidate.id
+    assert result.recovery["pointer_moved"] is True
+    assert result.recovery["stage"] == "projection_or_pointer_finalization"
+
+
+@pytest.mark.asyncio
+async def test_activation_rejects_expected_pointer_that_is_not_draft_base():
+    solution_id = uuid4()
+    candidate = deployment(solution_id, "ready", uuid4())
+    repository = FakeRepository([candidate], candidate.base_deployment_id)
+
+    with pytest.raises(ValueError, match="draft base"):
+        await service(repository, FakeHooks()).activate(
+            candidate.id, None, expected_active_deployment_id=uuid4()
+        )
+
+
+@pytest.mark.asyncio
+async def test_repository_transition_rules_allow_rollback_but_not_ready_to_active():
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = MagicMock(spec=SolutionDeployment)
+    session.execute = AsyncMock(return_value=result)
+    repository = SolutionDeploymentRepository(cast(Any, session))
+
+    await repository.transition(
+        uuid4(), None, expected_state="superseded", new_state="activating"
+    )
+    with pytest.raises(InvalidDeploymentTransition, match="ready -> active"):
+        await repository.transition(
+            uuid4(), None, expected_state="ready", new_state="active"
+        )

--- a/api/tests/unit/services/solutions/test_deployment_activation.py
+++ b/api/tests/unit/services/solutions/test_deployment_activation.py
@@ -191,10 +191,12 @@ async def test_activation_rejects_expected_pointer_that_is_not_draft_base():
     solution_id = uuid4()
     candidate = deployment(solution_id, "ready", uuid4())
     repository = FakeRepository([candidate], candidate.base_deployment_id)
+    activation = service(repository, FakeHooks())
+    unexpected_active_id = uuid4()
 
     with pytest.raises(ValueError, match="draft base"):
-        await service(repository, FakeHooks()).activate(
-            candidate.id, None, expected_active_deployment_id=uuid4()
+        await activation.activate(
+            candidate.id, None, expected_active_deployment_id=unexpected_active_id
         )
 
 
@@ -209,7 +211,8 @@ async def test_repository_transition_rules_allow_rollback_but_not_ready_to_activ
     await repository.transition(
         uuid4(), None, expected_state="superseded", new_state="activating"
     )
+    deployment_id = uuid4()
     with pytest.raises(InvalidDeploymentTransition, match="ready -> active"):
         await repository.transition(
-            uuid4(), None, expected_state="ready", new_state="active"
+            deployment_id, None, expected_state="ready", new_state="active"
         )


### PR DESCRIPTION
## Summary
- atomically move Solution.active_deployment_id with expected-active compare-and-swap
- activate or roll back only through explicit deployment state transitions
- distinguish deterministic two-draft conflicts from recovery-required partial failures
- preserve pointer/evidence state for operator recovery when finalization fails after movement

## Stack
Depends on #451 (and transitively #449). This intentionally excludes execution pinning, API endpoints, cs CLI integration, and live deployment.

## Verification
- 18 focused tests
- Ruff
- targeted Pyright (0 errors)
- sole Alembic head
- git diff --check

No live Bifrost state was mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment activation and rollback workflows with conflict detection and recovery handling.
  * Added atomic active-deployment updates to prevent competing changes from overwriting each other.
  * Added validation for deployment ownership, starting states, state transitions, and finalized runtime fields.
  * Added support for marking previous deployments as superseded after successful activation.

* **Tests**
  * Added coverage for activation, rollback, conflicts, recovery scenarios, and invalid transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->