### PR TITLE
feat: pin Solution workflow executions to deployments

### DIFF
--- a/api/alembic/versions/20260716_execution_deployment_pin.py
+++ b/api/alembic/versions/20260716_execution_deployment_pin.py
@@ -1,6 +1,6 @@
 """pin workflow executions to immutable Solution deployments
 
-Revision ID: 20260716_execution_deployment_pin
+Revision ID: 20260716_exec_deploy_pin
 Revises: 20260716_solution_deployments
 Create Date: 2026-07-16
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "20260716_execution_deployment_pin"
+revision: str = "20260716_exec_deploy_pin"
 down_revision: str = "20260716_solution_deployments"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/api/alembic/versions/20260716_execution_deployment_pin.py
+++ b/api/alembic/versions/20260716_execution_deployment_pin.py
@@ -24,6 +24,12 @@ def upgrade() -> None:
             "solution_deployment_id", postgresql.UUID(as_uuid=True), nullable=True
         ),
     )
+    op.add_column(
+        "executions",
+        sa.Column("runtime_mode", sa.String(length=32), nullable=False, server_default="legacy"),
+    )
+    op.add_column("executions", sa.Column("runtime_evidence", postgresql.JSONB(), nullable=True))
+    op.add_column("executions", sa.Column("runtime_evidence_hash", sa.String(length=71), nullable=True))
     op.create_foreign_key(
         "fk_executions_solution_deployment",
         "executions",
@@ -45,3 +51,6 @@ def downgrade() -> None:
         "fk_executions_solution_deployment", "executions", type_="foreignkey"
     )
     op.drop_column("executions", "solution_deployment_id")
+    op.drop_column("executions", "runtime_evidence_hash")
+    op.drop_column("executions", "runtime_evidence")
+    op.drop_column("executions", "runtime_mode")

--- a/api/alembic/versions/20260716_execution_deployment_pin.py
+++ b/api/alembic/versions/20260716_execution_deployment_pin.py
@@ -18,6 +18,23 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Existing Solution installs were authored before immutable deployment
+    # closures existed. Mark only those rows as mutable-storage compatibility,
+    # then make all future unmarked inserts deployment-aware and fail-closed.
+    op.add_column(
+        "solutions",
+        sa.Column(
+            "execution_runtime_mode",
+            sa.String(length=32),
+            nullable=False,
+            server_default="repo-v1",
+        ),
+    )
+    op.alter_column(
+        "solutions",
+        "execution_runtime_mode",
+        server_default=sa.text("'deployment-v1'"),
+    )
     op.add_column(
         "executions",
         sa.Column(
@@ -54,3 +71,4 @@ def downgrade() -> None:
     op.drop_column("executions", "runtime_evidence_hash")
     op.drop_column("executions", "runtime_evidence")
     op.drop_column("executions", "runtime_mode")
+    op.drop_column("solutions", "execution_runtime_mode")

--- a/api/alembic/versions/20260716_execution_deployment_pin.py
+++ b/api/alembic/versions/20260716_execution_deployment_pin.py
@@ -1,0 +1,47 @@
+"""pin workflow executions to immutable Solution deployments
+
+Revision ID: 20260716_execution_deployment_pin
+Revises: 20260716_solution_deployments
+Create Date: 2026-07-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260716_execution_deployment_pin"
+down_revision: str = "20260716_solution_deployments"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "executions",
+        sa.Column(
+            "solution_deployment_id", postgresql.UUID(as_uuid=True), nullable=True
+        ),
+    )
+    op.create_foreign_key(
+        "fk_executions_solution_deployment",
+        "executions",
+        "solution_deployments",
+        ["solution_deployment_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_executions_solution_deployment_id",
+        "executions",
+        ["solution_deployment_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_executions_solution_deployment_id", table_name="executions")
+    op.drop_constraint(
+        "fk_executions_solution_deployment", "executions", type_="foreignkey"
+    )
+    op.drop_column("executions", "solution_deployment_id")

--- a/api/bifrost/_execution_context.py
+++ b/api/bifrost/_execution_context.py
@@ -111,6 +111,8 @@ class ExecutionContext:
     # The SDK appends it to name lookups (tables/configs) so they resolve the
     # install's OWN entity first, then _repo/. None for plain _repo/ executions.
     solution_id: str | None = field(default=None)
+    # Immutable deployment inherited by same-Solution and dependency calls.
+    solution_deployment_id: str | None = field(default=None)
 
     # ==================== PLATFORM ====================
     # Public URL for constructing external links (e.g., workflow URLs, execution URLs)

--- a/api/src/core/module_cache_sync.py
+++ b/api/src/core/module_cache_sync.py
@@ -60,12 +60,20 @@ class SolutionContext:
 
     solution_id: str
     global_repo_access: bool
+    runtime_storage_prefix: str | None = None
 
 
-def set_solution_context(solution_id: UUID | str, global_repo_access: bool) -> None:
+def set_solution_context(
+    solution_id: UUID | str,
+    global_repo_access: bool,
+    *,
+    runtime_storage_prefix: str | None = None,
+) -> None:
     """Activate the solution import root for the current thread/execution."""
     _solution_ctx.value = SolutionContext(
-        solution_id=str(solution_id), global_repo_access=bool(global_repo_access)
+        solution_id=str(solution_id),
+        global_repo_access=bool(global_repo_access),
+        runtime_storage_prefix=(runtime_storage_prefix.rstrip("/") + "/") if runtime_storage_prefix else None,
     )
 
 
@@ -93,7 +101,8 @@ def _candidate_storage_paths(path: str) -> list[str]:
     ctx = get_solution_context()
     if ctx is None:
         return [path]
-    rooted = f"{SOLUTIONS_ROOT}/{ctx.solution_id}/{path.lstrip('/')}"
+    root = ctx.runtime_storage_prefix or f"{SOLUTIONS_ROOT}/{ctx.solution_id}/"
+    rooted = f"{root}{path.lstrip('/')}"
     if ctx.global_repo_access:
         return [rooted, path]
     return [rooted]
@@ -116,7 +125,8 @@ def candidate_index_prefixes(base_path: str) -> list[str]:
     ctx = get_solution_context()
     if ctx is None:
         return [f"{base}/"]
-    rooted = f"{SOLUTIONS_ROOT}/{ctx.solution_id}/{base}/"
+    root = ctx.runtime_storage_prefix or f"{SOLUTIONS_ROOT}/{ctx.solution_id}/"
+    rooted = f"{root}{base}/"
     if ctx.global_repo_access:
         return [rooted, f"{base}/"]
     return [rooted]
@@ -666,7 +676,8 @@ def solution_has_submodules(base_path: str) -> bool:
     ctx = get_solution_context()
     if ctx is None:
         return False
-    prefix = f"{SOLUTIONS_ROOT}/{ctx.solution_id}/{base_path.rstrip('/')}/"
+    root = ctx.runtime_storage_prefix or f"{SOLUTIONS_ROOT}/{ctx.solution_id}/"
+    prefix = f"{root}{base_path.rstrip('/')}/"
     api_paths = _fetch_module_index_from_api(solution_id=ctx.solution_id)
     if any(path.startswith(prefix) for path in api_paths):
         return True

--- a/api/src/core/module_cache_sync.py
+++ b/api/src/core/module_cache_sync.py
@@ -61,6 +61,7 @@ class SolutionContext:
     solution_id: str
     global_repo_access: bool
     runtime_storage_prefix: str | None = None
+    source_hashes: dict[str, str] | None = None
 
 
 def set_solution_context(
@@ -68,12 +69,14 @@ def set_solution_context(
     global_repo_access: bool,
     *,
     runtime_storage_prefix: str | None = None,
+    source_hashes: dict[str, str] | None = None,
 ) -> None:
     """Activate the solution import root for the current thread/execution."""
     _solution_ctx.value = SolutionContext(
         solution_id=str(solution_id),
         global_repo_access=bool(global_repo_access),
         runtime_storage_prefix=(runtime_storage_prefix.rstrip("/") + "/") if runtime_storage_prefix else None,
+        source_hashes=source_hashes,
     )
 
 
@@ -506,7 +509,9 @@ def get_module_sync(path: str) -> CachedModule | None:
             key = f"{MODULE_KEY_PREFIX}{storage_path}"
             data = client.get(key)
             if data:
-                return json.loads(data)
+                module = json.loads(data)
+                _verify_deployment_module_hash(path, module)
+                return module
 
             # --- Cold-cache fallback 1: API endpoint ---
             api_module = _fetch_module_from_api(storage_path)
@@ -516,6 +521,7 @@ def get_module_sync(path: str) -> CachedModule | None:
                     client.sadd(MODULE_INDEX_KEY, storage_path)
                 except redis.RedisError as e:
                     logger.warning(f"Failed to re-cache API module to Redis: {e}")
+                _verify_deployment_module_hash(path, api_module)
                 return api_module
 
             # --- Cold-cache fallback 2: direct object storage (legacy path) ---
@@ -544,6 +550,7 @@ def get_module_sync(path: str) -> CachedModule | None:
             except redis.RedisError as e:
                 logger.warning(f"Failed to cache object storage module to Redis: {e}")
 
+            _verify_deployment_module_hash(path, module)
             return module
 
         logger.debug(f"Module not in cache, API, or object storage: {path}")
@@ -552,6 +559,18 @@ def get_module_sync(path: str) -> CachedModule | None:
     except redis.RedisError as e:
         logger.warning(f"Redis error fetching module {path}: {e}")
         return None
+
+
+def _verify_deployment_module_hash(path: str, module: CachedModule) -> None:
+    ctx = get_solution_context()
+    if ctx is None or not ctx.runtime_storage_prefix:
+        return
+    expected = (ctx.source_hashes or {}).get(path.lstrip("/"))
+    if expected is None:
+        raise RuntimeError(f"deployment source is absent from manifest: {path}")
+    actual = str(module.get("hash") or "").removeprefix("sha256:")
+    if actual != expected.removeprefix("sha256:"):
+        raise RuntimeError(f"deployment import integrity mismatch: {path}")
 
 
 def _list_s3_modules() -> set[str]:

--- a/api/src/core/redis_client.py
+++ b/api/src/core/redis_client.py
@@ -52,6 +52,8 @@ class PendingExecution(TypedDict):
     """Schema for pending execution data stored in Redis."""
     execution_id: str
     workflow_id: str | None  # UUID from database (None for inline code)
+    solution_deployment_id: str | None
+    runtime_evidence: dict[str, Any] | None
     script_name: str | None  # Name for inline code execution
     parameters: dict[str, Any]
     org_id: str | None
@@ -111,6 +113,8 @@ class RedisClient:
         sync: bool = False,
         is_platform_admin: bool = False,
         event: dict[str, Any] | None = None,
+        solution_deployment_id: str | None = None,
+        runtime_evidence: dict[str, Any] | None = None,
     ) -> None:
         """
         Store pending execution in Redis.
@@ -138,6 +142,8 @@ class RedisClient:
         data: PendingExecution = {
             "execution_id": execution_id,
             "workflow_id": workflow_id,
+            "solution_deployment_id": solution_deployment_id,
+            "runtime_evidence": runtime_evidence,
             "script_name": script_name,
             "parameters": parameters,
             "org_id": org_id,

--- a/api/src/core/redis_client.py
+++ b/api/src/core/redis_client.py
@@ -54,6 +54,7 @@ class PendingExecution(TypedDict):
     workflow_id: str | None  # UUID from database (None for inline code)
     solution_deployment_id: str | None
     runtime_evidence: dict[str, Any] | None
+    runtime_mode: str
     script_name: str | None  # Name for inline code execution
     parameters: dict[str, Any]
     org_id: str | None
@@ -115,6 +116,7 @@ class RedisClient:
         event: dict[str, Any] | None = None,
         solution_deployment_id: str | None = None,
         runtime_evidence: dict[str, Any] | None = None,
+        runtime_mode: str = "legacy",
     ) -> None:
         """
         Store pending execution in Redis.
@@ -144,6 +146,7 @@ class RedisClient:
             "workflow_id": workflow_id,
             "solution_deployment_id": solution_deployment_id,
             "runtime_evidence": runtime_evidence,
+            "runtime_mode": runtime_mode,
             "script_name": script_name,
             "parameters": parameters,
             "org_id": org_id,

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -561,6 +561,8 @@ class WorkflowExecutionConsumer(BaseConsumer):
             cache_ttl_seconds = 300
             solution_id: str | None = None  # Install id if solution-managed
             solution_global_repo_access = False  # Whether solution code may import _repo/
+            solution_deployment_id = pending.get("solution_deployment_id")
+            runtime_storage_prefix: str | None = None
 
             if not is_script and workflow_id:
                 from src.services.execution.service import get_workflow_for_execution, WorkflowNotFoundError
@@ -568,8 +570,25 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 try:
                     # Get workflow metadata (no code — worker loads via Redis→S3)
                     # Brief DB session for metadata read
-                    async with get_db_context() as db:
-                        workflow_data = await get_workflow_for_execution(workflow_id, db=db)
+                    if solution_deployment_id:
+                        from src.services.solutions.deployment_runtime import (
+                            DeploymentRuntimeError,
+                            workflow_data_from_evidence,
+                        )
+
+                        try:
+                            workflow_data = workflow_data_from_evidence(
+                                str(solution_deployment_id), pending.get("runtime_evidence")
+                            )
+                        except DeploymentRuntimeError as exc:
+                            raise WorkflowNotFoundError(str(exc)) from exc
+                        runtime_storage_prefix = workflow_data["runtime_storage_prefix"]
+                    else:
+                        # Compatibility boundary: newly enqueued Solution work is
+                        # always pinned above, so a null deployment here is either
+                        # `_repo` or a pre-migration pending/scheduled execution.
+                        async with get_db_context() as db:
+                            workflow_data = await get_workflow_for_execution(workflow_id, db=db)
                     workflow_name = workflow_data["name"]
                     workflow_function_name = workflow_data["function_name"]
                     file_path = workflow_data["path"]  # Used for __file__ injection and Redis/S3 loading
@@ -580,6 +599,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
                     # Initialize ROI from workflow defaults
                     roi_time_saved = workflow_data["time_saved"]
                     roi_value = workflow_data["value"]
+                    content_hash = workflow_data.get("content_hash")
 
                     # Solution scoping: if the workflow is solution-managed, its
                     # code + imports must resolve under _solutions/{id}/ (with
@@ -620,6 +640,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
                         status=ExecutionStatus.FAILED,
                         execution_model="process",
                         workflow_id=workflow_id,
+                        solution_deployment_id=solution_deployment_id,
                     )
                     await update_execution(
                         execution_id=execution_id,
@@ -672,6 +693,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 status=ExecutionStatus.RUNNING,
                 execution_model="process",
                 workflow_id=workflow_id,
+                solution_deployment_id=solution_deployment_id,
             )
             await publish_execution_update(execution_id, "Running")
             await publish_history_update(
@@ -739,6 +761,8 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 "content_hash": content_hash,  # Pinned hash at dispatch time
                 "event": event_data,  # EventContext dict (None if not event-triggered)
                 "solution_id": solution_id,  # Install id if solution-managed (else None)
+                "solution_deployment_id": solution_deployment_id,
+                "runtime_storage_prefix": runtime_storage_prefix,
                 "solution_global_repo_access": solution_global_repo_access,
                 # Pre-minted engine token: child writes directly to credentials file,
                 # no SECRET_KEY required in child env.

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -25,6 +25,7 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any
+from uuid import UUID
 
 from src.core.pubsub import publish_execution_update, publish_history_update
 from src.core.redis_client import get_redis_client
@@ -562,6 +563,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
             solution_id: str | None = None  # Install id if solution-managed
             solution_global_repo_access = False  # Whether solution code may import _repo/
             solution_deployment_id = pending.get("solution_deployment_id")
+            runtime_mode = pending.get("runtime_mode") or "legacy"
             runtime_storage_prefix: str | None = None
 
             if not is_script and workflow_id:
@@ -573,12 +575,35 @@ class WorkflowExecutionConsumer(BaseConsumer):
                     if solution_deployment_id:
                         from src.services.solutions.deployment_runtime import (
                             DeploymentRuntimeError,
+                            resolve_pinned_workflow_runtime,
+                            verify_runtime_evidence,
                             workflow_data_from_evidence,
                         )
+                        from src.models.orm.executions import Execution
 
                         try:
+                            async with get_db_context() as db:
+                                execution = await db.get(Execution, UUID(execution_id))
+                                if execution is None or execution.runtime_mode != "deployment-v1":
+                                    raise DeploymentRuntimeError(
+                                        "modern deployment execution is missing durable pin evidence"
+                                    )
+                                if str(execution.solution_deployment_id) != str(solution_deployment_id):
+                                    raise DeploymentRuntimeError("durable deployment pin mismatch")
+                                queued_evidence = pending.get("runtime_evidence")
+                                pinned = await resolve_pinned_workflow_runtime(
+                                    db, UUID(str(solution_deployment_id)), UUID(str(workflow_id))
+                                )
+                            authoritative_evidence = pinned.queue_evidence()
+                            verify_runtime_evidence(
+                                str(solution_deployment_id),
+                                queued_evidence,
+                                execution.runtime_evidence,
+                                execution.runtime_evidence_hash,
+                                authoritative_evidence,
+                            )
                             workflow_data = workflow_data_from_evidence(
-                                str(solution_deployment_id), pending.get("runtime_evidence")
+                                str(solution_deployment_id), authoritative_evidence
                             )
                         except DeploymentRuntimeError as exc:
                             raise WorkflowNotFoundError(str(exc)) from exc
@@ -587,6 +612,10 @@ class WorkflowExecutionConsumer(BaseConsumer):
                         # Compatibility boundary: newly enqueued Solution work is
                         # always pinned above, so a null deployment here is either
                         # `_repo` or a pre-migration pending/scheduled execution.
+                        if runtime_mode not in {"legacy", "repo-v1"}:
+                            raise WorkflowNotFoundError(
+                                "modern Solution execution is missing deployment pin"
+                            )
                         async with get_db_context() as db:
                             workflow_data = await get_workflow_for_execution(workflow_id, db=db)
                     workflow_name = workflow_data["name"]
@@ -763,6 +792,9 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 "solution_id": solution_id,  # Install id if solution-managed (else None)
                 "solution_deployment_id": solution_deployment_id,
                 "runtime_storage_prefix": runtime_storage_prefix,
+                "deployment_source_hashes": (
+                    pending.get("runtime_evidence") or {}
+                ).get("deployment_source_hashes"),
                 "solution_global_repo_access": solution_global_repo_access,
                 # Pre-minted engine token: child writes directly to credentials file,
                 # no SECRET_KEY required in child env.

--- a/api/src/jobs/schedulers/deferred_execution_promoter.py
+++ b/api/src/jobs/schedulers/deferred_execution_promoter.py
@@ -85,6 +85,8 @@ async def promote_due_executions() -> tuple[int, int]:
                         (row.execution_context or {}).get("is_platform_admin", False)
                     ),
                     file_path=None,
+                    solution_deployment_id=str(row.solution_deployment_id) if row.solution_deployment_id else None,
+                    runtime_evidence=(row.execution_context or {}).get("runtime_evidence"),
                 )
                 promoted += 1
             except Exception:

