### PR TITLE
feat: expose SolutionDeployment API contracts

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -431,6 +431,11 @@
 | POST | `/api/solutions/{solution_id}/capture/preview` |
 | GET | `/api/solutions/{solution_id}/deletion-summary` |
 | POST | `/api/solutions/{solution_id}/deploy` |
+| POST | `/api/solutions/{solution_id}/deployments` |
+| GET | `/api/solutions/{solution_id}/deployments/capabilities` |
+| GET | `/api/solutions/{solution_id}/deployments/{deployment_id}` |
+| POST | `/api/solutions/{solution_id}/deployments/{deployment_id}/activate` |
+| POST | `/api/solutions/{solution_id}/deployments/{deployment_id}/rollback` |
 | GET | `/api/solutions/{solution_id}/entities` |
 | POST | `/api/solutions/{solution_id}/export` |
 | GET | `/api/solutions/{solution_id}/export-jobs` |

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -75,6 +75,7 @@ from src.routers import (
     tables_router,
     claims_router,
     solutions_router,
+    solution_deployments_router,
     knowledge_sources_router,
     app_embed_secrets_router,
     applications_router,
@@ -605,6 +606,7 @@ def create_app() -> FastAPI:
     app.include_router(tables_router)
     app.include_router(claims_router)
     app.include_router(solutions_router)
+    app.include_router(solution_deployments_router)
     app.include_router(knowledge_sources_router)
     app.include_router(app_embed_secrets_router)
     app.include_router(applications_router)

--- a/api/src/models/contracts/solution_deployments.py
+++ b/api/src/models/contracts/solution_deployments.py
@@ -60,3 +60,12 @@ class DeploymentActivationPublic(BaseModel):
     active_deployment_id: UUID | None
     conflict: dict | None = None
     recovery: dict | None = None
+
+
+class SolutionDeploymentCapabilities(BaseModel):
+    registration: bool = True
+    inspection: bool = True
+    artifact_upload: bool = False
+    server_side_compilation: bool = False
+    activation_configured: bool = False
+    safe_for_end_to_end_cs_deploy: bool = False

--- a/api/src/models/contracts/solution_deployments.py
+++ b/api/src/models/contracts/solution_deployments.py
@@ -1,0 +1,62 @@
+"""HTTP contracts for immutable Solution deployment revisions."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from src.services.solutions.deployment_manifest import (
+    CompiledDeploymentManifest,
+    DeploymentResolutionMap,
+)
+
+
+class SolutionDeploymentCreate(BaseModel):
+    """Register already revision-addressed source/runtime references.
+
+    This endpoint does not upload a source archive or runtime files. The
+    manifest references must already exist at the canonical deployment keys.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    compiled_manifest: CompiledDeploymentManifest
+    resolution_map: DeploymentResolutionMap
+    base_deployment_id: UUID | None = None
+    parent_deployment_id: UUID | None = None
+    declared_version: str | None = None
+    git_repository: str | None = None
+    git_ref: str | None = None
+    git_commit_sha: str | None = None
+    codex_worker_id: str | None = None
+
+
+class DeploymentPointerRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    expected_active_deployment_id: UUID | None
+
+
+class SolutionDeploymentPublic(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: UUID
+    organization_id: UUID | None
+    solution_id: UUID
+    parent_deployment_id: UUID | None
+    base_deployment_id: UUID | None
+    state: str
+    bundle_hash: str
+    compiled_manifest_hash: str
+    resolution_map_hash: str
+    source_artifact_key: str
+    runtime_storage_prefix: str
+    created_at: datetime
+    failure_detail: dict | None = None
+
+
+class DeploymentActivationPublic(BaseModel):
+    deployment_id: UUID
+    solution_id: UUID
+    state: str
+    previous_active_deployment_id: UUID | None
+    active_deployment_id: UUID | None
+    conflict: dict | None = None
+    recovery: dict | None = None

--- a/api/src/repositories/solution_deployments.py
+++ b/api/src/repositories/solution_deployments.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import datetime
 from uuid import UUID
 
@@ -46,11 +47,15 @@ class SolutionDeploymentRepository:
     @staticmethod
     def _scope_clause(organization_id: UUID | None):
         column = SolutionDeployment.organization_id
-        return column.is_(None) if organization_id is None else column == organization_id
+        return (
+            column.is_(None) if organization_id is None else column == organization_id
+        )
 
     async def create(self, deployment: SolutionDeployment) -> SolutionDeployment:
         solution_org = await self.session.scalar(
-            select(Solution.organization_id).where(Solution.id == deployment.solution_id)
+            select(Solution.organization_id).where(
+                Solution.id == deployment.solution_id
+            )
         )
         if solution_org != deployment.organization_id:
             raise ValueError("deployment scope must exactly match its Solution install")
@@ -61,19 +66,28 @@ class SolutionDeploymentRepository:
             expected_manifest_hash=deployment.compiled_manifest_hash,
             expected_resolution_hash=deployment.resolution_map_hash,
         )
+        await self.validate_dependencies(deployment)
         self.session.add(deployment)
         await self.session.flush()
         return deployment
 
     async def get_runtime_closure(
-        self, deployment_id: UUID, organization_id: UUID | None
+        self,
+        deployment_id: UUID,
+        organization_id: UUID | None,
+        solution_id: UUID | None = None,
     ) -> SolutionDeployment | None:
+        clauses = [
+            SolutionDeployment.id == deployment_id,
+            self._scope_clause(organization_id),
+        ]
+        if solution_id is not None:
+            clauses.append(SolutionDeployment.solution_id == solution_id)
         result = await self.session.execute(
             select(SolutionDeployment)
             .options(selectinload(SolutionDeployment.dependencies))
             .where(
-                SolutionDeployment.id == deployment_id,
-                self._scope_clause(organization_id),
+                *clauses,
             )
         )
         return result.scalar_one_or_none()
@@ -88,6 +102,29 @@ class SolutionDeploymentRepository:
             .where(SolutionDeployment.id == deployment_id)
         )
         return result.scalar_one_or_none()
+
+    async def validate_dependencies(self, deployment: SolutionDeployment) -> None:
+        for edge in deployment.dependencies:
+            dependency = await self.session.scalar(
+                select(SolutionDeployment).where(
+                    SolutionDeployment.id == edge.dependency_deployment_id,
+                    SolutionDeployment.solution_id == edge.dependency_solution_id,
+                )
+            )
+            if dependency is None:
+                raise ValueError("dependency deployment does not exist")
+            if dependency.organization_id not in {None, deployment.organization_id}:
+                raise ValueError("dependency deployment is outside the Solution scope")
+            if dependency.state not in {"active", "superseded", "committed_unpushed"}:
+                raise ValueError("dependency deployment is not finalized")
+            if dependency.bundle_hash != edge.resolved_bundle_hash:
+                raise ValueError("dependency deployment bundle hash mismatch")
+
+    @asynccontextmanager
+    async def projection_savepoint(self):
+        """Keep adapter DB failures from poisoning recovery evidence persistence."""
+        async with self.session.begin_nested():
+            yield
 
     async def transition(
         self,
@@ -129,7 +166,9 @@ class SolutionDeploymentRepository:
         )
         deployment = result.scalar_one_or_none()
         if deployment is None:
