### PR TITLE
fix(skills): keep issue text out of shell source

### DIFF
--- a/.agents/skills/bifrost-issues/SKILL.md
+++ b/.agents/skills/bifrost-issues/SKILL.md
@@ -54,8 +54,13 @@ Before any code, before any worktree, get an issue number.
 Search for existing issues:
 
 ```bash
-SEARCH_TERMS="auth timeout"
-gh issue list --search "$SEARCH_TERMS" --state all --limit 5
+ISSUE_TMP_DIR="$(mktemp -d)"
+SEARCH_FILE="$ISSUE_TMP_DIR/search.txt"
+# Write the exact search text to $SEARCH_FILE with the agent's file-edit tool.
+# Do not put conversation-derived text in shell source.
+gh issue list --search "$(<"$SEARCH_FILE")" --state all --limit 5
+rm -f -- "$SEARCH_FILE"
+rmdir -- "$ISSUE_TMP_DIR"
 ```
 
 If a plausible match exists, surface it: "This looks related to #N — is that the same thing, or a new one?"
@@ -67,7 +72,7 @@ When drafting an issue body:
 - Pick the template (`bug`, `feature`, `chore`) from the work description.
 - Fill every field from conversation context; ask the user only for gaps.
 - Show the draft (title + body + labels + assignee) before filing.
-- On approval, file via `gh issue create --title "..." --body "..." --label "..." --assignee "@me"` (self-assign only if the user is doing the work).
+- On approval, use the file-backed pattern below. Never interpolate conversation-derived title/body/search text into shell source.
 
 ### 2. Worktree setup
 
@@ -263,37 +268,28 @@ Do **not** add priority labels, milestones, or status labels.
 
 ## The `gh issue create` Pattern
 
+Treat issue search terms, titles, and bodies as untrusted data. Never embed them in a shell command, quoted assignment, command-generating template, or fixed-delimiter heredoc. Shell quoting is not a substitute for separating data from shell source.
+
 ```bash
-BODY_FILE="$(mktemp -t bifrost-issue-body.XXXXXX.md)"
-cat >"$BODY_FILE" <<'EOF'
-## Summary
-...
+ISSUE_TMP_DIR="$(mktemp -d)"
+TITLE_FILE="$ISSUE_TMP_DIR/title.txt"
+BODY_FILE="$ISSUE_TMP_DIR/body.md"
 
-## Steps to reproduce
-...
-
-## Expected behavior
-...
-
-## Actual behavior
-...
-
-## Environment
-...
-
-## Notes
-- File paths and line numbers where relevant
-- Proposed approach if known
-EOF
-
+# Write title.txt and body.md with the agent's file-edit API/tool, not with
+# shell interpolation, echo/printf, a here-string, or a heredoc. The body file
+# should mirror the relevant template in .github/ISSUE_TEMPLATE/.
 gh issue create \
-  --title "[bug]: <summary>" \
+  --title "$(<"$TITLE_FILE")" \
   --body-file "$BODY_FILE" \
   --label "bug" \
   --assignee "@me"   # only if user is doing the work
+
+# Remove only the exact files created above; leave cleanup visible and bounded.
+rm -f -- "$TITLE_FILE" "$BODY_FILE"
+rmdir -- "$ISSUE_TMP_DIR"
 ```
 
-Mirror the relevant template in `.github/ISSUE_TEMPLATE/`. Use `[bug]:`, `[feature]:`, or `[chore]:` title prefixes.
+Labels and assignees must come from fixed repository conventions or a validated allowlist. For batch triage, repeat the file-backed invocation per issue; do not construct a shell loop containing untrusted issue text. Use `[bug]:`, `[feature]:`, or `[chore]:` title prefixes.
 
 ## What This Skill Does NOT Do
 

--- a/.claude/skills/bifrost-issues/SKILL.md
+++ b/.claude/skills/bifrost-issues/SKILL.md
@@ -54,8 +54,13 @@ Before any code, before any worktree, get an issue number.
 Search for existing issues:
 
 ```bash
-search_terms="<2-3 key terms>"
-gh issue list --search "$search_terms" --state all --limit 5
+ISSUE_TMP_DIR="$(mktemp -d)"
+SEARCH_FILE="$ISSUE_TMP_DIR/search.txt"
+# Write the exact search text to $SEARCH_FILE with the agent's file-edit tool.
+# Do not put conversation-derived text in shell source.
+gh issue list --search "$(<"$SEARCH_FILE")" --state all --limit 5
+rm -f -- "$SEARCH_FILE"
+rmdir -- "$ISSUE_TMP_DIR"
 ```
 
 If a plausible match exists, surface it: "This looks related to #N — is that the same thing, or a new one?"
