### PR TITLE
fix: enforce inactive Solution execution revocation

### DIFF
--- a/api/src/services/solutions/deployment_runtime.py
+++ b/api/src/services/solutions/deployment_runtime.py
@@ -154,7 +154,7 @@ async def pin_workflow_runtime(
     workflow, solution = row
     if workflow.solution_id is None:
         return None
-    if solution is None or (caller_deployment_id is None and solution.status != "active"):
+    if solution is None or solution.status != "active":
         raise DeploymentRuntimeError("Solution is not active")
     selected_deployment_id = await _select_deployment_id(
         session, workflow.solution_id, solution.active_deployment_id, caller_deployment_id

--- a/api/tests/unit/services/solutions/test_deployment_runtime.py
+++ b/api/tests/unit/services/solutions/test_deployment_runtime.py
@@ -228,6 +228,19 @@ async def test_child_call_inherits_superseded_parent_deployment(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pinned_runtime_rejects_inactive_solution():
+    solution_id, workflow_id, deployment_id = uuid4(), uuid4(), uuid4()
+    workflow = SimpleNamespace(id=workflow_id, solution_id=solution_id)
+    solution = SimpleNamespace(id=solution_id, status="inactive")
+    session = SimpleNamespace(execute=AsyncMock(return_value=_Result((workflow, solution))))
+
+    with pytest.raises(DeploymentRuntimeError, match="Solution is not active"):
+        await pin_workflow_runtime(
+            session, workflow_id, caller_deployment_id=deployment_id
+        )
+
+
+@pytest.mark.asyncio
 async def test_cross_solution_child_uses_exact_dependency_deployment(monkeypatch):
     owner_solution_id, target_solution_id, workflow_id = uuid4(), uuid4(), uuid4()
     caller_id, dependency_id, current_target_id = uuid4(), uuid4(), uuid4()


### PR DESCRIPTION
### Motivation
- Close a lifecycle authorization bypass where deployment-pinned workflow executions could run after a Solution was flipped to `inactive`, allowing queued/scheduled pinned executions to bypass the legacy inactive-Solution gate.

### Description
- Tighten runtime pinning in `api/src/services/solutions/deployment_runtime.py` by always rejecting workflows whose owning `Solution` is not `active`, regardless of a `caller_deployment_id` (change in `pin_workflow_runtime`).
- Add a regression unit test `test_pinned_runtime_rejects_inactive_solution` in `api/tests/unit/services/solutions/test_deployment_runtime.py` that verifies pinned resolution fails for an inactive Solution.
- Commit message: `fix: enforce inactive solution execution revocation` and updated the two files above.

### Testing
- Static checks passed: `python3 -m py_compile api/src/services/solutions/deployment_runtime.py api/tests/unit/services/solutions/test_deployment_runtime.py` and `ruff check` completed successfully. 
- `git diff --check` passed and changes were committed locally. 
- Added unit test covering the regression, but running the Dockerized test harness (`./test.sh ...`) was not possible here because Docker is unavailable in this environment, so the new test was not executed end-to-end in the CI-like stack.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5937af3ffc8328b461da476e154144)