### PR TITLE
fix: clear 16 code scanning security alerts

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -82,46 +82,6 @@ RUN cd /app/src/services/app_bundler && npm ci --ignore-scripts --omit=dev
 # SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
 # /api/sdk/download can bundle + serve the installable `bifrost` package without
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
-COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
-COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
-COPY client/src/lib/app-sdk/provider.tsx \
-     client/src/lib/app-sdk/tables.ts \
-     client/src/lib/app-sdk/transport.ts \
-     client/src/lib/app-sdk/use-table.ts \
-     client/src/lib/app-sdk/use-infinite-table.ts \
-     client/src/lib/app-sdk/ws-client.ts \
-     client/src/lib/app-sdk/use-workflow.ts \
-     client/src/lib/app-sdk/use-workflow-hooks.ts \
-     client/src/lib/app-sdk/bifrost-header.tsx \
-     /app/src/services/sdk_package/sdk_src/
-COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
-
-# SDK package builder (esbuild) + the v2 `bifrost` SDK source it bundles. The
-# SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
-# /api/sdk/download can bundle + serve the installable `bifrost` package without
-# the client/ tree at runtime. A unit test enforces this file list stays in sync.
-COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
-COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
-COPY client/src/lib/app-sdk/provider.tsx \
-     client/src/lib/app-sdk/tables.ts \
-     client/src/lib/app-sdk/transport.ts \
-     client/src/lib/app-sdk/use-table.ts \
-     client/src/lib/app-sdk/use-infinite-table.ts \
-     client/src/lib/app-sdk/ws-client.ts \
-     client/src/lib/app-sdk/use-workflow.ts \
-     client/src/lib/app-sdk/use-workflow-hooks.ts \
-     client/src/lib/app-sdk/files.ts \
-     client/src/lib/app-sdk/use-files.ts \
-     client/src/lib/app-sdk/bifrost-header.tsx \
-     /app/src/services/sdk_package/sdk_src/
-COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
-
-# SDK package builder (esbuild) + the v2 `bifrost` SDK source it bundles. The
-# SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
-# /api/sdk/download can bundle + serve the installable `bifrost` package without
-# the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package.json api/src/services/sdk_package/package-lock.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
 RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # flags unpinned `pip install <pkg>` invocations, and the pip shipped in
 # python:3.14-slim already supports --require-hashes (>= 8.0).
 COPY pyproject.toml requirements.lock ./
-RUN pip install --no-cache-dir --require-hashes -r requirements.lock
+RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.lock
 
 # =============================================================================
 # Stage 2: Runtime
@@ -72,11 +72,11 @@ COPY api/scripts/ /app/scripts/
 COPY api/src/services/app_compiler/package.json api/src/services/app_compiler/package-lock.json* /app/src/services/app_compiler/
 COPY api/src/services/app_compiler/compile.js /app/src/services/app_compiler/
 COPY api/src/services/app_compiler/tailwind.js /app/src/services/app_compiler/
-RUN cd /app/src/services/app_compiler && npm ci --omit=dev
+RUN cd /app/src/services/app_compiler && npm ci --ignore-scripts --omit=dev
 
 # Install app bundler Node.js dependencies (esbuild)
 COPY api/src/services/app_bundler/package.json api/src/services/app_bundler/package-lock.json* /app/src/services/app_bundler/
-RUN cd /app/src/services/app_bundler && npm ci --omit=dev
+RUN cd /app/src/services/app_bundler && npm ci --ignore-scripts --omit=dev
 
 # SDK package builder (esbuild) + the v2 `bifrost` SDK source it bundles. The
 # SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
@@ -84,7 +84,7 @@ RUN cd /app/src/services/app_bundler && npm ci --omit=dev
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --omit=dev
+RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
 COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/tables.ts \
      client/src/lib/app-sdk/transport.ts \
@@ -103,7 +103,7 @@ COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/in
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --omit=dev
+RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
 COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/tables.ts \
      client/src/lib/app-sdk/transport.ts \
@@ -124,7 +124,7 @@ COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/in
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package.json api/src/services/sdk_package/package-lock.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --omit=dev
+RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
 COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/tables.ts \
      client/src/lib/app-sdk/transport.ts \

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -26,8 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # flags unpinned `pip install <pkg>` invocations, and the pip shipped in
 # python:3.14-slim already supports --require-hashes (>= 8.0).
 COPY pyproject.toml requirements.lock requirements-pyright.lock ./
-RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
-    && pip install --no-cache-dir --require-hashes -r requirements-pyright.lock
+RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.lock \
+    && pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements-pyright.lock
 
 # =============================================================================
 # Stage 2: Runtime
@@ -72,11 +72,11 @@ RUN mkdir -p /workspace /tmp/bifrost && \
 COPY api/src/services/app_compiler/package.json api/src/services/app_compiler/package-lock.json* /app/src/services/app_compiler/
 COPY api/src/services/app_compiler/compile.js /app/src/services/app_compiler/
 COPY api/src/services/app_compiler/tailwind.js /app/src/services/app_compiler/
-RUN cd /app/src/services/app_compiler && npm ci --omit=dev
+RUN cd /app/src/services/app_compiler && npm ci --ignore-scripts --omit=dev
 
 # Install app bundler Node.js dependencies (esbuild)
 COPY api/src/services/app_bundler/package.json api/src/services/app_bundler/package-lock.json* /app/src/services/app_bundler/
-RUN cd /app/src/services/app_bundler && npm ci --omit=dev
+RUN cd /app/src/services/app_bundler && npm ci --ignore-scripts --omit=dev
 
 # SDK package builder (esbuild) + the v2 `bifrost` SDK source it bundles. The
 # SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
@@ -84,7 +84,7 @@ RUN cd /app/src/services/app_bundler && npm ci --omit=dev
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --omit=dev
+RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
 COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/tables.ts \
      client/src/lib/app-sdk/transport.ts \
@@ -103,7 +103,7 @@ COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/in
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --omit=dev
+RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
 COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/tables.ts \
      client/src/lib/app-sdk/transport.ts \
@@ -125,7 +125,7 @@ RUN chmod -R a+rX /app/src/services/sdk_package
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package.json api/src/services/sdk_package/package-lock.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --omit=dev
+RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
 COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/tables.ts \
      client/src/lib/app-sdk/transport.ts \

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -82,47 +82,6 @@ RUN cd /app/src/services/app_bundler && npm ci --ignore-scripts --omit=dev
 # SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
 # /api/sdk/download can bundle + serve the installable `bifrost` package without
 # the client/ tree at runtime. A unit test enforces this file list stays in sync.
-COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
-COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
-COPY client/src/lib/app-sdk/provider.tsx \
-     client/src/lib/app-sdk/tables.ts \
-     client/src/lib/app-sdk/transport.ts \
-     client/src/lib/app-sdk/use-table.ts \
-     client/src/lib/app-sdk/use-infinite-table.ts \
-     client/src/lib/app-sdk/ws-client.ts \
-     client/src/lib/app-sdk/use-workflow.ts \
-     client/src/lib/app-sdk/use-workflow-hooks.ts \
-     client/src/lib/app-sdk/bifrost-header.tsx \
-     /app/src/services/sdk_package/sdk_src/
-COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
-
-# SDK package builder (esbuild) + the v2 `bifrost` SDK source it bundles. The
-# SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
-# /api/sdk/download can bundle + serve the installable `bifrost` package without
-# the client/ tree at runtime. A unit test enforces this file list stays in sync.
-COPY api/src/services/sdk_package/package*.json /app/src/services/sdk_package/
-COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
-RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev
-COPY client/src/lib/app-sdk/provider.tsx \
-     client/src/lib/app-sdk/tables.ts \
-     client/src/lib/app-sdk/transport.ts \
-     client/src/lib/app-sdk/use-table.ts \
-     client/src/lib/app-sdk/use-infinite-table.ts \
-     client/src/lib/app-sdk/ws-client.ts \
-     client/src/lib/app-sdk/use-workflow.ts \
-     client/src/lib/app-sdk/use-workflow-hooks.ts \
-     client/src/lib/app-sdk/files.ts \
-     client/src/lib/app-sdk/use-files.ts \
-     client/src/lib/app-sdk/bifrost-header.tsx \
-     /app/src/services/sdk_package/sdk_src/
-COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
-RUN chmod -R a+rX /app/src/services/sdk_package
-
-# SDK package builder (esbuild) + the v2 `bifrost` SDK source it bundles. The
-# SDK source of truth lives in client/src/lib/app-sdk; it is copied here so
-# /api/sdk/download can bundle + serve the installable `bifrost` package without
-# the client/ tree at runtime. A unit test enforces this file list stays in sync.
 COPY api/src/services/sdk_package/package.json api/src/services/sdk_package/package-lock.json /app/src/services/sdk_package/
 COPY api/src/services/sdk_package/build_sdk.js /app/src/services/sdk_package/
 RUN cd /app/src/services/sdk_package && npm ci --ignore-scripts --omit=dev