-            raise InvalidDeploymentTransition("deployment missing, out of scope, or state changed")
+            raise InvalidDeploymentTransition(
+                "deployment missing, out of scope, or state changed"
+            )
         return deployment
 
     async def get_solution_active_deployment(

--- a/api/src/routers/__init__.py
+++ b/api/src/routers/__init__.py
@@ -47,6 +47,7 @@ from src.routers.hooks import router as hooks_router
 from src.routers.tables import router as tables_router
 from src.routers.claims import router as claims_router
 from src.routers.solutions import router as solutions_router
+from src.routers.solution_deployments import router as solution_deployments_router
 from src.routers.knowledge_sources import router as knowledge_sources_router
 from src.routers.app_embed_secrets import router as app_embed_secrets_router
 from src.routers.applications import router as applications_router
@@ -123,6 +124,7 @@ __all__ = [
     "tables_router",
     "claims_router",
     "solutions_router",
+    "solution_deployments_router",
     "knowledge_sources_router",
     "app_embed_secrets_router",
     "applications_router",

--- a/api/src/routers/solution_deployments.py
+++ b/api/src/routers/solution_deployments.py
@@ -10,14 +10,34 @@ from src.models.contracts.solution_deployments import (
     DeploymentActivationPublic,
     DeploymentPointerRequest,
     SolutionDeploymentCreate,
+    SolutionDeploymentCapabilities,
     SolutionDeploymentPublic,
 )
 from src.models.orm.solutions import Solution
 from src.repositories.solution_deployments import SolutionDeploymentRepository
-from src.services.solutions.deployment_activation import SolutionDeploymentActivationService
+from src.services.solutions.deployment_activation import (
+    SolutionDeploymentActivationService,
+)
 from src.services.solutions.deployment_api import SolutionDeploymentAPIService
+from src.services.solutions.deployment_api import DeploymentRegistrationConflict
+from src.services.solutions.write_lock import (
+    SolutionWriteLockHeld,
+    SolutionWriteLockLost,
+    solution_write_lock,
+)
 
-router = APIRouter(prefix="/api/solutions/{solution_id}/deployments", tags=["Solution Deployments"])
+router = APIRouter(
+    prefix="/api/solutions/{solution_id}/deployments", tags=["Solution Deployments"]
+)
+
+
+@router.get("/capabilities", response_model=SolutionDeploymentCapabilities)
+async def deployment_capabilities(
+    solution_id: UUID, ctx: Context, user: CurrentSuperuser
+):
+    del user
+    await _scope(ctx, solution_id)
+    return SolutionDeploymentCapabilities()
 
 
 async def _scope(ctx: Context, solution_id: UUID) -> UUID | None:
@@ -37,7 +57,10 @@ def get_activation_service(ctx: Context) -> SolutionDeploymentActivationService:
 
 @router.post("", response_model=SolutionDeploymentPublic, status_code=201)
 async def create_deployment(
-    solution_id: UUID, body: SolutionDeploymentCreate, ctx: Context, user: CurrentSuperuser
+    solution_id: UUID,
+    body: SolutionDeploymentCreate,
+    ctx: Context,
+    user: CurrentSuperuser,
 ):
     try:
         row = await SolutionDeploymentAPIService(ctx.db).create_ready_draft(
@@ -47,6 +70,16 @@ async def create_deployment(
         return row
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except DeploymentRegistrationConflict as exc:
+        await ctx.db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "deployment_registration_conflict",
+                "message": str(exc),
+                "reconcile": f"GET /api/solutions/{solution_id}/deployments/{body.compiled_manifest.deployment_id}",
+            },
+        ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -79,11 +112,23 @@ async def activate_deployment(
     del user
     organization_id = await _scope(ctx, solution_id)
     try:
-        result = await service.activate(
-            deployment_id,
-            organization_id,
-            expected_active_deployment_id=body.expected_active_deployment_id,
-        )
+        async with solution_write_lock(solution_id):
+            result = await service.activate(
+                deployment_id,
+                organization_id,
+                solution_id,
+                expected_active_deployment_id=body.expected_active_deployment_id,
+            )
+    except SolutionWriteLockHeld as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "solution_write_lock_held"}
+        ) from exc
+    except SolutionWriteLockLost as exc:
+        await ctx.db.rollback()
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "solution_write_lock_lost", "retryable": True},
+        ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     await ctx.db.commit()
@@ -105,14 +150,28 @@ async def rollback_deployment(
 ):
     del user
     if body.expected_active_deployment_id is None:
-        raise HTTPException(status_code=422, detail="rollback requires expected active deployment")
+        raise HTTPException(
+            status_code=422, detail="rollback requires expected active deployment"
+        )
     organization_id = await _scope(ctx, solution_id)
     try:
-        result = await service.rollback(
-            deployment_id,
-            organization_id,
-            expected_active_deployment_id=body.expected_active_deployment_id,
-        )
+        async with solution_write_lock(solution_id):
+            result = await service.rollback(
+                deployment_id,
+                organization_id,
+                solution_id,
+                expected_active_deployment_id=body.expected_active_deployment_id,
+            )
+    except SolutionWriteLockHeld as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "solution_write_lock_held"}
+        ) from exc
+    except SolutionWriteLockLost as exc:
+        await ctx.db.rollback()
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "solution_write_lock_lost", "retryable": True},
+        ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     await ctx.db.commit()

