### PR TITLE
ci: lint and harden platform Dockerfiles

### DIFF
--- a/.github/workflows/dockerfile-policy.yml
+++ b/.github/workflows/dockerfile-policy.yml
@@ -1,0 +1,64 @@
+name: Dockerfile Policy
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - api/Dockerfile
+      - api/Dockerfile.dev
+      - client/Dockerfile
+      - client/Dockerfile.dev
+      - client/Dockerfile.playwright
+      - droast.toml
+      - .github/workflows/dockerfile-policy.yml
+  push:
+    branches: [main]
+    paths:
+      - api/Dockerfile
+      - api/Dockerfile.dev
+      - client/Dockerfile
+      - client/Dockerfile.dev
+      - client/Dockerfile.playwright
+      - droast.toml
+      - .github/workflows/dockerfile-policy.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Roast platform Dockerfiles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Dockerfile Roast
+        id: install-droast
+        env:
+          DROAST_VERSION: "1.4.7"
+          DROAST_LINUX_X86_64_SHA256: 8051a050c3a4bd94dcea1e5d8cda3a57d37baa53ff394396793ebda9d094f68e
+        run: |
+          set -euo pipefail
+          install_path="$RUNNER_TEMP/droast"
+          curl --fail --location --silent --show-error \
+            "https://github.com/immanuwell/dockerfile-roast/releases/download/${DROAST_VERSION}/droast-linux-x86_64" \
+            --output "$install_path"
+          echo "${DROAST_LINUX_X86_64_SHA256}  ${install_path}" | sha256sum -c -
+          chmod +x "$install_path"
+          echo "bin=$install_path" >> "$GITHUB_OUTPUT"
+
+      - name: Lint platform Dockerfiles
+        run: >-
+          ${{ steps.install-droast.outputs.bin }}
+          --config droast.toml
+          --format github
+          --no-fail
+          api/Dockerfile
+          api/Dockerfile.dev
+          client/Dockerfile
+          client/Dockerfile.dev
+          client/Dockerfile.playwright

--- a/.github/workflows/dockerfile-policy.yml
+++ b/.github/workflows/dockerfile-policy.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Roast platform Dockerfiles

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -32,7 +32,7 @@ RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requireme
 # Stage 2: Runtime
 # =============================================================================
 # python:3.14-slim
-FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS runtime
 
 WORKDIR /app
 
@@ -100,7 +100,7 @@ COPY client/src/lib/app-sdk/provider.tsx \
 COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
 
 # Create non-root user
-RUN useradd -m -u 1000 bifrost && \
+RUN useradd --no-log-init -m -u 1000 bifrost && \
     chown -R bifrost:bifrost /app
 
 # Create directories for workspace and temp

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -33,7 +33,7 @@ RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requireme
 # Stage 2: Runtime
 # =============================================================================
 # python:3.14-slim
-FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS runtime
 
 WORKDIR /app
 
@@ -61,7 +61,7 @@ RUN printf '#!/bin/sh\nexec python -m bifrost "$@"\n' > /usr/local/bin/bifrost \
     && chmod +x /usr/local/bin/bifrost
 
 # Create non-root user
-RUN useradd -m -u 1000 bifrost && \
+RUN useradd --no-log-init -m -u 1000 bifrost && \
     chown -R bifrost:bifrost /app
 
 # Create directories for workspace and temp

--- a/droast.toml
+++ b/droast.toml
@@ -1,0 +1,7 @@
+#:schema https://raw.githubusercontent.com/immanuwell/dockerfile-roast/5fbb9b5638e602796436f82fa683a290cc576c7a/schemas/droast.schema.json
+
+# Ring 0 is advisory: CI supplies --no-fail while findings are classified.
+# Keep the policy unsuppressed so analyzer limitations and accepted risks remain visible.
+preset = "production"
+min-severity = "warning"
+no-roast = true


### PR DESCRIPTION
## Summary

- add an advisory, checksum-verified Dockerfile Roast 1.4.7 policy for the five inherited API/client Dockerfiles
- name both API runtime stages so multi-stage targets remain stable and readable
- create the bifrost user with --no-log-init to avoid sparse lastlog growth

## Findings

The production preset reported 12 warnings on current upstream/main, 8 on this fork before the change, and 4 after the change. The remaining advisory findings are contextual rather than immediate hardening defects:

- DF020: api/Dockerfile.dev starts as root only to repair mounted-volume ownership, then entrypoint.sh execs through gosu as bifrost
- DF061: client/Dockerfile intentionally uses BUILDPLATFORM so the static-asset builder runs natively
- DF007: client/Dockerfile broad COPY remains a valid cache-invalidation optimization signal, with a protected build context
- DF011: client/Dockerfile.dev deliberately keeps the Vite build toolchain in a development-only image

## Verification

- Dockerfile Roast 1.4.7 production preset: 4 contextual warnings, 0 errors
- actionlint .github/workflows/dockerfile-policy.yml
- git diff --check
- signed commit verified locally

The new policy is advisory via --no-fail. Linux image builds remain covered by the existing CI image jobs; this change does not publish or promote images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated Dockerfile policy checks for supported container configurations.
  - Added standardized production policy settings for container validation.

- **Bug Fixes**
  - Improved runtime container consistency by pinning the development image to a verified version.
  - Preserved non-root execution and improved container user setup.
  - Added clearer runtime stage identification for more reliable container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->