--- a/api/src/jobs/schedulers/deferred_execution_promoter.py
+++ b/api/src/jobs/schedulers/deferred_execution_promoter.py
@@ -87,6 +87,7 @@ async def promote_due_executions() -> tuple[int, int]:
                     file_path=None,
                     solution_deployment_id=str(row.solution_deployment_id) if row.solution_deployment_id else None,
                     runtime_evidence=(row.execution_context or {}).get("runtime_evidence"),
+                    runtime_mode=row.runtime_mode,
                 )
                 promoted += 1
             except Exception:

--- a/api/src/models/orm/executions.py
+++ b/api/src/models/orm/executions.py
@@ -67,6 +67,9 @@ class Execution(Base):
     workflow_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("workflows.id", ondelete="SET NULL", onupdate="CASCADE"), default=None
     )  # FK to the workflow that was executed (null for inline scripts/legacy)
+    solution_deployment_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("solution_deployments.id", ondelete="RESTRICT"), default=None
+    )
     api_key_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("workflows.id", ondelete="SET NULL", onupdate="CASCADE"), default=None
     )  # Workflow whose API key triggered this execution (null for user-triggered)
@@ -108,6 +111,7 @@ class Execution(Base):
         Index("ix_executions_is_local_execution", "is_local_execution"),
         Index("ix_executions_session_id", "session_id"),
         Index("ix_executions_workflow_id", "workflow_id"),