@@ -67,7 +72,7 @@ When drafting an issue body:
 - Pick the template (`bug`, `feature`, `chore`) from the work description.
 - Fill every field from conversation context; ask the user only for gaps.
 - Show the draft (title + body + labels + assignee) before filing.
-- On approval, file via `gh issue create --title "..." --body "..." --label "..." --assignee "@me"` (self-assign only if the user is doing the work).
+- On approval, use the file-backed pattern below. Never interpolate conversation-derived title/body/search text into shell source.
 
 ### 2. Worktree setup
 
@@ -290,35 +295,28 @@ Do **not** add priority labels, milestones, or status labels.
 
 ## The `gh issue create` Pattern
 
+Treat issue search terms, titles, and bodies as untrusted data. Never embed them in a shell command, quoted assignment, command-generating template, or fixed-delimiter heredoc. Shell quoting is not a substitute for separating data from shell source.
+
 ```bash
-tmp_body="$(mktemp)"
-cat > "$tmp_body" <<'EOF'
-## Summary
-...
+ISSUE_TMP_DIR="$(mktemp -d)"
+TITLE_FILE="$ISSUE_TMP_DIR/title.txt"
+BODY_FILE="$ISSUE_TMP_DIR/body.md"
 
-## Steps to reproduce
-...
-
-## Expected behavior
-...
-
-## Actual behavior
-...
-
-## Environment
-...
-
-## Notes
-- File paths and line numbers where relevant
-- Proposed approach if known
-EOF
+# Write title.txt and body.md with the agent's file-edit API/tool, not with
+# shell interpolation, echo/printf, a here-string, or a heredoc. The body file
+# should mirror the relevant template in .github/ISSUE_TEMPLATE/.
 gh issue create \
-  --title "[bug]: <summary>" \
-  --body-file "$tmp_body" \
+  --title "$(<"$TITLE_FILE")" \
+  --body-file "$BODY_FILE" \
   --label "bug" \
   --assignee "@me"   # only if user is doing the work
-rm -f "$tmp_body"
+
+# Remove only the exact files created above; leave cleanup visible and bounded.
+rm -f -- "$TITLE_FILE" "$BODY_FILE"
+rmdir -- "$ISSUE_TMP_DIR"
 ```
+
+Labels and assignees must come from fixed repository conventions or a validated allowlist. For batch triage, repeat the file-backed invocation per issue; do not construct a shell loop containing untrusted issue text.
 
 Mirror the relevant template in `.github/ISSUE_TEMPLATE/`. Use `[bug]:`, `[feature]:`, or `[chore]:` title prefixes.
 

--- a/.codex/skills/bifrost-issues/SKILL.md
+++ b/.codex/skills/bifrost-issues/SKILL.md
@@ -54,8 +54,13 @@ Before any code, before any worktree, get an issue number.
 Search for existing issues:
 
 ```bash
-search_terms="<2-3 key terms>"
-gh issue list --search "$search_terms" --state all --limit 5
+ISSUE_TMP_DIR="$(mktemp -d)"
+SEARCH_FILE="$ISSUE_TMP_DIR/search.txt"
+# Write the exact search text to $SEARCH_FILE with the agent's file-edit tool.
+# Do not put conversation-derived text in shell source.
+gh issue list --search "$(<"$SEARCH_FILE")" --state all --limit 5
+rm -f -- "$SEARCH_FILE"
+rmdir -- "$ISSUE_TMP_DIR"
 ```
 
 If a plausible match exists, surface it: "This looks related to #N — is that the same thing, or a new one?"
@@ -67,7 +72,7 @@ When drafting an issue body:
 - Pick the template (`bug`, `feature`, `chore`) from the work description.
 - Fill every field from conversation context; ask the user only for gaps.
 - Show the draft (title + body + labels + assignee) before filing.
-- On approval, file via `gh issue create --title "..." --body "..." --label "..." --assignee "@me"` (self-assign only if the user is doing the work).
+- On approval, use the file-backed pattern below. Never interpolate conversation-derived title/body/search text into shell source.
 
 ### 2. Worktree setup
 