--- a/api/src/routers/solution_deployments.py
+++ b/api/src/routers/solution_deployments.py
@@ -1,0 +1,121 @@
+"""Admin API for immutable Solution deployment registration and pointer movement."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from src.core.auth import Context, CurrentSuperuser
+from src.models.contracts.solution_deployments import (
+    DeploymentActivationPublic,
+    DeploymentPointerRequest,
+    SolutionDeploymentCreate,
+    SolutionDeploymentPublic,
+)
+from src.models.orm.solutions import Solution
+from src.repositories.solution_deployments import SolutionDeploymentRepository
+from src.services.solutions.deployment_activation import SolutionDeploymentActivationService
+from src.services.solutions.deployment_api import SolutionDeploymentAPIService
+
+router = APIRouter(prefix="/api/solutions/{solution_id}/deployments", tags=["Solution Deployments"])
+
+
+async def _scope(ctx: Context, solution_id: UUID) -> UUID | None:
+    solution = await ctx.db.get(Solution, solution_id)
+    if solution is None:
+        raise HTTPException(status_code=404, detail="Solution not found")
+    return solution.organization_id
+
+
+def get_activation_service(ctx: Context) -> SolutionDeploymentActivationService:
+    """Dependency seam overridden by the projection/artifact adapter and tests."""
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Solution deployment activation hooks are not configured",
+    )
+
+
+@router.post("", response_model=SolutionDeploymentPublic, status_code=201)
+async def create_deployment(
+    solution_id: UUID, body: SolutionDeploymentCreate, ctx: Context, user: CurrentSuperuser
+):
+    try:
+        row = await SolutionDeploymentAPIService(ctx.db).create_ready_draft(
+            solution_id, user.user_id, body
+        )
+        await ctx.db.commit()
+        return row
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/{deployment_id}", response_model=SolutionDeploymentPublic)
+async def inspect_deployment(
+    solution_id: UUID, deployment_id: UUID, ctx: Context, user: CurrentSuperuser
+):
+    del user
+    organization_id = await _scope(ctx, solution_id)
+    row = await SolutionDeploymentRepository(ctx.db).get_runtime_closure(
+        deployment_id, organization_id
+    )
+    if row is None or row.solution_id != solution_id:
+        raise HTTPException(status_code=404, detail="Deployment not found")
+    return row
+
+
+@router.post("/{deployment_id}/activate", response_model=DeploymentActivationPublic)
+async def activate_deployment(
+    solution_id: UUID,
+    deployment_id: UUID,
+    body: DeploymentPointerRequest,
+    ctx: Context,
+    user: CurrentSuperuser,
+    service: Annotated[
+        SolutionDeploymentActivationService, Depends(get_activation_service)
+    ],
+):
+    del user
+    organization_id = await _scope(ctx, solution_id)
+    try:
+        result = await service.activate(
+            deployment_id,
+            organization_id,
+            expected_active_deployment_id=body.expected_active_deployment_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await ctx.db.commit()
+    if result.state == "conflicted":
+        raise HTTPException(status_code=409, detail=result.conflict)
+    return result
+
+
+@router.post("/{deployment_id}/rollback", response_model=DeploymentActivationPublic)
+async def rollback_deployment(
+    solution_id: UUID,
+    deployment_id: UUID,
+    body: DeploymentPointerRequest,
+    ctx: Context,
+    user: CurrentSuperuser,
+    service: Annotated[
+        SolutionDeploymentActivationService, Depends(get_activation_service)
+    ],
+):
+    del user
+    if body.expected_active_deployment_id is None:
+        raise HTTPException(status_code=422, detail="rollback requires expected active deployment")
+    organization_id = await _scope(ctx, solution_id)
+    try:
+        result = await service.rollback(
+            deployment_id,
+            organization_id,
+            expected_active_deployment_id=body.expected_active_deployment_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await ctx.db.commit()
+    if result.state == "conflicted":
+        raise HTTPException(status_code=409, detail=result.conflict)
+    return result

--- a/api/src/routers/solution_deployments.py
+++ b/api/src/routers/solution_deployments.py
@@ -1,5 +1,7 @@
 """Admin API for immutable Solution deployment registration and pointer movement."""
 
+from collections.abc import Awaitable, Callable
+from functools import partial
 from typing import Annotated
 from uuid import UUID
 
@@ -16,6 +18,7 @@ from src.models.contracts.solution_deployments import (
 from src.models.orm.solutions import Solution
 from src.repositories.solution_deployments import SolutionDeploymentRepository
 from src.services.solutions.deployment_activation import (
+    ActivationResult,
     SolutionDeploymentActivationService,
 )
 from src.services.solutions.deployment_api import SolutionDeploymentAPIService
@@ -53,6 +56,34 @@ def get_activation_service(ctx: Context) -> SolutionDeploymentActivationService:
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Solution deployment activation hooks are not configured",
     )
+
+
+async def _run_pointer_move(
+    ctx: Context,
+    solution_id: UUID,
+    operation: Callable[[UUID | None], Awaitable[ActivationResult]],
+) -> ActivationResult:
+    """Serialize one pointer mutation and normalize its transactional errors."""
+    organization_id = await _scope(ctx, solution_id)
+    try:
+        async with solution_write_lock(solution_id):
+            result = await operation(organization_id)
+    except SolutionWriteLockHeld as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "solution_write_lock_held"}
+        ) from exc
+    except SolutionWriteLockLost as exc:
+        await ctx.db.rollback()
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "solution_write_lock_lost", "retryable": True},
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await ctx.db.commit()
+    if result.state == "conflicted":
+        raise HTTPException(status_code=409, detail=result.conflict)
+    return result
 
 
 @router.post("", response_model=SolutionDeploymentPublic, status_code=201)
@@ -98,7 +129,10 @@ async def inspect_deployment(
     return row
 
 
-@router.post("/{deployment_id}/activate", response_model=DeploymentActivationPublic)
+@router.post(
+    "/{deployment_id}/activate",
+    response_model=DeploymentActivationPublic,
+)
 async def activate_deployment(
     solution_id: UUID,
     deployment_id: UUID,
@@ -110,34 +144,22 @@ async def activate_deployment(
     ],
 ):
     del user
-    organization_id = await _scope(ctx, solution_id)
-    try:
-        async with solution_write_lock(solution_id):
-            result = await service.activate(
-                deployment_id,
-                organization_id,
-                solution_id,
-                expected_active_deployment_id=body.expected_active_deployment_id,
-            )
-    except SolutionWriteLockHeld as exc:
-        raise HTTPException(
-            status_code=409, detail={"code": "solution_write_lock_held"}
-        ) from exc
-    except SolutionWriteLockLost as exc:
-        await ctx.db.rollback()
-        raise HTTPException(
-            status_code=503,
-            detail={"code": "solution_write_lock_lost", "retryable": True},
-        ) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    await ctx.db.commit()
-    if result.state == "conflicted":
-        raise HTTPException(status_code=409, detail=result.conflict)
-    return result
+    return await _run_pointer_move(
+        ctx,
+        solution_id,
+        partial(
+            service.activate,
+            deployment_id,
+            solution_id=solution_id,
+            expected_active_deployment_id=body.expected_active_deployment_id,
+        ),
+    )
 
 
-@router.post("/{deployment_id}/rollback", response_model=DeploymentActivationPublic)
+@router.post(
+    "/{deployment_id}/rollback",
+    response_model=DeploymentActivationPublic,
+)
 async def rollback_deployment(
     solution_id: UUID,
     deployment_id: UUID,
@@ -153,28 +175,13 @@ async def rollback_deployment(
         raise HTTPException(
             status_code=422, detail="rollback requires expected active deployment"
         )
-    organization_id = await _scope(ctx, solution_id)
-    try:
-        async with solution_write_lock(solution_id):
-            result = await service.rollback(
-                deployment_id,
-                organization_id,
-                solution_id,
-                expected_active_deployment_id=body.expected_active_deployment_id,
-            )
-    except SolutionWriteLockHeld as exc:
-        raise HTTPException(
-            status_code=409, detail={"code": "solution_write_lock_held"}
-        ) from exc
-    except SolutionWriteLockLost as exc:
-        await ctx.db.rollback()
-        raise HTTPException(
-            status_code=503,
-            detail={"code": "solution_write_lock_lost", "retryable": True},
-        ) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    await ctx.db.commit()
-    if result.state == "conflicted":
-        raise HTTPException(status_code=409, detail=result.conflict)
-    return result
+    return await _run_pointer_move(
+        ctx,
+        solution_id,
+        partial(
+            service.rollback,
+            deployment_id,
+            solution_id=solution_id,
+            expected_active_deployment_id=body.expected_active_deployment_id,
+        ),
+    )

--- a/api/src/routers/solution_deployments.py
+++ b/api/src/routers/solution_deployments.py
@@ -34,7 +34,11 @@ router = APIRouter(
 )
 
 
-@router.get("/capabilities", response_model=SolutionDeploymentCapabilities)
+@router.get(
+    "/capabilities",
+    response_model=SolutionDeploymentCapabilities,
+    responses={404: {"description": "Solution not found"}},
+)
 async def deployment_capabilities(
     solution_id: UUID, ctx: Context, user: CurrentSuperuser
 ):
@@ -86,7 +90,16 @@ async def _run_pointer_move(
     return result
 
 
-@router.post("", response_model=SolutionDeploymentPublic, status_code=201)
+@router.post(
+    "",
+    response_model=SolutionDeploymentPublic,
+    status_code=201,
+    responses={
+        404: {"description": "Solution not found"},
+        409: {"description": "Deployment registration conflict"},
+        422: {"description": "Invalid deployment closure"},
+    },
+)
 async def create_deployment(
     solution_id: UUID,
     body: SolutionDeploymentCreate,
@@ -115,7 +128,11 @@ async def create_deployment(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
-@router.get("/{deployment_id}", response_model=SolutionDeploymentPublic)
+@router.get(
+    "/{deployment_id}",
+    response_model=SolutionDeploymentPublic,
+    responses={404: {"description": "Solution or deployment not found"}},
+)
 async def inspect_deployment(
     solution_id: UUID, deployment_id: UUID, ctx: Context, user: CurrentSuperuser
 ):
@@ -132,6 +149,12 @@ async def inspect_deployment(
 @router.post(
     "/{deployment_id}/activate",
     response_model=DeploymentActivationPublic,
+    responses={
+        404: {"description": "Solution or deployment not found"},
+        409: {"description": "Activation conflict or write lock held"},
+        422: {"description": "Invalid activation request"},
+        503: {"description": "Activation unavailable or write lock lost"},
+    },
 )
 async def activate_deployment(
     solution_id: UUID,
@@ -159,6 +182,12 @@ async def activate_deployment(
 @router.post(
     "/{deployment_id}/rollback",
     response_model=DeploymentActivationPublic,
+    responses={
+        404: {"description": "Solution or deployment not found"},
+        409: {"description": "Rollback conflict or write lock held"},
+        422: {"description": "Invalid rollback request"},
+        503: {"description": "Rollback unavailable or write lock lost"},
+    },
 )
 async def rollback_deployment(
     solution_id: UUID,

--- a/api/src/services/solutions/deployment_activation.py
+++ b/api/src/services/solutions/deployment_activation.py
@@ -45,10 +45,13 @@ class SolutionDeploymentActivationService:
         self,
         deployment_id: UUID,
         organization_id: UUID | None,
+        solution_id: UUID,
         *,
         expected_active_deployment_id: UUID | None,
     ) -> ActivationResult:
-        deployment = await self._require_deployment(deployment_id, organization_id)
+        deployment = await self._require_deployment(
+            deployment_id, organization_id, solution_id
+        )
         if deployment.base_deployment_id != expected_active_deployment_id:
             raise ValueError(
                 "expected active deployment must match the draft base deployment"
@@ -65,11 +68,12 @@ class SolutionDeploymentActivationService:
         self,
         target_deployment_id: UUID,
         organization_id: UUID | None,
+        solution_id: UUID,
         *,
         expected_active_deployment_id: UUID,
     ) -> ActivationResult:
         deployment = await self._require_deployment(
-            target_deployment_id, organization_id
+            target_deployment_id, organization_id, solution_id
         )
         if deployment.id == expected_active_deployment_id:
             raise ValueError("rollback target is already active")
@@ -167,7 +171,8 @@ class SolutionDeploymentActivationService:
             )
 
         try:
-            await self.hooks.rebuild_projections(deployment)
+            async with self.repository.projection_savepoint():
+                await self.hooks.rebuild_projections(deployment)
             if expected_active_deployment_id is not None:
                 previous = await self.repository.get_runtime_closure(
                     expected_active_deployment_id, organization_id
@@ -227,10 +232,10 @@ class SolutionDeploymentActivationService:
         )
 
     async def _require_deployment(
-        self, deployment_id: UUID, organization_id: UUID | None
+        self, deployment_id: UUID, organization_id: UUID | None, solution_id: UUID
     ) -> SolutionDeployment:
         deployment = await self.repository.get_runtime_closure(
-            deployment_id, organization_id
+            deployment_id, organization_id, solution_id
         )
         if deployment is None:
             raise ValueError("deployment missing or out of scope")

--- a/api/src/services/solutions/deployment_api.py
+++ b/api/src/services/solutions/deployment_api.py
@@ -52,6 +52,12 @@ class SolutionDeploymentAPIService:
         if manifest.source.runtime_prefix != expected_runtime:
             raise ValueError("runtime prefix must use the canonical deployment key")
 
+        # Registering an immutable deployment is the positive boundary between
+        # the mutable ZIP/_repo compatibility path and deployment-aware
+        # execution. From this transaction onward, a missing active pointer must
+        # fail closed rather than falling back to mutable Solution storage.
+        solution.execution_runtime_mode = "deployment-v1"
+
         resolution_hash = sha256_digest(canonical_json(body.resolution_map))
         manifest_hash = manifest.content_hash()
         existing = await self.session.get(SolutionDeployment, manifest.deployment_id)
@@ -83,7 +89,7 @@ class SolutionDeploymentAPIService:
             base_deployment_id=body.base_deployment_id,
             # The body is a complete, hash-validated immutable draft. `ready`
             # means it may enter the existing CAS activation seam.
-            state="ready",
+            state="draft",
             declared_version=body.declared_version,
             bundle_hash=manifest.bundle_hash,
             compiled_manifest=manifest.model_dump(mode="json", exclude_none=True),
@@ -102,6 +108,17 @@ class SolutionDeploymentAPIService:
             dependencies=dependencies,
         )
         await self.repository.create(deployment)
+        for expected_state, new_state in (
+            ("draft", "building"),
+            ("building", "validated"),
+            ("validated", "ready"),
+        ):
+            deployment = await self.repository.transition(
+                deployment.id,
+                solution.organization_id,
+                expected_state=expected_state,
+                new_state=new_state,
+            )
         # The source/runtime objects are reference-only inputs. The canonical
         # manifest itself is finalized server-side through create-only storage.
         try:

--- a/api/src/services/solutions/deployment_api.py
+++ b/api/src/services/solutions/deployment_api.py
@@ -1,0 +1,86 @@
+"""Application service behind the minimal SolutionDeployment HTTP API."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.contracts.solution_deployments import SolutionDeploymentCreate
+from src.models.orm.solution_deployments import (
+    SolutionDeployment,
+    SolutionDeploymentDependency,
+)
+from src.models.orm.solutions import Solution
+from src.repositories.solution_deployments import SolutionDeploymentRepository
+from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
+from src.services.solutions.deployment_storage import (
+    SolutionDeploymentStorage,
+    deployment_source_artifact_key,
+    deployment_runtime_prefix,
+)
+
+
+class SolutionDeploymentAPIService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.repository = SolutionDeploymentRepository(session)
+
+    async def create_ready_draft(
+        self, solution_id: UUID, created_by: UUID, body: SolutionDeploymentCreate
+    ) -> SolutionDeployment:
+        solution = await self.session.scalar(select(Solution).where(Solution.id == solution_id))
+        if solution is None:
+            raise LookupError("Solution not found")
+        manifest = body.compiled_manifest
+        if manifest.solution_id != solution_id:
+            raise ValueError("manifest solution_id does not match route")
+        expected_source = deployment_source_artifact_key(solution_id, manifest.deployment_id)
+        expected_runtime = deployment_runtime_prefix(solution_id, manifest.deployment_id)
+        if manifest.source.artifact_key != expected_source:
+            raise ValueError("source artifact must use the canonical deployment key")
+        if manifest.source.runtime_prefix != expected_runtime:
+            raise ValueError("runtime prefix must use the canonical deployment key")
+
+        resolution_hash = sha256_digest(canonical_json(body.resolution_map))
+        manifest_hash = manifest.content_hash()
+        dependencies = [
+            SolutionDeploymentDependency(
+                deployment_id=manifest.deployment_id,
+                dependency_solution_id=edge.solution_id,
+                dependency_deployment_id=edge.deployment_id,
+                declared_constraint=edge.declared_constraint,
+                resolved_bundle_hash=edge.bundle_hash,
+            )
+            for edge in manifest.dependencies.values()
+        ]
+        deployment = SolutionDeployment(
+            id=manifest.deployment_id,
+            organization_id=solution.organization_id,
+            solution_id=solution_id,
+            parent_deployment_id=body.parent_deployment_id,
+            base_deployment_id=body.base_deployment_id,
+            # The body is a complete, hash-validated immutable draft. `ready`
+            # means it may enter the existing CAS activation seam.
+            state="ready",
+            declared_version=body.declared_version,
+            bundle_hash=manifest.bundle_hash,
+            compiled_manifest=manifest.model_dump(mode="json", exclude_none=True),
+            compiled_manifest_hash=manifest_hash,
+            resolution_map=body.resolution_map.model_dump(mode="json", exclude_none=True),
+            resolution_map_hash=resolution_hash,
+            source_artifact_key=expected_source,
+            runtime_storage_prefix=expected_runtime,
+            git_repository=body.git_repository,
+            git_ref=body.git_ref,
+            git_commit_sha=body.git_commit_sha,
+            created_by=created_by,
+            codex_worker_id=body.codex_worker_id,
+            dependencies=dependencies,
+        )
+        await self.repository.create(deployment)
+        # The source/runtime objects are reference-only inputs. The canonical
+        # manifest itself is finalized server-side through create-only storage.
+        await SolutionDeploymentStorage(solution_id, manifest.deployment_id).write_compiled_manifest(
+            manifest.canonical_bytes()
+        )
+        return deployment

