### PR TITLE
fix: clear remaining Scorecard vulnerability

### DIFF
--- a/scripts/docs/package-lock.json
+++ b/scripts/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "bifrost-docs-pipeline",
       "version": "0.0.1",
       "dependencies": {
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.0",
         "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
         "sharp": "^0.34.2",
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/scripts/docs/package.json
+++ b/scripts/docs/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "description": "Tooling for the gobifrost screenshot pipeline.",
   "dependencies": {
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "sharp": "^0.34.2",


### PR DESCRIPTION
## Summary

- raise the docs pipeline's direct js-yaml floor from 4.2.0 to patched 4.3.0
- update the dedicated scripts/docs lockfile and integrity metadata
- clear the remaining GHSA-52cp-r559-cp3m finding reported by Scorecard after #462 merged

## Verification

- npm ci --ignore-scripts
- npm audit --json: 0 vulnerabilities
- npm ls js-yaml: 4.3.0 only
- js-yaml parse smoke test
- git diff --check

This is the repository-owned lockfile missed by #462. Alert #149 should reconcile after this merges and Scorecard reruns on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML parsing dependency used by documentation tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->