--- a/api/src/services/solutions/deployment_activation.py
+++ b/api/src/services/solutions/deployment_activation.py
@@ -12,13 +12,13 @@ from src.repositories.solution_deployments import SolutionDeploymentRepository
 
 
 class DeploymentActivationHooks(Protocol):
-    """External artifact/projection work required before pointer movement."""
+    """External artifact and projection work required during activation."""
 
     async def verify_finalized(self, deployment: SolutionDeployment) -> None:
         """Verify that deployment artifacts are finalized and ready to activate."""
 
     async def rebuild_projections(self, deployment: SolutionDeployment) -> None:
-        """Rebuild external projections for the deployment before pointer movement."""
+        """Rebuild external projections for the deployment after pointer movement."""
 
 
 @dataclass(frozen=True)

--- a/api/src/services/solutions/deployment_activation.py
+++ b/api/src/services/solutions/deployment_activation.py
@@ -14,9 +14,11 @@ from src.repositories.solution_deployments import SolutionDeploymentRepository
 class DeploymentActivationHooks(Protocol):
     """External artifact/projection work required before pointer movement."""
 
-    async def verify_finalized(self, deployment: SolutionDeployment) -> None: ...
+    async def verify_finalized(self, deployment: SolutionDeployment) -> None:
+        """Verify that deployment artifacts are finalized and ready to activate."""
 
-    async def rebuild_projections(self, deployment: SolutionDeployment) -> None: ...
+    async def rebuild_projections(self, deployment: SolutionDeployment) -> None:
+        """Rebuild external projections for the deployment before pointer movement."""
 
 
 @dataclass(frozen=True)

--- a/api/tests/unit/test_compose_test_harness.py
+++ b/api/tests/unit/test_compose_test_harness.py
@@ -119,7 +119,10 @@ def test_dev_image_installs_pyright_from_hash_pinned_lock():
     """Local Docker type-checks should not depend on host pyright installs."""
     dockerfile = _find_repo_file("api/Dockerfile.dev").read_text()
     assert "requirements-pyright.lock" in dockerfile
-    assert "pip install --no-cache-dir --require-hashes -r requirements-pyright.lock" in dockerfile
+    assert (
+        "pip install --no-cache-dir --only-binary :all: --require-hashes "
+        "-r requirements-pyright.lock"
+    ) in dockerfile
 
 
 def test_test_sh_advertises_dockerized_api_quality_lane():

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2772,9 +2772,9 @@
 			}
 		},
 		"node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2782,9 +2782,9 @@
 			}
 		},
 		"node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -5282,9 +5282,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -136,6 +136,9 @@
 		"vitest": "^4.1.4"
 	},
 	"overrides": {
-		"dompurify": "^3.4.10"
+		"dompurify": "^3.4.10",
+		"@redocly/openapi-core": {
+			"js-yaml": "4.3.0"
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- clear 13 SonarCloud Docker supply-chain alerts by requiring binary-only Python dependencies and disabling npm lifecycle scripts
- clear 2 CodeQL ineffectual-statement alerts by replacing protocol ellipsis bodies with lifecycle-accurate declarations
- clear the Scorecard vulnerability alert by moving `brace-expansion` to 1.1.16/2.1.2 and overriding Redocly's exact `js-yaml` pin to patched 4.3.0
- remove four redundant SDK image setup blocks identified during review

## Delivery lane

Lane 3 — security and container build behavior. The PR is isolated and CI is the authoritative Linux/Docker verification.

## Verification

- required GitHub CI: lint/type-check, backend unit tests, client unit tests, and all four E2E shards passed
- CodeQL Python and JavaScript/TypeScript analyses passed
- SonarCloud Quality Gate passed with 0 new issues and 0 security hotspots
- CodeRabbit approved the final diff
- Snyk Open Source/IaC, Socket, and CodSpeed passed
- each Linux CI job successfully built the hardened `api/Dockerfile.dev`
- local `npm ci --ignore-scripts`, `npm audit --json` (0 vulnerabilities), client build, OpenAPI generator, and Node runtime smoke checks passed
- `python -m compileall` and `git diff --check` passed

## Security notes

- patched npm versions were verified against GHSA-3jxr-9vmj-r5cp and GHSA-52cp-r559-cp3m
- package registry integrity metadata matches the lockfile
- no new package names or lifecycle scripts were introduced
- rollback is a straight revert; no schema or data migration is involved

Alerts #149 and #699-#713 remain open on the default branch until this PR merges and the next main-branch analyses reconcile them.