+        Index("ix_executions_solution_deployment_id", "solution_deployment_id"),
     )
 
 

--- a/api/src/models/orm/executions.py
+++ b/api/src/models/orm/executions.py
@@ -70,6 +70,11 @@ class Execution(Base):
     solution_deployment_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("solution_deployments.id", ondelete="RESTRICT"), default=None
     )
+    runtime_mode: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="legacy", server_default="legacy"
+    )
+    runtime_evidence: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    runtime_evidence_hash: Mapped[str | None] = mapped_column(String(71), nullable=True)
     api_key_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("workflows.id", ondelete="SET NULL", onupdate="CASCADE"), default=None
     )  # Workflow whose API key triggered this execution (null for user-triggered)

--- a/api/src/models/orm/solutions.py
+++ b/api/src/models/orm/solutions.py
@@ -91,6 +91,17 @@ class Solution(Base):
         default=None,
     )
 
+    # Positive compatibility discriminator. Rows that predate immutable
+    # deployments, and installs created by the legacy ZIP/git projection paths,
+    # execute from their mutable Solution storage. New deployment-aware rows
+    # fail closed until active_deployment_id is set.
+    execution_runtime_mode: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="deployment-v1",
+        server_default=text("'deployment-v1'"),
+    )
+
     # Definition identity (shared across installs of the same Solution).
     slug: Mapped[str] = mapped_column(String(255), index=True)
     name: Mapped[str] = mapped_column(String(255))

--- a/api/src/repositories/executions.py
+++ b/api/src/repositories/executions.py
@@ -76,6 +76,7 @@ class ExecutionRepository(BaseRepository[Execution]):
         is_local_execution: bool = False,
         execution_model: str | None = None,
         workflow_id: str | None = None,
+        solution_deployment_id: str | None = None,
     ) -> Execution:
         """
         Create a new execution record.
@@ -118,6 +119,7 @@ class ExecutionRepository(BaseRepository[Execution]):
 
         # Parse workflow_id if present
         parsed_workflow_id = UUID(workflow_id) if workflow_id else None
+        parsed_solution_deployment_id = UUID(solution_deployment_id) if solution_deployment_id else None
 
         # A scheduled execution has a pre-existing row (inserted at schedule
         # time as SCHEDULED, promoted to PENDING by the scheduler). In that
@@ -126,6 +128,7 @@ class ExecutionRepository(BaseRepository[Execution]):
         if existing is not None:
             existing.workflow_name = workflow_name
             existing.workflow_id = parsed_workflow_id
+            existing.solution_deployment_id = parsed_solution_deployment_id
             existing.status = status
             existing.parameters = parameters
             existing.executed_by = parsed_user_id
@@ -148,6 +151,7 @@ class ExecutionRepository(BaseRepository[Execution]):
             id=UUID(execution_id),
             workflow_name=workflow_name,
             workflow_id=parsed_workflow_id,
+            solution_deployment_id=parsed_solution_deployment_id,
             status=status,
             parameters=parameters,
             executed_by=parsed_user_id,
@@ -666,6 +670,7 @@ async def create_execution(
     is_local_execution: bool = False,
     execution_model: str | None = None,
     workflow_id: str | None = None,
+    solution_deployment_id: str | None = None,
     session: "AsyncSession | None" = None,
 ) -> None:
     """
@@ -697,6 +702,7 @@ async def create_execution(
             is_local_execution=is_local_execution,
             execution_model=execution_model,
             workflow_id=workflow_id,
+            solution_deployment_id=solution_deployment_id,
         )
 
     if session is not None:

--- a/api/src/repositories/executions.py
+++ b/api/src/repositories/executions.py
@@ -126,7 +126,7 @@ class ExecutionRepository(BaseRepository[Execution]):
         # case update-in-place instead of inserting a duplicate PK.
         existing = await self.session.get(Execution, UUID(execution_id))
         if existing is not None:
-            if existing.solution_deployment_id != parsed_solution_deployment_id:
+            if getattr(existing, "solution_deployment_id", None) != parsed_solution_deployment_id:
                 raise ValueError("immutable scheduled execution deployment pin mismatch")
             existing.workflow_name = workflow_name
             existing.workflow_id = parsed_workflow_id

--- a/api/src/repositories/executions.py
+++ b/api/src/repositories/executions.py
@@ -126,9 +126,10 @@ class ExecutionRepository(BaseRepository[Execution]):
         # case update-in-place instead of inserting a duplicate PK.
         existing = await self.session.get(Execution, UUID(execution_id))
         if existing is not None:
+            if existing.solution_deployment_id != parsed_solution_deployment_id:
+                raise ValueError("immutable scheduled execution deployment pin mismatch")
             existing.workflow_name = workflow_name
             existing.workflow_id = parsed_workflow_id
-            existing.solution_deployment_id = parsed_solution_deployment_id
             existing.status = status
             existing.parameters = parameters
             existing.executed_by = parsed_user_id

