### PR TITLE
Allow aborting conflicted workspace changesets

### DIFF
--- a/api/src/services/workspace_repo_changesets.py
+++ b/api/src/services/workspace_repo_changesets.py
@@ -66,6 +66,7 @@ CommitCallback = Callable[[str, bool], Awaitable[tuple[str | None, str | None]]]
 
 class WorkspaceRepoChangesetService:
     ACTIVE = {"open", "staged", "validated"}
+    ABORTABLE = ACTIVE | {"conflicted"}
 
     def __init__(
         self,
@@ -466,7 +467,10 @@ class WorkspaceRepoChangesetService:
 
     async def abort(self, changeset_id: UUID) -> WorkspaceRepoChangesetResponse:
         row = await self._required(changeset_id, for_update=True)
-        self._ensure_active(row)
+        if row.status not in self.ABORTABLE:
+            raise ChangesetInvalid(
+                f"changeset in {row.status!r} state cannot be aborted"
+            )
         row.status = "aborted"
         await self.db.flush()
         return self._response(row)

--- a/api/tests/unit/services/test_workspace_repo_changesets.py
+++ b/api/tests/unit/services/test_workspace_repo_changesets.py
@@ -233,6 +233,9 @@ async def test_path_level_cas_allows_disjoint_change_and_rejects_touched_change(
         await svc.activate(second.id, WorkspaceRepoActivateRequest(), "tester")
     assert exc.value.detail["conflicting_paths"] == ["features/a.py"]
 
+    aborted = await svc.abort(second.id)
+    assert aborted.status == "aborted"
+
 
 @pytest.mark.asyncio
 async def test_activation_compensates_storage_on_partial_failure(monkeypatch):


### PR DESCRIPTION
## Summary
- allow an audited workspace changeset to transition from `conflicted` to `aborted`
- keep stage/validate mutations restricted to active states
- extend the CAS conflict regression test through cleanup

## Live proof
A two-draft `_repo` proof on dev produced deterministic `revision_mismatch` for the losing draft, then exposed that `/abort` rejected its persisted `conflicted` state. This change closes that exact lifecycle gap.

## Validation
- `git diff --check`
- focused regression added to `api/tests/unit/services/test_workspace_repo_changesets.py`
- Windows host pytest intentionally skipped per platform repo policy; Linux CI is the execution proof

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Changesets in a conflicted state can now be aborted.

- **Bug Fixes**
  - Aborting a changeset now provides a status-specific error when the action isn’t allowed.
  - Added coverage to confirm conflicted changesets are correctly marked as aborted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->