--- a/api/src/services/solutions/deployment_api.py
+++ b/api/src/services/solutions/deployment_api.py
@@ -14,10 +14,15 @@ from src.models.orm.solutions import Solution
 from src.repositories.solution_deployments import SolutionDeploymentRepository
 from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
 from src.services.solutions.deployment_storage import (
+    DeploymentArtifactIntegrityError,
     SolutionDeploymentStorage,
     deployment_source_artifact_key,
     deployment_runtime_prefix,
 )
+
+
+class DeploymentRegistrationConflict(ValueError):
+    """A deployment identifier already names a different immutable closure."""
 
 
 class SolutionDeploymentAPIService:
@@ -28,14 +33,20 @@ class SolutionDeploymentAPIService:
     async def create_ready_draft(
         self, solution_id: UUID, created_by: UUID, body: SolutionDeploymentCreate
     ) -> SolutionDeployment:
-        solution = await self.session.scalar(select(Solution).where(Solution.id == solution_id))
+        solution = await self.session.scalar(
+            select(Solution).where(Solution.id == solution_id)
+        )
         if solution is None:
             raise LookupError("Solution not found")
         manifest = body.compiled_manifest
         if manifest.solution_id != solution_id:
             raise ValueError("manifest solution_id does not match route")
-        expected_source = deployment_source_artifact_key(solution_id, manifest.deployment_id)
-        expected_runtime = deployment_runtime_prefix(solution_id, manifest.deployment_id)
+        expected_source = deployment_source_artifact_key(
+            solution_id, manifest.deployment_id
+        )
+        expected_runtime = deployment_runtime_prefix(
+            solution_id, manifest.deployment_id
+        )
         if manifest.source.artifact_key != expected_source:
             raise ValueError("source artifact must use the canonical deployment key")
         if manifest.source.runtime_prefix != expected_runtime:
@@ -43,6 +54,17 @@ class SolutionDeploymentAPIService:
 
         resolution_hash = sha256_digest(canonical_json(body.resolution_map))
         manifest_hash = manifest.content_hash()
+        existing = await self.session.get(SolutionDeployment, manifest.deployment_id)
+        if existing is not None:
+            if (
+                existing.solution_id == solution_id
+                and existing.compiled_manifest_hash == manifest_hash
+                and existing.resolution_map_hash == resolution_hash
+            ):
+                return existing
+            raise DeploymentRegistrationConflict(
+                "deployment id already names a different immutable closure"
+            )
         dependencies = [
             SolutionDeploymentDependency(
                 deployment_id=manifest.deployment_id,
@@ -66,7 +88,9 @@ class SolutionDeploymentAPIService:
             bundle_hash=manifest.bundle_hash,
             compiled_manifest=manifest.model_dump(mode="json", exclude_none=True),
             compiled_manifest_hash=manifest_hash,
-            resolution_map=body.resolution_map.model_dump(mode="json", exclude_none=True),
+            resolution_map=body.resolution_map.model_dump(
+                mode="json", exclude_none=True
+            ),
             resolution_map_hash=resolution_hash,
             source_artifact_key=expected_source,
             runtime_storage_prefix=expected_runtime,
@@ -80,7 +104,12 @@ class SolutionDeploymentAPIService:
         await self.repository.create(deployment)
         # The source/runtime objects are reference-only inputs. The canonical
         # manifest itself is finalized server-side through create-only storage.
-        await SolutionDeploymentStorage(solution_id, manifest.deployment_id).write_compiled_manifest(
-            manifest.canonical_bytes()
-        )
+        try:
+            await SolutionDeploymentStorage(
+                solution_id, manifest.deployment_id
+            ).write_compiled_manifest(manifest.canonical_bytes())
+        except DeploymentArtifactIntegrityError as exc:
+            raise DeploymentRegistrationConflict(
+                "manifest storage already exists; inspect the deployment before retrying"
+            ) from exc
         return deployment

--- a/api/src/services/solutions/write_lock.py
+++ b/api/src/services/solutions/write_lock.py
@@ -21,6 +21,7 @@ under a live holder — Codex #13).
 Manual deploy and git-connected sync share the SAME key namespace, so they can't
 race each other either.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -66,6 +67,10 @@ class SolutionWriteLockHeld(Exception):
     """Another writer already holds this install's deploy lock."""
 
 
+class SolutionWriteLockLost(RuntimeError):
+    """The holder lost its fencing token before completing the mutation."""
+
+
 @contextlib.asynccontextmanager
 async def solution_write_lock(solution_id: UUID) -> AsyncIterator[None]:
     """Hold the per-install write lock across a deploy's DB + S3 phases.
@@ -90,6 +95,8 @@ async def solution_write_lock(solution_id: UUID) -> AsyncIterator[None]:
     if not acquired:
         raise SolutionWriteLockHeld(str(solution_id))
 
+    lost = asyncio.Event()
+
     async def _renew() -> None:
         # Keep renewing for the lifetime of the context. A transient redis error
         # must NOT end the loop (that would silently stop renewal and let the
@@ -97,17 +104,22 @@ async def solution_write_lock(solution_id: UUID) -> AsyncIterator[None]:
         while True:
             await asyncio.sleep(_RENEW_INTERVAL_S)
             try:
-                await renew(keys=[key], args=[token, _LOCK_TTL_S])
+                if not await renew(keys=[key], args=[token, _LOCK_TTL_S]):
+                    lost.set()
+                    return
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001 - renewal is best-effort; keep trying
                 logger.warning(
-                    "write-lock renewal failed for %s (will retry)", log_safe(solution_id)
+                    "write-lock renewal failed for %s (will retry)",
+                    log_safe(solution_id),
                 )
 
     watchdog = asyncio.create_task(_renew())
     try:
         yield
+        if lost.is_set():
+            raise SolutionWriteLockLost(str(solution_id))
     finally:
         watchdog.cancel()
         with contextlib.suppress(asyncio.CancelledError):

--- a/api/tests/unit/routers/test_solution_deployments.py
+++ b/api/tests/unit/routers/test_solution_deployments.py
@@ -4,6 +4,8 @@ from types import ModuleType
 
 from fastapi import FastAPI
 
+from src.models.contracts.solution_deployments import SolutionDeploymentCapabilities
+
 # Import the focused router without eagerly importing every optional router
 # dependency from src.routers.__init__.
 routers_package = ModuleType("src.routers")
@@ -31,3 +33,14 @@ def test_solution_deployment_openapi_exposes_minimal_cs_surface():
     ]
     assert create_schema["$ref"].endswith("SolutionDeploymentCreate")
     assert "multipart/form-data" not in paths[base]["post"]["requestBody"]["content"]
+
+
+def test_capabilities_fail_closed_for_unconfigured_end_to_end_deployment():
+    capabilities = SolutionDeploymentCapabilities()
+
+    assert capabilities.registration is True
+    assert capabilities.inspection is True
+    assert capabilities.artifact_upload is False
+    assert capabilities.server_side_compilation is False
+    assert capabilities.activation_configured is False
+    assert capabilities.safe_for_end_to_end_cs_deploy is False

--- a/api/tests/unit/routers/test_solution_deployments.py
+++ b/api/tests/unit/routers/test_solution_deployments.py
@@ -1,18 +1,7 @@
-import sys
-from pathlib import Path
-from types import ModuleType
-
 from fastapi import FastAPI
 
 from src.models.contracts.solution_deployments import SolutionDeploymentCapabilities
-
-# Import the focused router without eagerly importing every optional router
-# dependency from src.routers.__init__.
-routers_package = ModuleType("src.routers")
-routers_package.__path__ = [str(Path(__file__).parents[3] / "src" / "routers")]
-sys.modules["src.routers"] = routers_package
-
-from src.routers.solution_deployments import router  # noqa: E402
+from src.routers.solution_deployments import router
 
 
 def test_solution_deployment_openapi_exposes_minimal_cs_surface():

--- a/api/tests/unit/routers/test_solution_deployments.py
+++ b/api/tests/unit/routers/test_solution_deployments.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from fastapi import FastAPI
+
+# Import the focused router without eagerly importing every optional router
+# dependency from src.routers.__init__.
+routers_package = ModuleType("src.routers")
+routers_package.__path__ = [str(Path(__file__).parents[3] / "src" / "routers")]
+sys.modules["src.routers"] = routers_package
+
+from src.routers.solution_deployments import router  # noqa: E402
+
+
+def test_solution_deployment_openapi_exposes_minimal_cs_surface():
+    app = FastAPI()
+    app.include_router(router)
+    schema = app.openapi()
+    paths = schema["paths"]
+
+    base = "/api/solutions/{solution_id}/deployments"
+    item = f"{base}/{{deployment_id}}"
+    assert set(paths[base]) >= {"post"}
+    assert set(paths[item]) >= {"get"}
+    assert set(paths[f"{item}/activate"]) >= {"post"}
+    assert set(paths[f"{item}/rollback"]) >= {"post"}
+    create_schema = paths[base]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    assert create_schema["$ref"].endswith("SolutionDeploymentCreate")
+    assert "multipart/form-data" not in paths[base]["post"]["requestBody"]["content"]

--- a/api/tests/unit/routers/test_solution_deployments.py
+++ b/api/tests/unit/routers/test_solution_deployments.py
@@ -22,11 +22,12 @@ def test_solution_deployment_openapi_exposes_minimal_cs_surface():
     base = "/api/solutions/{solution_id}/deployments"
     item = f"{base}/{{deployment_id}}"
     assert set(paths[base]) >= {"post"}
+    assert set(paths[f"{base}/capabilities"]) >= {"get"}
     assert set(paths[item]) >= {"get"}
     assert set(paths[f"{item}/activate"]) >= {"post"}
     assert set(paths[f"{item}/rollback"]) >= {"post"}
-    create_schema = paths[base]["post"]["requestBody"]["content"][
-        "application/json"
-    ]["schema"]
+    create_schema = paths[base]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
     assert create_schema["$ref"].endswith("SolutionDeploymentCreate")
     assert "multipart/form-data" not in paths[base]["post"]["requestBody"]["content"]

--- a/api/tests/unit/services/solutions/test_deployment_activation.py
+++ b/api/tests/unit/services/solutions/test_deployment_activation.py
@@ -218,9 +218,10 @@ async def test_activation_rejects_deployment_from_different_solution_in_same_sco
     actual_solution_id = uuid4()
     candidate = deployment(actual_solution_id, "ready", None)
     repository = FakeRepository([candidate], None)
+    activation = service(repository, FakeHooks())
 
     with pytest.raises(ValueError, match="missing or out of scope"):
-        await service(repository, FakeHooks()).activate(
+        await activation.activate(
             candidate.id,
             None,
             route_solution_id,

--- a/api/tests/unit/services/solutions/test_deployment_activation.py
+++ b/api/tests/unit/services/solutions/test_deployment_activation.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
@@ -39,13 +40,21 @@ class FakeRepository:
         self.deployments = {item.id: item for item in deployments}
         self.active = active
 
-    async def get_runtime_closure(self, deployment_id, organization_id):
+    async def get_runtime_closure(
+        self, deployment_id, organization_id, solution_id=None
+    ):
         item = self.deployments.get(deployment_id)
         return (
             item
-            if item is not None and item.organization_id == organization_id
+            if item is not None
+            and item.organization_id == organization_id
+            and (solution_id is None or item.solution_id == solution_id)
             else None
         )
+
+    @asynccontextmanager
+    async def projection_savepoint(self):
+        yield
 
     async def transition(
         self, deployment_id, organization_id, *, expected_state, new_state, **values
@@ -111,10 +120,10 @@ async def test_two_drafts_from_one_base_have_deterministic_cas_conflict():
     activation = service(repository, hooks)
 
     winner = await activation.activate(
-        first.id, None, expected_active_deployment_id=current.id
+        first.id, None, solution_id, expected_active_deployment_id=current.id
     )
     loser = await activation.activate(
-        second.id, None, expected_active_deployment_id=current.id
+        second.id, None, solution_id, expected_active_deployment_id=current.id
     )
 
     assert winner.state == "active"
@@ -140,7 +149,7 @@ async def test_rollback_reactivates_prior_immutable_deployment_by_cas():
     activation = service(repository, FakeHooks())
 
     result = await activation.rollback(
-        prior.id, None, expected_active_deployment_id=current.id
+        prior.id, None, solution_id, expected_active_deployment_id=current.id
     )
 
     assert result.state == "active"
@@ -159,7 +168,7 @@ async def test_artifact_failure_records_recovery_without_moving_pointer():
     activation = service(repository, FakeHooks(fail_verify=True))
 
     result = await activation.activate(
-        candidate.id, None, expected_active_deployment_id=current.id
+        candidate.id, None, solution_id, expected_active_deployment_id=current.id
     )
 
     assert result.state == "recovery_required"
@@ -177,7 +186,7 @@ async def test_projection_failure_records_pointer_moved_recovery_evidence():
     activation = service(repository, FakeHooks(fail_projection=True))
 
     result = await activation.activate(
-        candidate.id, None, expected_active_deployment_id=current.id
+        candidate.id, None, solution_id, expected_active_deployment_id=current.id
     )
 
     assert result.state == "recovery_required"
@@ -196,7 +205,26 @@ async def test_activation_rejects_expected_pointer_that_is_not_draft_base():
 
     with pytest.raises(ValueError, match="draft base"):
         await activation.activate(
-            candidate.id, None, expected_active_deployment_id=unexpected_active_id
+            candidate.id,
+            None,
+            solution_id,
+            expected_active_deployment_id=unexpected_active_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_activation_rejects_deployment_from_different_solution_in_same_scope():
+    route_solution_id = uuid4()
+    actual_solution_id = uuid4()
+    candidate = deployment(actual_solution_id, "ready", None)
+    repository = FakeRepository([candidate], None)
+
+    with pytest.raises(ValueError, match="missing or out of scope"):
+        await service(repository, FakeHooks()).activate(
+            candidate.id,
+            None,
+            route_solution_id,
+            expected_active_deployment_id=None,
         )
 
 

--- a/api/tests/unit/services/solutions/test_deployment_api.py
+++ b/api/tests/unit/services/solutions/test_deployment_api.py
@@ -36,7 +36,8 @@ async def test_create_registers_complete_reference_only_ready_draft(monkeypatch)
         ),
     )
     session = SimpleNamespace(
-        scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None))
+        scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None)),
+        get=AsyncMock(return_value=None),
     )
     created = []
     written = []
@@ -55,8 +56,12 @@ async def test_create_registers_complete_reference_only_ready_draft(monkeypatch)
         async def write_compiled_manifest(self, content):
             written.append(content)
 
-    monkeypatch.setattr("src.services.solutions.deployment_api.SolutionDeploymentRepository", Repository)
-    monkeypatch.setattr("src.services.solutions.deployment_api.SolutionDeploymentStorage", Storage)
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_api.SolutionDeploymentRepository", Repository
+    )
+    monkeypatch.setattr(
+        "src.services.solutions.deployment_api.SolutionDeploymentStorage", Storage
+    )
     service = SolutionDeploymentAPIService(session)
     row = await service.create_ready_draft(
         solution_id,
@@ -80,14 +85,19 @@ async def test_create_rejects_noncanonical_external_source_reference():
         deployment_id=deployment_id,
         bundle_hash="sha256:bundle",
         resolution_map_hash=sha256_digest(canonical_json(resolution)),
-        source=DeploymentSource(artifact_key="mutable/source.zip", runtime_prefix="runtime/"),
+        source=DeploymentSource(
+            artifact_key="mutable/source.zip", runtime_prefix="runtime/"
+        ),
     )
     session = SimpleNamespace(
-        scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None))
+        scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None)),
+        get=AsyncMock(return_value=None),
     )
     with pytest.raises(ValueError, match="canonical deployment key"):
         await SolutionDeploymentAPIService(session).create_ready_draft(
             solution_id,
             uuid4(),
-            SolutionDeploymentCreate(compiled_manifest=manifest, resolution_map=resolution),
+            SolutionDeploymentCreate(
+                compiled_manifest=manifest, resolution_map=resolution
+            ),
         )

--- a/api/tests/unit/services/solutions/test_deployment_api.py
+++ b/api/tests/unit/services/solutions/test_deployment_api.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.models.contracts.solution_deployments import SolutionDeploymentCreate
+from src.services.solutions.deployment_api import SolutionDeploymentAPIService
+from src.services.solutions.deployment_manifest import (
+    CompiledDeploymentManifest,
+    DeploymentResolutionMap,
+    DeploymentSource,
+    canonical_json,
+    sha256_digest,
+)
+from src.services.solutions.deployment_storage import (
+    deployment_source_artifact_key,
+    deployment_runtime_prefix,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_registers_complete_reference_only_ready_draft(monkeypatch):
+    solution_id = uuid4()
+    deployment_id = uuid4()
+    resolution = DeploymentResolutionMap()
+    resolution_hash = sha256_digest(canonical_json(resolution))
+    manifest = CompiledDeploymentManifest(
+        solution_id=solution_id,
+        deployment_id=deployment_id,
+        bundle_hash="sha256:bundle",
+        resolution_map_hash=resolution_hash,
+        source=DeploymentSource(
+            artifact_key=deployment_source_artifact_key(solution_id, deployment_id),
+            runtime_prefix=deployment_runtime_prefix(solution_id, deployment_id),
+        ),
+    )
+    session = SimpleNamespace(
+        scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None))
+    )
+    created = []
+    written = []
+
+    class Repository:
+        def __init__(self, _session):
+            pass
+
+        async def create(self, deployment):
+            created.append(deployment)
+
+    class Storage:
+        def __init__(self, *_args):
+            pass
+
+        async def write_compiled_manifest(self, content):
+            written.append(content)
+
+    monkeypatch.setattr("src.services.solutions.deployment_api.SolutionDeploymentRepository", Repository)
+    monkeypatch.setattr("src.services.solutions.deployment_api.SolutionDeploymentStorage", Storage)
+    service = SolutionDeploymentAPIService(session)
+    row = await service.create_ready_draft(
+        solution_id,
+        uuid4(),
+        SolutionDeploymentCreate(compiled_manifest=manifest, resolution_map=resolution),
+    )
+
+    assert row.state == "ready"
+    assert row.source_artifact_key == manifest.source.artifact_key
+    assert created == [row]
+    assert written == [manifest.canonical_bytes()]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_noncanonical_external_source_reference():
+    solution_id = uuid4()
+    deployment_id = uuid4()
+    resolution = DeploymentResolutionMap()
+    manifest = CompiledDeploymentManifest(
+        solution_id=solution_id,
+        deployment_id=deployment_id,
+        bundle_hash="sha256:bundle",
+        resolution_map_hash=sha256_digest(canonical_json(resolution)),
+        source=DeploymentSource(artifact_key="mutable/source.zip", runtime_prefix="runtime/"),
+    )
+    session = SimpleNamespace(
+        scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None))
+    )
+    with pytest.raises(ValueError, match="canonical deployment key"):
+        await SolutionDeploymentAPIService(session).create_ready_draft(
+            solution_id,
+            uuid4(),
+            SolutionDeploymentCreate(compiled_manifest=manifest, resolution_map=resolution),
+        )

--- a/api/tests/unit/services/solutions/test_deployment_api.py
+++ b/api/tests/unit/services/solutions/test_deployment_api.py
@@ -93,11 +93,10 @@ async def test_create_rejects_noncanonical_external_source_reference():
         scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None)),
         get=AsyncMock(return_value=None),
     )
+    api = SolutionDeploymentAPIService(session)
+    user_id = uuid4()
+    body = SolutionDeploymentCreate(
+        compiled_manifest=manifest, resolution_map=resolution
+    )
     with pytest.raises(ValueError, match="canonical deployment key"):
-        await SolutionDeploymentAPIService(session).create_ready_draft(
-            solution_id,
-            uuid4(),
-            SolutionDeploymentCreate(
-                compiled_manifest=manifest, resolution_map=resolution
-            ),
-        )
+        await api.create_ready_draft(solution_id, user_id, body)

--- a/api/tests/unit/services/solutions/test_deployment_api.py
+++ b/api/tests/unit/services/solutions/test_deployment_api.py
@@ -35,11 +35,15 @@ async def test_create_registers_complete_reference_only_ready_draft(monkeypatch)
             runtime_prefix=deployment_runtime_prefix(solution_id, deployment_id),
         ),
     )
+    solution = SimpleNamespace(
+        organization_id=None, execution_runtime_mode="repo-v1"
+    )
     session = SimpleNamespace(
-        scalar=AsyncMock(return_value=SimpleNamespace(organization_id=None)),
+        scalar=AsyncMock(return_value=solution),
         get=AsyncMock(return_value=None),
     )
     created = []
+    transitions = []
     written = []
 
     class Repository:
@@ -48,6 +52,17 @@ async def test_create_registers_complete_reference_only_ready_draft(monkeypatch)
 
         async def create(self, deployment):
             created.append(deployment)
+
+        async def transition(
+            self, deployment_id, organization_id, *, expected_state, new_state
+        ):
+            row = created[0]
+            assert row.id == deployment_id
+            assert organization_id is None
+            assert row.state == expected_state
+            transitions.append((expected_state, new_state))
+            row.state = new_state
+            return row
 
     class Storage:
         def __init__(self, *_args):
@@ -72,6 +87,12 @@ async def test_create_registers_complete_reference_only_ready_draft(monkeypatch)
     assert row.state == "ready"
     assert row.source_artifact_key == manifest.source.artifact_key
     assert created == [row]
+    assert transitions == [
+        ("draft", "building"),
+        ("building", "validated"),
+        ("validated", "ready"),
+    ]
+    assert solution.execution_runtime_mode == "deployment-v1"
     assert written == [manifest.canonical_bytes()]
 
 


### PR DESCRIPTION
## Summary
- register a complete hash-validated deployment from compiled manifest and resolution map
- inspect deployments with Solution and organization scope enforcement
- expose expected-active CAS activation and explicit CAS rollback
- publish JSON-only request/response/OpenAPI contracts for cs

## Safety boundary
Source and runtime artifacts must already use canonical revision-addressed references; this slice does not add upload transport. Production activation deliberately returns 503 until real artifact verification and administrative projection rebuild hooks are configured, so it cannot move the pointer through placeholder hooks.

## Stack
Depends on #452, #451, and #449.

## Verification
- 9 focused API/activation tests
- OpenAPI JSON-only surface proof
- Ruff
- Pyright (0 errors)
- compile and diff checks

No live Bifrost state was mutated.