@@ -290,35 +295,28 @@ Do **not** add priority labels, milestones, or status labels.
 
 ## The `gh issue create` Pattern
 
+Treat issue search terms, titles, and bodies as untrusted data. Never embed them in a shell command, quoted assignment, command-generating template, or fixed-delimiter heredoc. Shell quoting is not a substitute for separating data from shell source.
+
 ```bash
-tmp_body="$(mktemp)"
-cat > "$tmp_body" <<'EOF'
-## Summary
-...
+ISSUE_TMP_DIR="$(mktemp -d)"
+TITLE_FILE="$ISSUE_TMP_DIR/title.txt"
+BODY_FILE="$ISSUE_TMP_DIR/body.md"
 
-## Steps to reproduce
-...
-
-## Expected behavior
-...
-
-## Actual behavior
-...
-
-## Environment
-...
-
-## Notes
-- File paths and line numbers where relevant
-- Proposed approach if known
-EOF
+# Write title.txt and body.md with the agent's file-edit API/tool, not with
+# shell interpolation, echo/printf, a here-string, or a heredoc. The body file
+# should mirror the relevant template in .github/ISSUE_TEMPLATE/.
 gh issue create \
-  --title "[bug]: <summary>" \
-  --body-file "$tmp_body" \
+  --title "$(<"$TITLE_FILE")" \
+  --body-file "$BODY_FILE" \
   --label "bug" \
   --assignee "@me"   # only if user is doing the work
-rm -f "$tmp_body"
+
+# Remove only the exact files created above; leave cleanup visible and bounded.
+rm -f -- "$TITLE_FILE" "$BODY_FILE"
+rmdir -- "$ISSUE_TMP_DIR"
 ```
+
+Labels and assignees must come from fixed repository conventions or a validated allowlist. For batch triage, repeat the file-backed invocation per issue; do not construct a shell loop containing untrusted issue text.
 
 Mirror the relevant template in `.github/ISSUE_TEMPLATE/`. Use `[bug]:`, `[feature]:`, or `[chore]:` title prefixes.
 

--- a/api/tests/unit/test_issue_skill_shell_safety.py
+++ b/api/tests/unit/test_issue_skill_shell_safety.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILL_PATHS = (
+    REPO_ROOT / ".claude/skills/bifrost-issues/SKILL.md",
+    REPO_ROOT / ".codex/skills/bifrost-issues/SKILL.md",
+    REPO_ROOT / ".agents/skills/bifrost-issues/SKILL.md",
+)
+pytestmark = pytest.mark.skipif(
+    not all(path.exists() for path in SKILL_PATHS),
+    reason="repo-root skill directories are not mounted in the API test container",
+)
+
+
+def test_issue_skills_keep_untrusted_text_out_of_shell_source() -> None:
+    for path in SKILL_PATHS:
+        content = path.read_text(encoding="utf-8")
+
+        assert "fixed-delimiter heredoc" in content
+        assert 'gh issue list --search "$(<"$SEARCH_FILE")"' in content
+        assert '--title "$(<"$TITLE_FILE")"' in content
+        assert '--body-file "$BODY_FILE"' in content
+        assert "<<'EOF'" not in content
+        assert 'search_terms="<2-3 key terms>"' not in content
+        assert 'gh issue create --title "..." --body "..."' not in content
+        assert '--title "[bug]: <summary>"' not in content
+
+
+def test_codex_issue_skill_mirror_matches_canonical() -> None:
+    canonical = SKILL_PATHS[0].read_bytes()
+    assert SKILL_PATHS[1].read_bytes() == canonical


### PR DESCRIPTION
## Summary
- keep conversation-derived issue search terms, titles, and bodies out of shell source
- use file-backed data arguments in all three issue-skill copies
- add regression coverage for the unsafe patterns and Codex mirror parity

## Security finding
Resolves Codex Cloud Security finding 0fcdabaac42081918df5bdf0a8778dde.

## Verification
- 2 shell-safety tests pass locally
- Ruff passes
- diff check passes
- existing mirror test's execute-bit assertion is Linux-only and cannot pass under Windows; GitHub CI is the authoritative run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved issue search and creation workflows to safely handle user-provided content.
  * Added stricter validation for labels and assignees.
  * Improved cleanup of temporary files after issue operations.

* **Tests**
  * Added automated checks to verify safe handling of issue content and consistency across workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->