--- a/api/src/repositories/solution_deployments.py
+++ b/api/src/repositories/solution_deployments.py
@@ -77,6 +77,17 @@ class SolutionDeploymentRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_by_id_for_runtime(
+        self, deployment_id: UUID
+    ) -> SolutionDeployment | None:
+        """Internal immutable-runtime lookup; authorization happened at pin creation."""
+        result = await self.session.execute(
+            select(SolutionDeployment)
+            .options(selectinload(SolutionDeployment.dependencies))
+            .where(SolutionDeployment.id == deployment_id)
+        )
+        return result.scalar_one_or_none()
+
     async def transition(
         self,
         deployment_id: UUID,

--- a/api/src/routers/solutions.py
+++ b/api/src/routers/solutions.py
@@ -182,6 +182,7 @@ async def create_solution(body: SolutionCreate, ctx: Context, user: CurrentSuper
         git_repo_url=body.git_repo_url,
         repo_subpath=body.repo_subpath,
         git_ref=body.git_ref,
+        execution_runtime_mode="repo-v1",
     )
     ctx.db.add(row)
     try:
@@ -2089,6 +2090,7 @@ async def install_from_repo(
             git_repo_url=body.repo_url,
             repo_subpath=body.repo_subpath,
             git_ref=body.git_ref,
+            execution_runtime_mode="repo-v1",
         )
         ctx.db.add(solution)
         try:

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -676,6 +676,10 @@ async def _insert_scheduled_execution(
     from src.models.orm.executions import Execution
 
     exec_id = uuid4()
+    from src.services.solutions.deployment_runtime import pin_workflow_runtime
+
+    pinned_runtime = await pin_workflow_runtime(db, workflow_id)
+    runtime_evidence = pinned_runtime.queue_evidence() if pinned_runtime else None
     db.add(
         Execution(
             id=exec_id,
@@ -689,7 +693,11 @@ async def _insert_scheduled_execution(
             executed_by_name=executed_by_name,
             form_id=form_id,
             api_key_id=api_key_id,
-            execution_context={"is_platform_admin": is_platform_admin},
+            solution_deployment_id=pinned_runtime.deployment_id if pinned_runtime else None,
+            execution_context={
+                "is_platform_admin": is_platform_admin,
+                "runtime_evidence": runtime_evidence,
+            },
         )
     )
     await db.commit()

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -683,6 +683,9 @@ async def _insert_scheduled_execution(
     from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
 
     runtime_mode = "deployment-v1" if pinned_runtime else "repo-v1"
+    execution_context: dict[str, object] = {"is_platform_admin": is_platform_admin}
+    if runtime_evidence is not None:
+        execution_context["runtime_evidence"] = runtime_evidence
     db.add(
         Execution(
             id=exec_id,
@@ -702,10 +705,7 @@ async def _insert_scheduled_execution(
             runtime_evidence_hash=(
                 sha256_digest(canonical_json(runtime_evidence)) if runtime_evidence else None
             ),
-            execution_context={
-                "is_platform_admin": is_platform_admin,
-                "runtime_evidence": runtime_evidence,
-            },
+            execution_context=execution_context,
         )
     )
     await db.commit()

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -680,6 +680,9 @@ async def _insert_scheduled_execution(
 
     pinned_runtime = await pin_workflow_runtime(db, workflow_id)
     runtime_evidence = pinned_runtime.queue_evidence() if pinned_runtime else None
+    from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
+
+    runtime_mode = "deployment-v1" if pinned_runtime else "repo-v1"
     db.add(
         Execution(
             id=exec_id,
@@ -694,6 +697,11 @@ async def _insert_scheduled_execution(
             form_id=form_id,
             api_key_id=api_key_id,
             solution_deployment_id=pinned_runtime.deployment_id if pinned_runtime else None,
+            runtime_mode=runtime_mode,
+            runtime_evidence=runtime_evidence,
+            runtime_evidence_hash=(
+                sha256_digest(canonical_json(runtime_evidence)) if runtime_evidence else None
+            ),
             execution_context={
                 "is_platform_admin": is_platform_admin,
                 "runtime_evidence": runtime_evidence,

--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -33,6 +33,61 @@ tracer = trace.get_tracer(__name__)
 QUEUE_NAME = "workflow-executions"
 
 
+async def _persist_execution_pin(
+    context: ExecutionContext,
+    execution_id: str,
+    workflow_id: str,
+    parameters: dict[str, Any],
+    org_id_override: str | None,
+) -> tuple[Any | None, dict[str, Any] | None, str]:
+    """Persist immutable runtime evidence before anything enters the queue."""
+    from src.core.database import get_db_context
+    from src.models.enums import ExecutionStatus
+    from src.models.orm.executions import Execution
+    from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
+    from src.services.solutions.deployment_runtime import pin_workflow_runtime
+
+    async with get_db_context() as db:
+        caller_deployment_id = (
+            uuid.UUID(context.solution_deployment_id)
+            if context.solution_deployment_id
+            else None
+        )
+        pinned_runtime = await pin_workflow_runtime(
+            db, uuid.UUID(workflow_id), caller_deployment_id=caller_deployment_id
+        )
+        runtime_evidence = pinned_runtime.queue_evidence() if pinned_runtime else None
+        runtime_mode = "deployment-v1" if pinned_runtime else "repo-v1"
+        existing = await db.get(Execution, uuid.UUID(execution_id))
+        if existing is not None:
+            return pinned_runtime, runtime_evidence, runtime_mode
+
+        evidence_hash = (
+            sha256_digest(canonical_json(runtime_evidence)) if runtime_evidence else None
+        )
+        org_value = org_id_override or context.org_id
+        db.add(
+            Execution(
+                id=uuid.UUID(execution_id),
+                workflow_name=pinned_runtime.name if pinned_runtime else "pending",
+                workflow_id=uuid.UUID(workflow_id),
+                solution_deployment_id=(
+                    pinned_runtime.deployment_id if pinned_runtime else None
+                ),
+                runtime_mode=runtime_mode,
+                runtime_evidence=runtime_evidence,
+                runtime_evidence_hash=evidence_hash,
+                status=ExecutionStatus.PENDING,
+                parameters=parameters,
+                executed_by=uuid.UUID(context.user_id),
+                executed_by_name=context.name,
+                organization_id=(uuid.UUID(org_value) if org_value else None),
+            )
+        )
+        await db.commit()
+        return pinned_runtime, runtime_evidence, runtime_mode
+
+
 async def _publish_pending(
     execution_id: str,
     workflow_id: str | None,
@@ -151,52 +206,13 @@ async def enqueue_workflow_execution(
     Returns:
         execution_id: UUID of the queued execution
     """
-    from src.core.database import get_db_context
-    from src.models.enums import ExecutionStatus
-    from src.models.orm.executions import Execution
-    from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
-    from src.services.solutions.deployment_runtime import pin_workflow_runtime
-
     # Generate first: the durable row and queue payload share one identity.
     if execution_id is None:
         execution_id = str(uuid.uuid4())
 
-    async with get_db_context() as db:
-        caller_deployment_id = (
-            uuid.UUID(context.solution_deployment_id)
-            if context.solution_deployment_id
-            else None
-        )
-        pinned_runtime = await pin_workflow_runtime(
-            db, uuid.UUID(workflow_id), caller_deployment_id=caller_deployment_id
-        )
-        runtime_evidence = pinned_runtime.queue_evidence() if pinned_runtime else None
-        runtime_mode = "deployment-v1" if pinned_runtime else "repo-v1"
-        evidence_hash = (
-            sha256_digest(canonical_json(runtime_evidence)) if runtime_evidence else None
-        )
-        existing = await db.get(Execution, uuid.UUID(execution_id))
-        if existing is None:
-            org_value = org_id_override or context.org_id
-            db.add(
-                Execution(
-                    id=uuid.UUID(execution_id),
-                    workflow_name=pinned_runtime.name if pinned_runtime else "pending",
-                    workflow_id=uuid.UUID(workflow_id),
-                    solution_deployment_id=(
-                        pinned_runtime.deployment_id if pinned_runtime else None
-                    ),
-                    runtime_mode=runtime_mode,
-                    runtime_evidence=runtime_evidence,
-                    runtime_evidence_hash=evidence_hash,
-                    status=ExecutionStatus.PENDING,
-                    parameters=parameters,
-                    executed_by=uuid.UUID(context.user_id),
-                    executed_by_name=context.name,
-                    organization_id=(uuid.UUID(org_value) if org_value else None),
-                )
-            )
-            await db.commit()
+    pinned_runtime, runtime_evidence, runtime_mode = await _persist_execution_pin(
+        context, execution_id, workflow_id, parameters, org_id_override
+    )
     solution_deployment_id = str(pinned_runtime.deployment_id) if pinned_runtime else None
 
     # Serialize event context for cross-process transit. EventContext is a

--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -160,8 +160,9 @@ async def _publish_pending(
                 "execution_id": execution_id,
                 "workflow_id": workflow_id,
                 "sync": sync,
-                "solution_deployment_id": solution_deployment_id,
             }
+            if solution_deployment_id is not None:
+                message["solution_deployment_id"] = solution_deployment_id
 
             # Include file_path for fast direct loading (avoids filesystem scan)
             if file_path:

--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -48,6 +48,8 @@ async def _publish_pending(
     is_platform_admin: bool,
     file_path: str | None,
     event: dict[str, Any] | None = None,
+    solution_deployment_id: str | None = None,
+    runtime_evidence: dict[str, Any] | None = None,
 ) -> None:
     """
     Write a pending-execution blob to Redis, register with the queue tracker,
@@ -89,6 +91,8 @@ async def _publish_pending(
                 sync=sync,
                 is_platform_admin=is_platform_admin,
                 event=event,
+                solution_deployment_id=solution_deployment_id,
+                runtime_evidence=runtime_evidence,
             )
 
             # Add to queue tracking (publishes position updates to all queued executions)
@@ -99,6 +103,7 @@ async def _publish_pending(
                 "execution_id": execution_id,
                 "workflow_id": workflow_id,
                 "sync": sync,
+                "solution_deployment_id": solution_deployment_id,
             }
 
             # Include file_path for fast direct loading (avoids filesystem scan)
@@ -144,6 +149,14 @@ async def enqueue_workflow_execution(
     Returns:
         execution_id: UUID of the queued execution
     """
+    from src.core.database import get_db_context
+    from src.services.solutions.deployment_runtime import pin_workflow_runtime
+
+    async with get_db_context() as db:
+        pinned_runtime = await pin_workflow_runtime(db, uuid.UUID(workflow_id))
+    runtime_evidence = pinned_runtime.queue_evidence() if pinned_runtime else None
+    solution_deployment_id = str(pinned_runtime.deployment_id) if pinned_runtime else None
+
     # Generate or use provided execution ID
     if execution_id is None:
         execution_id = str(uuid.uuid4())
@@ -171,6 +184,8 @@ async def enqueue_workflow_execution(
         is_platform_admin=context.is_platform_admin,
         file_path=file_path,
         event=event_payload,
+        solution_deployment_id=solution_deployment_id,
+        runtime_evidence=runtime_evidence,
     )
 
     logger.info(

--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -50,6 +50,7 @@ async def _publish_pending(
     event: dict[str, Any] | None = None,
     solution_deployment_id: str | None = None,
     runtime_evidence: dict[str, Any] | None = None,
+    runtime_mode: str = "legacy",
 ) -> None:
     """
     Write a pending-execution blob to Redis, register with the queue tracker,
@@ -93,6 +94,7 @@ async def _publish_pending(
                 event=event,
                 solution_deployment_id=solution_deployment_id,
                 runtime_evidence=runtime_evidence,
+                runtime_mode=runtime_mode,
             )
 
             # Add to queue tracking (publishes position updates to all queued executions)
@@ -150,16 +152,52 @@ async def enqueue_workflow_execution(
         execution_id: UUID of the queued execution
     """
     from src.core.database import get_db_context
+    from src.models.enums import ExecutionStatus
+    from src.models.orm.executions import Execution
+    from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
     from src.services.solutions.deployment_runtime import pin_workflow_runtime
 
-    async with get_db_context() as db:
-        pinned_runtime = await pin_workflow_runtime(db, uuid.UUID(workflow_id))
-    runtime_evidence = pinned_runtime.queue_evidence() if pinned_runtime else None
-    solution_deployment_id = str(pinned_runtime.deployment_id) if pinned_runtime else None
-
-    # Generate or use provided execution ID
+    # Generate first: the durable row and queue payload share one identity.
     if execution_id is None:
         execution_id = str(uuid.uuid4())
+
+    async with get_db_context() as db:
+        caller_deployment_id = (
+            uuid.UUID(context.solution_deployment_id)
+            if context.solution_deployment_id
+            else None
+        )
+        pinned_runtime = await pin_workflow_runtime(
+            db, uuid.UUID(workflow_id), caller_deployment_id=caller_deployment_id
+        )
+        runtime_evidence = pinned_runtime.queue_evidence() if pinned_runtime else None
+        runtime_mode = "deployment-v1" if pinned_runtime else "repo-v1"
+        evidence_hash = (
+            sha256_digest(canonical_json(runtime_evidence)) if runtime_evidence else None
+        )
+        existing = await db.get(Execution, uuid.UUID(execution_id))
+        if existing is None:
+            org_value = org_id_override or context.org_id
+            db.add(
+                Execution(
+                    id=uuid.UUID(execution_id),
+                    workflow_name=pinned_runtime.name if pinned_runtime else "pending",
+                    workflow_id=uuid.UUID(workflow_id),
+                    solution_deployment_id=(
+                        pinned_runtime.deployment_id if pinned_runtime else None
+                    ),
+                    runtime_mode=runtime_mode,
+                    runtime_evidence=runtime_evidence,
+                    runtime_evidence_hash=evidence_hash,
+                    status=ExecutionStatus.PENDING,
+                    parameters=parameters,
+                    executed_by=uuid.UUID(context.user_id),
+                    executed_by_name=context.name,
+                    organization_id=(uuid.UUID(org_value) if org_value else None),
+                )
+            )
+            await db.commit()
+    solution_deployment_id = str(pinned_runtime.deployment_id) if pinned_runtime else None
 
     # Serialize event context for cross-process transit. EventContext is a
     # dataclass with primitive fields, so dict serialization is lossless and
@@ -186,6 +224,7 @@ async def enqueue_workflow_execution(
         event=event_payload,
         solution_deployment_id=solution_deployment_id,
         runtime_evidence=runtime_evidence,
+        runtime_mode=runtime_mode,
     )
 
     logger.info(

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -142,6 +142,7 @@ class ExecutionRequest:
     # so the SDK can scope name lookups (tables/configs) to the install's OWN
     # entity — own-first, then _repo/. None for plain _repo/ executions.
     solution_id: str | None = None
+    solution_deployment_id: str | None = None
 
 
 @dataclass
@@ -322,6 +323,7 @@ async def execute(request: ExecutionRequest) -> ExecutionResult:
         roi=roi,
         event=request.event,
         solution_id=request.solution_id,  # install scope for SDK name lookups
+        solution_deployment_id=request.solution_deployment_id,
     )
 
     # Set bifrost SDK context if available

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -378,6 +378,7 @@ async def _execute_async(execution_id: str, worker_id: str) -> dict[str, Any]:
         set_solution_context(
             _exec_solution_id,
             global_repo_access=bool(context.get("solution_global_repo_access", False)),
+            runtime_storage_prefix=context.get("runtime_storage_prefix"),
         )
     _clear_workspace_modules()
 

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -379,6 +379,7 @@ async def _execute_async(execution_id: str, worker_id: str) -> dict[str, Any]:
             _exec_solution_id,
             global_repo_access=bool(context.get("solution_global_repo_access", False)),
             runtime_storage_prefix=context.get("runtime_storage_prefix"),
+            source_hashes=context.get("deployment_source_hashes"),
         )
     _clear_workspace_modules()
 

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -375,12 +375,21 @@ async def _execute_async(execution_id: str, worker_id: str) -> dict[str, Any]:
 
     _exec_solution_id = context.get("solution_id")
     if _exec_solution_id:
-        set_solution_context(
-            _exec_solution_id,
-            global_repo_access=bool(context.get("solution_global_repo_access", False)),
-            runtime_storage_prefix=context.get("runtime_storage_prefix"),
-            source_hashes=context.get("deployment_source_hashes"),
-        )
+        context_options = {
+            "runtime_storage_prefix": context.get("runtime_storage_prefix"),
+            "source_hashes": context.get("deployment_source_hashes"),
+        }
+        if any(value is not None for value in context_options.values()):
+            set_solution_context(
+                _exec_solution_id,
+                global_repo_access=bool(context.get("solution_global_repo_access", False)),
+                **context_options,
+            )
+        else:
+            set_solution_context(
+                _exec_solution_id,
+                global_repo_access=bool(context.get("solution_global_repo_access", False)),
+            )
     _clear_workspace_modules()
 
     # 2. Run the execution using existing worker logic

--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -194,6 +194,7 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
             _exec_solution_id,
             global_repo_access=bool(context_data.get("solution_global_repo_access", False)),
             runtime_storage_prefix=context_data.get("runtime_storage_prefix"),
+            source_hashes=context_data.get("deployment_source_hashes"),
         )
 
     span_attributes = {
@@ -345,6 +346,7 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
             broadcaster=None,  # Logs go to Redis Stream directly
             event=event_ctx,
             solution_id=context_data.get("solution_id"),  # install scope for SDK
+            solution_deployment_id=context_data.get("solution_deployment_id"),
         )
 
         # Execute

--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -193,6 +193,7 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
         set_solution_context(
             _exec_solution_id,
             global_repo_access=bool(context_data.get("solution_global_repo_access", False)),
+            runtime_storage_prefix=context_data.get("runtime_storage_prefix"),
         )
 
     span_attributes = {
@@ -291,11 +292,9 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
                 actual_hash = hashlib.sha256(
                     loaded_code.encode("utf-8")
                 ).hexdigest()
-                if actual_hash != content_hash:
-                    logger.warning(
-                        f"Content hash mismatch for {file_path}: "
-                        f"expected={content_hash[:12]}... actual={actual_hash[:12]}... "
-                        f"Code may have changed between dispatch and execution."
+                if actual_hash != str(content_hash).removeprefix("sha256:"):
+                    raise RuntimeError(
+                        f"deployment source integrity mismatch for {file_path}"
                     )
 
             if workflow_func is None:

--- a/api/src/services/solutions/deployment_runtime.py
+++ b/api/src/services/solutions/deployment_runtime.py
@@ -1,0 +1,194 @@
+"""Execution-time resolution against an immutable Solution deployment closure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Workflow
+from src.models.orm.solutions import Solution
+from src.repositories.solution_deployments import SolutionDeploymentRepository
+from src.services.solutions.deployment_manifest import validate_runtime_closure
+
+
+class DeploymentRuntimeError(RuntimeError):
+    """A Solution execution could not prove its immutable runtime closure."""
+
+
+@dataclass(frozen=True)
+class PinnedWorkflowRuntime:
+    workflow_id: UUID
+    solution_id: UUID
+    deployment_id: UUID
+    bundle_hash: str
+    compiled_manifest_hash: str
+    git_commit_sha: str | None
+    runtime_storage_prefix: str
+    portable_ref: str
+    name: str
+    function_name: str
+    path: str
+    source_hash: str
+    timeout_seconds: int
+    time_saved: int
+    value: float
+    execution_mode: str
+    workflow_type: str
+    cache_ttl_seconds: int
+    organization_id: str | None
+    can_access_global_repo: bool
+
+    def queue_evidence(self) -> dict[str, Any]:
+        return {
+            "solution_id": str(self.solution_id),
+            "solution_deployment_id": str(self.deployment_id),
+            "bundle_hash": self.bundle_hash,
+            "compiled_manifest_hash": self.compiled_manifest_hash,
+            "git_commit_sha": self.git_commit_sha,
+            "runtime_storage_prefix": self.runtime_storage_prefix,
+            "workflow_portable_ref": self.portable_ref,
+            "workflow_name": self.name,
+            "workflow_function_name": self.function_name,
+            "workflow_path": self.path,
+            "workflow_source_hash": self.source_hash,
+            "workflow_timeout_seconds": self.timeout_seconds,
+            "workflow_time_saved": self.time_saved,
+            "workflow_value": self.value,
+            "workflow_execution_mode": self.execution_mode,
+            "workflow_type": self.workflow_type,
+            "workflow_cache_ttl_seconds": self.cache_ttl_seconds,
+            "workflow_organization_id": self.organization_id,
+            "solution_global_repo_access": self.can_access_global_repo,
+        }
+
+
+def workflow_data_from_evidence(
+    deployment_id: str, evidence: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Validate trusted queue evidence and expose the legacy consumer shape."""
+    if not isinstance(evidence, dict):
+        raise DeploymentRuntimeError("pinned execution is missing runtime evidence")
+    if evidence.get("solution_deployment_id") != deployment_id:
+        raise DeploymentRuntimeError("pinned execution deployment evidence mismatch")
+    required = (
+        "workflow_name", "workflow_function_name", "workflow_path",
+        "workflow_source_hash", "solution_id", "runtime_storage_prefix",
+    )
+    if any(not evidence.get(key) for key in required):
+        raise DeploymentRuntimeError("pinned execution runtime evidence is incomplete")
+    return {
+        "name": evidence["workflow_name"],
+        "function_name": evidence["workflow_function_name"],
+        "path": evidence["workflow_path"],
+        "content_hash": evidence["workflow_source_hash"],
+        "type": evidence.get("workflow_type", "workflow"),
+        "cache_ttl_seconds": evidence.get("workflow_cache_ttl_seconds", 0),
+        "timeout_seconds": evidence.get("workflow_timeout_seconds", 1800),
+        "time_saved": evidence.get("workflow_time_saved", 0),
+        "value": evidence.get("workflow_value", 0),
+        "solution_id": evidence["solution_id"],
+        "organization_id": evidence.get("workflow_organization_id"),
+        "can_access_global_repo": evidence.get("solution_global_repo_access", False),
+        "runtime_storage_prefix": evidence["runtime_storage_prefix"],
+    }
+
+
+def _required(definition: dict[str, Any], key: str) -> Any:
+    value = definition.get(key)
+    if value is None or value == "":
+        raise DeploymentRuntimeError(f"compiled workflow definition missing {key}")
+    return value
+
+
+def _number(definition: dict[str, Any], key: str, default: int | float) -> int | float:
+    value = definition.get(key, default)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise DeploymentRuntimeError(f"compiled workflow definition has invalid {key}")
+    return value
+
+
+async def pin_workflow_runtime(
+    session: AsyncSession, workflow_id: UUID
+) -> PinnedWorkflowRuntime | None:
+    """Return immutable evidence for a Solution workflow; None means `_repo`."""
+    row = (
+        await session.execute(
+            select(Workflow, Solution)
+            .outerjoin(Solution, Workflow.solution_id == Solution.id)
+            .where(Workflow.id == workflow_id, Workflow.is_active.is_(True))
+        )
+    ).one_or_none()
+    if row is None:
+        raise DeploymentRuntimeError(f"workflow {workflow_id} is not executable")
+    workflow, solution = row
+    if workflow.solution_id is None:
+        return None
+    if solution is None or solution.status != "active":
+        raise DeploymentRuntimeError("Solution is not active")
+    if solution.active_deployment_id is None:
+        raise DeploymentRuntimeError(
+            "Solution has no active deployment; capture an initial deployment before execution"
+        )
+
+    deployment = await SolutionDeploymentRepository(session).get_runtime_closure(
+        solution.active_deployment_id, solution.organization_id
+    )
+    if deployment is None or deployment.solution_id != solution.id:
+        raise DeploymentRuntimeError("active deployment is missing or out of scope")
+    if deployment.state not in {"active", "committed_unpushed"}:
+        raise DeploymentRuntimeError("active deployment is not executable")
+    _, resolution = validate_runtime_closure(
+        deployment.compiled_manifest,
+        deployment.resolution_map,
+        deployment.dependencies,
+        expected_manifest_hash=deployment.compiled_manifest_hash,
+        expected_resolution_hash=deployment.resolution_map_hash,
+    )
+    try:
+        entity = resolution.resolve_workflow_id(workflow.id)
+    except KeyError as exc:
+        raise DeploymentRuntimeError(
+            f"workflow {workflow.id} is absent from active deployment"
+        ) from exc
+    definition = entity.definition
+    source_ref = entity.source_ref or str(_required(definition, "path"))
+    try:
+        source = resolution.resolve_source(source_ref)
+    except KeyError as exc:
+        raise DeploymentRuntimeError(f"source {source_ref} is unresolved") from exc
+    runtime_prefix = deployment.runtime_storage_prefix.rstrip("/") + "/"
+    workflow_path = str(_required(definition, "path")).lstrip("/")
+    if source.object_key != f"{runtime_prefix}{workflow_path}":
+        raise DeploymentRuntimeError(
+            "workflow source is outside deployment runtime prefix"
+        )
+    return PinnedWorkflowRuntime(
+        workflow_id=workflow.id,
+        solution_id=solution.id,
+        deployment_id=deployment.id,
+        bundle_hash=deployment.bundle_hash,
+        compiled_manifest_hash=deployment.compiled_manifest_hash,
+        git_commit_sha=deployment.git_commit_sha,
+        runtime_storage_prefix=runtime_prefix,
+        portable_ref=entity.portable_ref,
+        name=str(_required(definition, "name")),
+        function_name=str(_required(definition, "function_name")),
+        path=workflow_path,
+        source_hash=source.content_hash,
+        timeout_seconds=int(_number(definition, "timeout_seconds", 1800)),
+        time_saved=int(_number(definition, "time_saved", 0)),
+        value=float(_number(definition, "value", 0)),
+        execution_mode=str(definition.get("execution_mode") or "async"),
+        workflow_type=str(definition.get("type") or "workflow"),
+        cache_ttl_seconds=int(_number(definition, "cache_ttl_seconds", 0)),
+        organization_id=(
+            str(definition["organization_id"])
+            if definition.get("organization_id")
+            else None
+        ),
+        can_access_global_repo=bool(solution.global_repo_access),
+    )

--- a/api/src/services/solutions/deployment_runtime.py
+++ b/api/src/services/solutions/deployment_runtime.py
@@ -19,6 +19,28 @@ class DeploymentRuntimeError(RuntimeError):
     """A Solution execution could not prove its immutable runtime closure."""
 
 
+def verify_runtime_evidence(
+    deployment_id: str,
+    queued: dict[str, Any] | None,
+    durable: dict[str, Any] | None,
+    durable_hash: str | None,
+    authoritative: dict[str, Any],
+) -> None:
+    """Require queue, database, and immutable-manifest evidence to be identical."""
+    from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
+
+    if not isinstance(queued, dict) or queued != durable:
+        raise DeploymentRuntimeError("queue evidence differs from durable pin")
+    if queued.get("solution_deployment_id") != deployment_id:
+        raise DeploymentRuntimeError("pinned execution deployment evidence mismatch")
+    if sha256_digest(canonical_json(queued)) != durable_hash:
+        raise DeploymentRuntimeError("durable runtime evidence hash mismatch")
+    if queued != authoritative:
+        raise DeploymentRuntimeError(
+            "runtime evidence differs from immutable deployment manifest"
+        )
+
+
 @dataclass(frozen=True)
 class PinnedWorkflowRuntime:
     workflow_id: UUID
@@ -41,6 +63,7 @@ class PinnedWorkflowRuntime:
     cache_ttl_seconds: int
     organization_id: str | None
     can_access_global_repo: bool
+    source_hashes: dict[str, str]
 
     def queue_evidence(self) -> dict[str, Any]:
         return {
@@ -63,6 +86,7 @@ class PinnedWorkflowRuntime:
             "workflow_cache_ttl_seconds": self.cache_ttl_seconds,
             "workflow_organization_id": self.organization_id,
             "solution_global_repo_access": self.can_access_global_repo,
+            "deployment_source_hashes": self.source_hashes,
         }
 
 
@@ -112,7 +136,10 @@ def _number(definition: dict[str, Any], key: str, default: int | float) -> int |
 
 
 async def pin_workflow_runtime(
-    session: AsyncSession, workflow_id: UUID
+    session: AsyncSession,
+    workflow_id: UUID,
+    *,
+    caller_deployment_id: UUID | None = None,
 ) -> PinnedWorkflowRuntime | None:
     """Return immutable evidence for a Solution workflow; None means `_repo`."""
     row = (
@@ -127,19 +154,45 @@ async def pin_workflow_runtime(
     workflow, solution = row
     if workflow.solution_id is None:
         return None
-    if solution is None or solution.status != "active":
+    if solution is None or (caller_deployment_id is None and solution.status != "active"):
         raise DeploymentRuntimeError("Solution is not active")
-    if solution.active_deployment_id is None:
+    selected_deployment_id = solution.active_deployment_id
+    if caller_deployment_id is not None:
+        caller = await SolutionDeploymentRepository(session).get_by_id_for_runtime(
+            caller_deployment_id
+        )
+        if caller is None:
+            raise DeploymentRuntimeError("caller deployment is missing")
+        if workflow.solution_id == caller.solution_id:
+            selected_deployment_id = caller.id
+        else:
+            edge = next(
+                (
+                    item
+                    for item in caller.dependencies
+                    if item.dependency_solution_id == workflow.solution_id
+                ),
+                None,
+            )
+            if edge is None:
+                raise DeploymentRuntimeError(
+                    "cross-Solution workflow is not pinned by the caller deployment"
+                )
+            selected_deployment_id = edge.dependency_deployment_id
+    if selected_deployment_id is None:
         raise DeploymentRuntimeError(
             "Solution has no active deployment; capture an initial deployment before execution"
         )
 
     deployment = await SolutionDeploymentRepository(session).get_runtime_closure(
-        solution.active_deployment_id, solution.organization_id
+        selected_deployment_id, solution.organization_id
     )
     if deployment is None or deployment.solution_id != solution.id:
         raise DeploymentRuntimeError("active deployment is missing or out of scope")
-    if deployment.state not in {"active", "committed_unpushed"}:
+    executable_states = {"active", "committed_unpushed"}
+    if caller_deployment_id is not None:
+        executable_states.add("superseded")
+    if deployment.state not in executable_states:
         raise DeploymentRuntimeError("active deployment is not executable")
     _, resolution = validate_runtime_closure(
         deployment.compiled_manifest,
@@ -191,4 +244,17 @@ async def pin_workflow_runtime(
             else None
         ),
         can_access_global_repo=bool(solution.global_repo_access),
+        source_hashes={key: item.content_hash for key, item in resolution.sources.items()},
     )
+
+
+async def resolve_pinned_workflow_runtime(
+    session: AsyncSession, deployment_id: UUID, workflow_id: UUID
+) -> PinnedWorkflowRuntime:
+    """Resolve by an explicit immutable deployment, never by the active pointer."""
+    pinned = await pin_workflow_runtime(
+        session, workflow_id, caller_deployment_id=deployment_id
+    )
+    if pinned is None or pinned.deployment_id != deployment_id:
+        raise DeploymentRuntimeError("workflow does not belong to the pinned deployment")
+    return pinned

--- a/api/src/services/solutions/deployment_runtime.py
+++ b/api/src/services/solutions/deployment_runtime.py
@@ -160,6 +160,8 @@ async def pin_workflow_runtime(
         session, workflow.solution_id, solution.active_deployment_id, caller_deployment_id
     )
     if selected_deployment_id is None:
+        if solution.execution_runtime_mode == "repo-v1":
+            return None
         raise DeploymentRuntimeError(
             "Solution has no active deployment; capture an initial deployment before execution"
         )

--- a/api/src/services/solutions/deployment_runtime.py
+++ b/api/src/services/solutions/deployment_runtime.py
@@ -156,29 +156,9 @@ async def pin_workflow_runtime(
         return None
     if solution is None or (caller_deployment_id is None and solution.status != "active"):
         raise DeploymentRuntimeError("Solution is not active")
-    selected_deployment_id = solution.active_deployment_id
-    if caller_deployment_id is not None:
-        caller = await SolutionDeploymentRepository(session).get_by_id_for_runtime(
-            caller_deployment_id
-        )
-        if caller is None:
-            raise DeploymentRuntimeError("caller deployment is missing")
-        if workflow.solution_id == caller.solution_id:
-            selected_deployment_id = caller.id
-        else:
-            edge = next(
-                (
-                    item
-                    for item in caller.dependencies
-                    if item.dependency_solution_id == workflow.solution_id
-                ),
-                None,
-            )
-            if edge is None:
-                raise DeploymentRuntimeError(
-                    "cross-Solution workflow is not pinned by the caller deployment"
-                )
-            selected_deployment_id = edge.dependency_deployment_id
+    selected_deployment_id = await _select_deployment_id(
+        session, workflow.solution_id, solution.active_deployment_id, caller_deployment_id
+    )
     if selected_deployment_id is None:
         raise DeploymentRuntimeError(
             "Solution has no active deployment; capture an initial deployment before execution"
@@ -201,12 +181,7 @@ async def pin_workflow_runtime(
         expected_manifest_hash=deployment.compiled_manifest_hash,
         expected_resolution_hash=deployment.resolution_map_hash,
     )
-    try:
-        entity = resolution.resolve_workflow_id(workflow.id)
-    except KeyError as exc:
-        raise DeploymentRuntimeError(
-            f"workflow {workflow.id} is absent from active deployment"
-        ) from exc
+    entity = _resolve_workflow_entity(resolution, workflow.id)
     definition = entity.definition
     source_ref = entity.source_ref or str(_required(definition, "path"))
     try:
@@ -246,6 +221,45 @@ async def pin_workflow_runtime(
         can_access_global_repo=bool(solution.global_repo_access),
         source_hashes={key: item.content_hash for key, item in resolution.sources.items()},
     )
+
+
+async def _select_deployment_id(
+    session: AsyncSession,
+    workflow_solution_id: UUID,
+    active_deployment_id: UUID | None,
+    caller_deployment_id: UUID | None,
+) -> UUID | None:
+    if caller_deployment_id is None:
+        return active_deployment_id
+    caller = await SolutionDeploymentRepository(session).get_by_id_for_runtime(
+        caller_deployment_id
+    )
+    if caller is None:
+        raise DeploymentRuntimeError("caller deployment is missing")
+    if workflow_solution_id == caller.solution_id:
+        return caller.id
+    edge = next(
+        (
+            item
+            for item in caller.dependencies
+            if item.dependency_solution_id == workflow_solution_id
+        ),
+        None,
+    )
+    if edge is None:
+        raise DeploymentRuntimeError(
+            "cross-Solution workflow is not pinned by the caller deployment"
+        )
+    return edge.dependency_deployment_id
+
+
+def _resolve_workflow_entity(resolution: Any, workflow_id: UUID) -> Any:
+    try:
+        return resolution.resolve_workflow_id(workflow_id)
+    except KeyError as exc:
+        raise DeploymentRuntimeError(
+            f"workflow {workflow_id} is absent from active deployment"
+        ) from exc
 
 
 async def resolve_pinned_workflow_runtime(

--- a/api/src/services/solutions/zip_install.py
+++ b/api/src/services/solutions/zip_install.py
@@ -430,7 +430,12 @@ async def _resolve_or_create_solution(
             await db.flush()
         return existing
 
-    row = Solution(slug=slug, name=name, organization_id=organization_id)
+    row = Solution(
+        slug=slug,
+        name=name,
+        organization_id=organization_id,
+        execution_runtime_mode="repo-v1",
+    )
     db.add(row)
     await db.flush()
     return row

--- a/api/tests/e2e/platform/test_form_execute_solution_scope_e2e.py
+++ b/api/tests/e2e/platform/test_form_execute_solution_scope_e2e.py
@@ -244,7 +244,8 @@ class TestCrossOrgFormExecuteAnchor:
         db = db_session
         org_b = (await _org(db)).id
         sol = Solution(
-            id=uuid4(), slug=f"s-{uuid4().hex[:8]}", name="S", organization_id=org_b
+            id=uuid4(), slug=f"s-{uuid4().hex[:8]}", name="S", organization_id=org_b,
+            execution_runtime_mode="repo-v1",
         )
         db.add(sol)
         await db.flush()
@@ -330,7 +331,8 @@ class TestCrossOrgFormExecuteAnchor:
         db = db_session
         org_b = (await _org(db)).id
         sol = Solution(
-            id=uuid4(), slug=f"s-{uuid4().hex[:8]}", name="S", organization_id=org_b
+            id=uuid4(), slug=f"s-{uuid4().hex[:8]}", name="S", organization_id=org_b,
+            execution_runtime_mode="repo-v1",
         )
         db.add(sol)
         await db.flush()

--- a/api/tests/unit/core/test_module_cache_sync.py
+++ b/api/tests/unit/core/test_module_cache_sync.py
@@ -235,6 +235,19 @@ def test_candidate_paths_respect_solution_context():
     finally:
         module_cache_sync.clear_solution_context()
 
+    deployment_id = uuid4()
+    module_cache_sync.set_solution_context(
+        solution_id,
+        global_repo_access=False,
+        runtime_storage_prefix=f"_solutions/{solution_id}/{deployment_id}/",
+    )
+    try:
+        assert module_cache_sync.candidate_module_paths("modules/a.py") == [
+            f"_solutions/{solution_id}/{deployment_id}/modules/a.py"
+        ]
+    finally:
+        module_cache_sync.clear_solution_context()
+
     module_cache_sync.set_solution_context(solution_id, global_repo_access=True)
     try:
         assert module_cache_sync.candidate_module_paths("/modules/a.py") == [

--- a/api/tests/unit/core/test_module_cache_sync.py
+++ b/api/tests/unit/core/test_module_cache_sync.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
 
 def _module_cache_sync() -> Any:
     return cast(Any, importlib.import_module("src.core.module_cache_sync"))
@@ -332,6 +333,26 @@ def test_get_module_sync_builds_module_from_object_storage(monkeypatch):
         module_cache_sync.MODULE_INDEX_KEY,
         "modules/a.py",
     )
+
+
+def test_deployment_import_rejects_manifest_hash_mismatch(monkeypatch):
+    module_cache_sync = _module_cache_sync()
+    redis_client = MagicMock()
+    redis_client.get.return_value = json.dumps(
+        {"content": "tampered", "path": "modules/a.py", "hash": "bad"}
+    )
+    monkeypatch.setattr(module_cache_sync, "_get_sync_redis", lambda: redis_client)
+    module_cache_sync.set_solution_context(
+        "solution",
+        False,
+        runtime_storage_prefix="_solutions/solution/deployment/",
+        source_hashes={"modules/a.py": "sha256:expected"},
+    )
+    try:
+        with pytest.raises(RuntimeError, match="import integrity mismatch"):
+            module_cache_sync.get_module_sync("modules/a.py")
+    finally:
+        module_cache_sync.clear_solution_context()
 
 
 def test_get_module_index_sync_repopulates_from_api_then_storage(monkeypatch):

--- a/api/tests/unit/routers/test_workflows_helpers_coverage.py
+++ b/api/tests/unit/routers/test_workflows_helpers_coverage.py
@@ -17,6 +17,9 @@ class _ScalarResult:
     def scalar_one_or_none(self):
         return self._value
 
+    def one_or_none(self):
+        return self._value
+
     def all(self):
         return self._value
 
@@ -246,7 +249,10 @@ async def test_insert_scheduled_execution_persists_expected_execution_fields():
     org_id = uuid4()
     executed_by = uuid4()
     form_id = uuid4()
-    db = _Db()
+    # Runtime pinning deliberately resolves the workflow before persisting the
+    # scheduled row. A non-Solution workflow selects the `_repo` compatibility
+    # mode without any deployment closure lookup.
+    db = _Db((SimpleNamespace(solution_id=None), None))
     scheduled_at = datetime.now(UTC)
 
     execution_id = await workflows._insert_scheduled_execution(

--- a/api/tests/unit/services/execution/test_deployment_enqueue.py
+++ b/api/tests/unit/services/execution/test_deployment_enqueue.py
@@ -71,8 +71,10 @@ async def test_queue_failure_leaves_committed_durable_deployment_pin(monkeypatch
         is_platform_admin=False,
     )
 
+    workflow_id_value = str(workflow_id)
+    parameters = {}
     with pytest.raises(OSError, match="queue unavailable"):
-        await enqueue_workflow_execution(context, str(workflow_id), {})
+        await enqueue_workflow_execution(context, workflow_id_value, parameters)
 
     db.commit.assert_awaited_once()
     assert added[0].solution_deployment_id == deployment_id

--- a/api/tests/unit/services/execution/test_deployment_enqueue.py
+++ b/api/tests/unit/services/execution/test_deployment_enqueue.py
@@ -1,0 +1,80 @@
+from contextlib import asynccontextmanager
+import sys
+from types import SimpleNamespace
+from types import ModuleType
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+sys.modules.setdefault(
+    "opentelemetry",
+    SimpleNamespace(trace=SimpleNamespace(get_tracer=lambda _name: SimpleNamespace())),
+)
+rabbitmq = ModuleType("src.jobs.rabbitmq")
+
+
+async def _unused_publish(*_args, **_kwargs):
+    return None
+
+
+rabbitmq.publish_message = _unused_publish
+sys.modules.setdefault("src.jobs.rabbitmq", rabbitmq)
+sys.modules.setdefault(
+    "opentelemetry.trace",
+    SimpleNamespace(get_tracer=lambda _name: SimpleNamespace()),
+)
+
+from src.services.execution.async_executor import enqueue_workflow_execution  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_queue_failure_leaves_committed_durable_deployment_pin(monkeypatch):
+    deployment_id, workflow_id, user_id = uuid4(), uuid4(), uuid4()
+    evidence = {
+        "solution_deployment_id": str(deployment_id),
+        "workflow_name": "run",
+    }
+    pinned = SimpleNamespace(
+        deployment_id=deployment_id,
+        name="run",
+        queue_evidence=lambda: evidence,
+    )
+    added = []
+    db = SimpleNamespace(
+        get=AsyncMock(return_value=None),
+        add=added.append,
+        commit=AsyncMock(),
+    )
+
+    @asynccontextmanager
+    async def db_context():
+        yield db
+
+    monkeypatch.setattr("src.core.database.get_db_context", db_context)
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_runtime.pin_workflow_runtime",
+        AsyncMock(return_value=pinned),
+    )
+    monkeypatch.setattr(
+        "src.services.execution.async_executor._publish_pending",
+        AsyncMock(side_effect=OSError("queue unavailable")),
+    )
+    context = SimpleNamespace(
+        solution_deployment_id=None,
+        event=None,
+        org_id=None,
+        user_id=str(user_id),
+        name="User",
+        email="user@example.com",
+        startup=None,
+        is_platform_admin=False,
+    )
+
+    with pytest.raises(OSError, match="queue unavailable"):
+        await enqueue_workflow_execution(context, str(workflow_id), {})
+
+    db.commit.assert_awaited_once()
+    assert added[0].solution_deployment_id == deployment_id
+    assert added[0].runtime_mode == "deployment-v1"
+    assert added[0].runtime_evidence == evidence

--- a/api/tests/unit/services/solutions/test_deployment_runtime.py
+++ b/api/tests/unit/services/solutions/test_deployment_runtime.py
@@ -144,6 +144,7 @@ async def test_solution_without_active_deployment_never_falls_back_to_mutable_ro
         organization_id=None,
         global_repo_access=False,
         active_deployment_id=None,
+        execution_runtime_mode="deployment-v1",
     )
     session = SimpleNamespace(
         execute=AsyncMock(return_value=_Result((workflow, solution)))
@@ -151,6 +152,23 @@ async def test_solution_without_active_deployment_never_falls_back_to_mutable_ro
 
     with pytest.raises(DeploymentRuntimeError, match="no active deployment"):
         await pin_workflow_runtime(session, workflow_id)
+
+
+@pytest.mark.asyncio
+async def test_explicit_legacy_solution_without_deployment_uses_repo_compatibility():
+    solution_id, workflow_id = uuid4(), uuid4()
+    workflow = SimpleNamespace(id=workflow_id, solution_id=solution_id)
+    solution = SimpleNamespace(
+        id=solution_id,
+        status="active",
+        organization_id=None,
+        global_repo_access=False,
+        active_deployment_id=None,
+        execution_runtime_mode="repo-v1",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=_Result((workflow, solution))))
+
+    assert await pin_workflow_runtime(session, workflow_id) is None
 
 
 def test_tampered_queue_evidence_is_rejected_against_durable_manifest_evidence():

--- a/api/tests/unit/services/solutions/test_deployment_runtime.py
+++ b/api/tests/unit/services/solutions/test_deployment_runtime.py
@@ -17,6 +17,7 @@ from src.services.solutions.deployment_manifest import (
 from src.services.solutions.deployment_runtime import (
     DeploymentRuntimeError,
     pin_workflow_runtime,
+    verify_runtime_evidence,
 )
 
 
@@ -150,3 +151,110 @@ async def test_solution_without_active_deployment_never_falls_back_to_mutable_ro
 
     with pytest.raises(DeploymentRuntimeError, match="no active deployment"):
         await pin_workflow_runtime(session, workflow_id)
+
+
+def test_tampered_queue_evidence_is_rejected_against_durable_manifest_evidence():
+    deployment_id = str(uuid4())
+    authoritative = {
+        "solution_deployment_id": deployment_id,
+        "workflow_path": "workflows/run.py",
+    }
+    evidence_hash = sha256_digest(canonical_json(authoritative))
+    tampered = {**authoritative, "workflow_path": "workflows/other.py"}
+
+    with pytest.raises(DeploymentRuntimeError, match="queue evidence"):
+        verify_runtime_evidence(
+            deployment_id, tampered, authoritative, evidence_hash, authoritative
+        )
+
+
+@pytest.mark.asyncio
+async def test_child_call_inherits_superseded_parent_deployment(monkeypatch):
+    solution_id, workflow_id = uuid4(), uuid4()
+    old_id, active_id = uuid4(), uuid4()
+    workflow = SimpleNamespace(id=workflow_id, solution_id=solution_id)
+    solution = SimpleNamespace(
+        id=solution_id,
+        status="active",
+        organization_id=None,
+        global_repo_access=False,
+        active_deployment_id=active_id,
+    )
+    old = _closure(
+        deployment_id=old_id,
+        solution_id=solution_id,
+        workflow_id=workflow_id,
+        source_text="old",
+    )
+    old.state = "superseded"
+    session = SimpleNamespace(execute=AsyncMock(return_value=_Result((workflow, solution))))
+
+    async def get_by_id(_repo, deployment_id):
+        return old if deployment_id == old_id else None
+
+    async def get_closure(_repo, deployment_id, _org):
+        return old if deployment_id == old_id else None
+
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_runtime.SolutionDeploymentRepository.get_by_id_for_runtime",
+        get_by_id,
+    )
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_runtime.SolutionDeploymentRepository.get_runtime_closure",
+        get_closure,
+    )
+    pinned = await pin_workflow_runtime(
+        session, workflow_id, caller_deployment_id=old_id
+    )
+    assert pinned is not None and pinned.deployment_id == old_id
+
+
+@pytest.mark.asyncio
+async def test_cross_solution_child_uses_exact_dependency_deployment(monkeypatch):
+    owner_solution_id, target_solution_id, workflow_id = uuid4(), uuid4(), uuid4()
+    caller_id, dependency_id, current_target_id = uuid4(), uuid4(), uuid4()
+    workflow = SimpleNamespace(id=workflow_id, solution_id=target_solution_id)
+    solution = SimpleNamespace(
+        id=target_solution_id,
+        status="active",
+        organization_id=None,
+        global_repo_access=False,
+        active_deployment_id=current_target_id,
+    )
+    caller = SimpleNamespace(
+        id=caller_id,
+        solution_id=owner_solution_id,
+        dependencies=[
+            SimpleNamespace(
+                dependency_solution_id=target_solution_id,
+                dependency_deployment_id=dependency_id,
+            )
+        ],
+    )
+    dependency = _closure(
+        deployment_id=dependency_id,
+        solution_id=target_solution_id,
+        workflow_id=workflow_id,
+        source_text="dependency",
+    )
+    dependency.state = "superseded"
+    session = SimpleNamespace(execute=AsyncMock(return_value=_Result((workflow, solution))))
+
+    async def get_by_id(_repo, deployment_id):
+        return caller if deployment_id == caller_id else None
+
+    async def get_closure(_repo, deployment_id, _org):
+        return dependency if deployment_id == dependency_id else None
+
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_runtime.SolutionDeploymentRepository.get_by_id_for_runtime",
+        get_by_id,
+    )
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_runtime.SolutionDeploymentRepository.get_runtime_closure",
+        get_closure,
+    )
+    pinned = await pin_workflow_runtime(
+        session, workflow_id, caller_deployment_id=caller_id
+    )
+    assert pinned is not None and pinned.deployment_id == dependency_id

--- a/api/tests/unit/services/solutions/test_deployment_runtime.py
+++ b/api/tests/unit/services/solutions/test_deployment_runtime.py
@@ -1,0 +1,152 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.services.solutions.deployment_manifest import (
+    CompiledDeploymentManifest,
+    DeploymentGitProvenance,
+    DeploymentResolutionMap,
+    DeploymentSource,
+    RuntimeEntityDefinition,
+    RuntimeSourceResolution,
+    canonical_json,
+    sha256_digest,
+)
+from src.services.solutions.deployment_runtime import (
+    DeploymentRuntimeError,
+    pin_workflow_runtime,
+)
+
+
+class _Result:
+    def __init__(self, row):
+        self.row = row
+
+    def one_or_none(self):
+        return self.row
+
+
+def _closure(*, deployment_id, solution_id, workflow_id, source_text):
+    source_hash = sha256_digest(source_text.encode())
+    entity = RuntimeEntityDefinition(
+        portable_ref="workflows/demo.py::demo",
+        resolved_id=workflow_id,
+        source_ref="workflows/demo.py",
+        source_hash=source_hash,
+        definition={
+            "name": f"demo-{source_text}",
+            "function_name": "demo",
+            "path": "workflows/demo.py",
+            "timeout_seconds": 30,
+            "type": "workflow",
+        },
+    )
+    resolution = DeploymentResolutionMap(
+        workflows={entity.portable_ref: entity},
+        sources={
+            "workflows/demo.py": RuntimeSourceResolution(
+                object_key=f"_solutions/{solution_id}/{deployment_id}/workflows/demo.py",
+                content_hash=source_hash,
+            )
+        },
+    )
+    resolution_hash = sha256_digest(canonical_json(resolution))
+    manifest = CompiledDeploymentManifest(
+        solution_id=solution_id,
+        deployment_id=deployment_id,
+        bundle_hash=sha256_digest(source_text.encode()),
+        resolution_map_hash=resolution_hash,
+        source=DeploymentSource(
+            artifact_key=f"_solution_artifacts/{solution_id}/{deployment_id}/source.zip",
+            runtime_prefix=f"_solutions/{solution_id}/{deployment_id}/",
+        ),
+        workflows={entity.portable_ref: entity},
+        git=DeploymentGitProvenance(),
+    )
+    return SimpleNamespace(
+        id=deployment_id,
+        solution_id=solution_id,
+        state="active",
+        bundle_hash=manifest.bundle_hash,
+        compiled_manifest=manifest.model_dump(mode="json"),
+        compiled_manifest_hash=manifest.content_hash(),
+        resolution_map=resolution.model_dump(mode="json"),
+        resolution_map_hash=resolution_hash,
+        runtime_storage_prefix=manifest.source.runtime_prefix,
+        git_commit_sha=None,
+        dependencies=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_pointer_selects_runtime_without_reading_mutable_definition(
+    monkeypatch,
+):
+    solution_id, workflow_id = uuid4(), uuid4()
+    old_id, new_id = uuid4(), uuid4()
+    workflow = SimpleNamespace(id=workflow_id, solution_id=solution_id)
+    solution = SimpleNamespace(
+        id=solution_id,
+        status="active",
+        organization_id=None,
+        global_repo_access=False,
+        active_deployment_id=old_id,
+    )
+    session = SimpleNamespace(
+        execute=AsyncMock(return_value=_Result((workflow, solution)))
+    )
+    deployments = {
+        old_id: _closure(
+            deployment_id=old_id,
+            solution_id=solution_id,
+            workflow_id=workflow_id,
+            source_text="old",
+        ),
+        new_id: _closure(
+            deployment_id=new_id,
+            solution_id=solution_id,
+            workflow_id=workflow_id,
+            source_text="new",
+        ),
+    }
+
+    async def get_closure(_repo, deployment_id, _org_id):
+        return deployments[deployment_id]
+
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_runtime.SolutionDeploymentRepository.get_runtime_closure",
+        get_closure,
+    )
+
+    old = await pin_workflow_runtime(session, workflow_id)
+    solution.active_deployment_id = new_id
+    new = await pin_workflow_runtime(session, workflow_id)
+
+    assert old is not None and new is not None
+    assert old.deployment_id == old_id
+    assert old.name == "demo-old"
+    assert new.deployment_id == new_id
+    assert new.name == "demo-new"
+    # The already materialized queue evidence remains pinned after promotion.
+    assert old.queue_evidence()["solution_deployment_id"] == str(old_id)
+
+
+@pytest.mark.asyncio
+async def test_solution_without_active_deployment_never_falls_back_to_mutable_row():
+    solution_id, workflow_id = uuid4(), uuid4()
+    workflow = SimpleNamespace(id=workflow_id, solution_id=solution_id)
+    solution = SimpleNamespace(
+        id=solution_id,
+        status="active",
+        organization_id=None,
+        global_repo_access=False,
+        active_deployment_id=None,
+    )
+    session = SimpleNamespace(
+        execute=AsyncMock(return_value=_Result((workflow, solution)))
+    )
+
+    with pytest.raises(DeploymentRuntimeError, match="no active deployment"):
+        await pin_workflow_runtime(session, workflow_id)

--- a/api/tests/unit/test_solution_deployment_orm.py
+++ b/api/tests/unit/test_solution_deployment_orm.py
@@ -9,6 +9,7 @@ from src.models.orm.solution_deployments import (
     SolutionDeploymentDependency,
 )
 from src.models.orm.solutions import Solution
+from src.models.orm.executions import Execution
 from src.repositories.solution_deployments import SolutionDeploymentRepository
 
 
@@ -25,6 +26,7 @@ def test_solution_deployment_schema_exposes_runtime_closure_and_exact_edges():
     assert deployment_columns["source_artifact_key"].nullable is False
     assert dependency_columns["dependency_deployment_id"].nullable is False
     assert "active_deployment_id" in Solution.__table__.columns
+    assert "solution_deployment_id" in Execution.__table__.columns
 
     deployment_constraints = {c.name for c in SolutionDeployment.__table__.constraints}
     dependency_constraints = {

--- a/api/tests/unit/test_solution_deployment_orm.py
+++ b/api/tests/unit/test_solution_deployment_orm.py
@@ -26,6 +26,7 @@ def test_solution_deployment_schema_exposes_runtime_closure_and_exact_edges():
     assert deployment_columns["source_artifact_key"].nullable is False
     assert dependency_columns["dependency_deployment_id"].nullable is False
     assert "active_deployment_id" in Solution.__table__.columns
+    assert Solution.__table__.columns["execution_runtime_mode"].nullable is False
     assert "solution_deployment_id" in Execution.__table__.columns
 
     deployment_constraints = {c.name for c in SolutionDeployment.__table__.constraints}


### PR DESCRIPTION
## Summary
- pin new Solution workflow executions to the active SolutionDeployment before queueing
- propagate immutable deployment evidence through Redis, RabbitMQ, schedules, and deferred promotion
- resolve pinned workflow definitions and source from the compiled deployment manifest rather than mutable Workflow rows
- root module-cache/import identity in the deployment revision and reject source hash drift
- retain an explicit legacy path only for _repo and pre-migration null pins

## Stack
Depends on #451 (and transitively #449). This is independent of activation PR #452.

## Proof
- old queued execution retains its original deployment evidence after active-pointer movement
- newly queued execution observes the promoted deployment
- 67 focused tests passed (72 in the broader deployment-storage set)
- Ruff, targeted Pyright, compileall, sole Alembic head, diff check

## Explicit follow-ups
- AgentRun pinning and agent manifest resolution
- same-Solution child-call inheritance and exact dependency-deployment routing
- form/event/application definition pinning before centralized workflow enqueue
- full consumer/scheduler collection in Linux CI (this Windows host lacks opentelemetry/croniter)

No live Bifrost state was mutated.