### PR TITLE
fix: honor configured storage for Git repository sync

### DIFF
--- a/api/src/services/git_repo_manager.py
+++ b/api/src/services/git_repo_manager.py
@@ -20,7 +20,7 @@ import asyncio
 import hashlib
 import logging
 from contextlib import asynccontextmanager
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Iterable
 from pathlib import Path, PurePosixPath
 
 import redis.asyncio as redis
@@ -172,8 +172,8 @@ class GitRepoManager:
             await asyncio.to_thread(destination.write_bytes, content)
             downloaded_hashes[path] = hashlib.sha256(content).hexdigest()
 
-        await asyncio.gather(
-            *(download(path) for path in paths if not path.endswith("/"))
+        await self._run_transfers(
+            download(path) for path in paths if not path.endswith("/")
         )
         self._downloaded_hashes = downloaded_hashes
         logger.info(
@@ -186,11 +186,12 @@ class GitRepoManager:
 
         storage = RepoStorage(self._settings)
         semaphore = asyncio.Semaphore(OBJECT_STORAGE_CONCURRENCY)
-        local_files = {
-            path.relative_to(source).as_posix(): path
-            for path in source.rglob("*")
-            if path.is_file()
-        }
+        local_files: dict[str, Path] = {}
+        for path in source.rglob("*"):
+            if path.is_symlink():
+                raise ValueError(f"Symlinks are not supported: {path}")
+            if path.is_file():
+                local_files[path.relative_to(source).as_posix()] = path
         remote_paths = set(await storage.list())
 
         async def upload(relative_path: str, path: Path) -> None:
@@ -205,20 +206,30 @@ class GitRepoManager:
             async with semaphore:
                 await storage.delete(relative_path)
 
-        await asyncio.gather(
-            *(
-                upload(relative_path, path)
-                for relative_path, path in local_files.items()
-            )
+        await self._run_transfers(
+            upload(relative_path, path) for relative_path, path in local_files.items()
         )
         removed_paths = remote_paths - local_files.keys()
-        await asyncio.gather(*(delete(path) for path in removed_paths))
+        await self._run_transfers(delete(path) for path in removed_paths)
         logger.info(
             "sync_up: %s -> object storage (%d local files, %d deleted)",
             source,
             len(local_files),
             len(removed_paths),
         )
+
+    @staticmethod
+    async def _run_transfers(transfers: Iterable[Awaitable[None]]) -> None:
+        """Run transfers and drain cancelled siblings before returning an error."""
+        tasks = [asyncio.create_task(transfer) for transfer in transfers]
+        try:
+            await asyncio.gather(*tasks)
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
     @staticmethod
     def _safe_local_path(root: Path, relative_path: str) -> Path:

--- a/api/src/services/git_repo_manager.py
+++ b/api/src/services/git_repo_manager.py
@@ -1,9 +1,9 @@
 """
-Git Repo Manager — S3-backed persistent git working tree.
+Git Repo Manager — object-storage-backed persistent git working tree.
 
 Manages the lifecycle of a persistent local git working directory backed by
-S3 _repo/. Uses `aws s3 sync` for efficient incremental transfer of the
-entire directory tree including .git/ objects.
+the configured object storage provider's _repo/ prefix. S3 uses `aws s3 sync`
+for efficient incremental transfer; other providers use RepoStorage.
 
 The working directory is persistent at PERSISTENT_WORK_DIR and is NOT deleted
 between operations. This allows incremental syncs (only changed files are
@@ -17,10 +17,11 @@ only used for bulk sync operations (git clone/fetch/merge/push).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import redis.asyncio as redis
 
@@ -33,13 +34,15 @@ GIT_LOCK_KEY = "bifrost:git-lock"
 GIT_LOCK_TIMEOUT = 300  # 5 minutes
 
 PERSISTENT_WORK_DIR = Path("/tmp/git")
+OBJECT_STORAGE_CONCURRENCY = 16
 
 
 class GitRepoManager:
-    """Context manager that syncs _repo/ between S3 and a persistent local working dir."""
+    """Sync _repo/ between object storage and a persistent local working dir."""
 
     def __init__(self, settings: Settings | None = None):
         self._settings = settings or get_settings()
+        self._downloaded_hashes: dict[str, str] = {}
 
     @property
     def work_dir(self) -> Path:
@@ -110,11 +113,15 @@ class GitRepoManager:
             return
 
         client = redis.from_url(redis_url)
-        lock = client.lock(GIT_LOCK_KEY, timeout=GIT_LOCK_TIMEOUT, blocking_timeout=GIT_LOCK_TIMEOUT)
+        lock = client.lock(
+            GIT_LOCK_KEY, timeout=GIT_LOCK_TIMEOUT, blocking_timeout=GIT_LOCK_TIMEOUT
+        )
         try:
             acquired = await lock.acquire()
             if not acquired:
-                raise RuntimeError("Failed to acquire git lock — another git operation is in progress")
+                raise RuntimeError(
+                    "Failed to acquire git lock — another git operation is in progress"
+                )
             logger.debug("Acquired git lock")
             yield
         finally:
@@ -126,23 +133,110 @@ class GitRepoManager:
             await client.aclose()
 
     async def sync_down(self, target: Path) -> None:
-        """Sync _repo/ from S3 to a local directory."""
+        """Sync _repo/ from the configured object store to a local directory."""
         target.mkdir(parents=True, exist_ok=True)
+        if self._settings.object_storage_provider == "azure_blob":
+            await self._sync_down_with_repo_storage(target)
+            return
+
         s3_uri = self._s3_uri()
         cmd = self._build_sync_cmd(source=s3_uri, dest=str(target))
         logger.info(f"sync_down: {s3_uri} -> {target}")
         await self._run_aws_cli(cmd)
 
     async def sync_up(self, source: Path) -> None:
-        """Sync a local directory back to S3 _repo/ with --delete."""
+        """Sync a local directory back to _repo/, deleting removed objects."""
+        if self._settings.object_storage_provider == "azure_blob":
+            await self._sync_up_with_repo_storage(source)
+            return
+
         s3_uri = self._s3_uri()
         cmd = self._build_sync_cmd(source=str(source), dest=s3_uri, delete=True)
         logger.info(f"sync_up: {source} -> {s3_uri}")
         await self._run_aws_cli(cmd)
 
+    async def _sync_down_with_repo_storage(self, target: Path) -> None:
+        """Materialize Azure-backed _repo/ through the shared storage adapter."""
+        from src.services.repo_storage import RepoStorage
+
+        storage = RepoStorage(self._settings)
+        paths = await storage.list()
+        semaphore = asyncio.Semaphore(OBJECT_STORAGE_CONCURRENCY)
+        downloaded_hashes: dict[str, str] = {}
+
+        async def download(path: str) -> None:
+            destination = self._safe_local_path(target, path)
+            async with semaphore:
+                content = await storage.read(path)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(destination.write_bytes, content)
+            downloaded_hashes[path] = hashlib.sha256(content).hexdigest()
+
+        await asyncio.gather(
+            *(download(path) for path in paths if not path.endswith("/"))
+        )
+        self._downloaded_hashes = downloaded_hashes
+        logger.info(
+            "sync_down: object storage -> %s (%d files)", target, len(downloaded_hashes)
+        )
+
+    async def _sync_up_with_repo_storage(self, source: Path) -> None:
+        """Persist local changes through RepoStorage with aws-sync semantics."""
+        from src.services.repo_storage import RepoStorage
+
+        storage = RepoStorage(self._settings)
+        semaphore = asyncio.Semaphore(OBJECT_STORAGE_CONCURRENCY)
+        local_files = {
+            path.relative_to(source).as_posix(): path
+            for path in source.rglob("*")
+            if path.is_file()
+        }
+        remote_paths = set(await storage.list())
+
+        async def upload(relative_path: str, path: Path) -> None:
+            content = await asyncio.to_thread(path.read_bytes)
+            content_hash = hashlib.sha256(content).hexdigest()
+            if self._downloaded_hashes.get(relative_path) == content_hash:
+                return
+            async with semaphore:
+                await storage.write(relative_path, content)
+
+        async def delete(relative_path: str) -> None:
+            async with semaphore:
+                await storage.delete(relative_path)
+
+        await asyncio.gather(
+            *(
+                upload(relative_path, path)
+                for relative_path, path in local_files.items()
+            )
+        )
+        removed_paths = remote_paths - local_files.keys()
+        await asyncio.gather(*(delete(path) for path in removed_paths))
+        logger.info(
+            "sync_up: %s -> object storage (%d local files, %d deleted)",
+            source,
+            len(local_files),
+            len(removed_paths),
+        )
+
+    @staticmethod
+    def _safe_local_path(root: Path, relative_path: str) -> Path:
+        """Resolve an object key below root and reject traversal or absolute keys."""
+        posix_path = PurePosixPath(relative_path)
+        if posix_path.is_absolute() or ".." in posix_path.parts:
+            raise ValueError(f"Unsafe repository object path: {relative_path!r}")
+        destination = root.joinpath(*posix_path.parts)
+        if destination.resolve(strict=False) != root.resolve().joinpath(
+            *posix_path.parts
+        ):
+            raise ValueError(f"Unsafe repository object path: {relative_path!r}")
+        return destination
+
     async def has_git_dir(self) -> bool:
         """Check if .git/HEAD exists in S3 _repo/ (quick existence check)."""
         from src.services.repo_storage import RepoStorage
+
         storage = RepoStorage(self._settings)
         return await storage.exists(".git/HEAD")
 
@@ -172,6 +266,7 @@ class GitRepoManager:
     def _build_env(self) -> dict[str, str]:
         """Build environment variables for the aws CLI process."""
         import os
+
         env = {**os.environ}
         if self._settings.s3_access_key:
             env["AWS_ACCESS_KEY_ID"] = self._settings.s3_access_key

--- a/api/tests/unit/services/test_git_repo_manager.py
+++ b/api/tests/unit/services/test_git_repo_manager.py
@@ -1,6 +1,7 @@
-"""Tests for GitRepoManager — S3-backed persistent git working tree."""
+"""Tests for GitRepoManager object-storage-backed persistent git worktree."""
 
 import importlib
+import hashlib
 import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -21,6 +22,7 @@ def mock_settings():
     settings.s3_access_key = "bifrost"
     settings.s3_secret_key = "bifrost123"
     settings.s3_region = "us-east-1"
+    settings.object_storage_provider = "s3"
     settings.redis_url = ""  # Disable Redis lock in unit tests
     return settings
 
@@ -40,10 +42,13 @@ class TestBuildSyncCmd:
             dest="/tmp/work",
         )
         assert cmd == [
-            "aws", "s3", "sync",
+            "aws",
+            "s3",
+            "sync",
             "s3://bifrost-local/_repo/",
             "/tmp/work",
-            "--endpoint-url", "http://seaweedfs:8333",
+            "--endpoint-url",
+            "http://seaweedfs:8333",
             "--only-show-errors",
         ]
 
@@ -54,11 +59,14 @@ class TestBuildSyncCmd:
             delete=True,
         )
         assert cmd == [
-            "aws", "s3", "sync",
+            "aws",
+            "s3",
+            "sync",
             "/tmp/work",
             "s3://bifrost-local/_repo/",
             "--delete",
-            "--endpoint-url", "http://seaweedfs:8333",
+            "--endpoint-url",
+            "http://seaweedfs:8333",
             "--only-show-errors",
         ]
 
@@ -72,7 +80,9 @@ class TestBuildSyncCmd:
         )
         assert "--endpoint-url" not in cmd
         assert cmd == [
-            "aws", "s3", "sync",
+            "aws",
+            "s3",
+            "sync",
             "s3://prod-bucket/_repo/",
             "/tmp/work",
             "--only-show-errors",
@@ -104,14 +114,18 @@ class TestS3Uri:
 class TestPersistentWorkDir:
     """Tests for persistent worktree helpers."""
 
-    def test_work_dir_creates_configured_persistent_path(self, manager, tmp_path, monkeypatch):
+    def test_work_dir_creates_configured_persistent_path(
+        self, manager, tmp_path, monkeypatch
+    ):
         work_dir = tmp_path / "git-work"
         monkeypatch.setattr(git_repo_manager, "PERSISTENT_WORK_DIR", work_dir)
 
         assert manager.work_dir == work_dir
         assert work_dir.is_dir()
 
-    def test_is_initialized_requires_git_directory(self, manager, tmp_path, monkeypatch):
+    def test_is_initialized_requires_git_directory(
+        self, manager, tmp_path, monkeypatch
+    ):
         work_dir = tmp_path / "git-work"
         monkeypatch.setattr(git_repo_manager, "PERSISTENT_WORK_DIR", work_dir)
 
@@ -126,14 +140,22 @@ class TestHasGitDir:
 
     @pytest.mark.asyncio
     async def test_returns_true_when_git_head_exists(self, manager):
-        with patch("src.services.repo_storage.RepoStorage.exists", new_callable=AsyncMock, return_value=True) as mock_exists:
+        with patch(
+            "src.services.repo_storage.RepoStorage.exists",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_exists:
             result = await manager.has_git_dir()
             assert result is True
             mock_exists.assert_awaited_once_with(".git/HEAD")
 
     @pytest.mark.asyncio
     async def test_returns_false_when_no_git_dir(self, manager):
-        with patch("src.services.repo_storage.RepoStorage.exists", new_callable=AsyncMock, return_value=False) as mock_exists:
+        with patch(
+            "src.services.repo_storage.RepoStorage.exists",
+            new_callable=AsyncMock,
+            return_value=False,
+        ) as mock_exists:
             result = await manager.has_git_dir()
             assert result is False
             mock_exists.assert_awaited_once_with(".git/HEAD")
@@ -148,7 +170,9 @@ class TestRunAwsCli:
         mock_process.communicate = AsyncMock(return_value=(b"", b""))
         mock_process.returncode = 0
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_process
+        ) as mock_exec:
             await manager._run_aws_cli(["aws", "s3", "sync", "src", "dst"])
             mock_exec.assert_called_once()
             # Verify env includes AWS credentials
@@ -199,12 +223,14 @@ class TestSyncDown:
     @pytest.mark.asyncio
     async def test_creates_target_dir(self, manager):
         import tempfile
+
         target = Path(tempfile.mkdtemp()) / "subdir"
         with patch.object(manager, "_run_aws_cli", new_callable=AsyncMock):
             await manager.sync_down(target)
             assert target.exists()
         # Cleanup
         import shutil
+
         shutil.rmtree(target.parent)
 
 
@@ -223,6 +249,76 @@ class TestSyncUp:
             assert "--delete" in cmd
 
 
+class TestAzureBlobSync:
+    """Azure Blob uses RepoStorage rather than the AWS CLI."""
+
+    @pytest.fixture
+    def azure_manager(self, mock_settings):
+        mock_settings.object_storage_provider = "azure_blob"
+        return GitRepoManager(settings=mock_settings)
+
+    @pytest.mark.asyncio
+    async def test_sync_down_materializes_repo_objects(self, azure_manager, tmp_path):
+        storage = MagicMock()
+        storage.list = AsyncMock(return_value=[".git/HEAD", "workflows/test.py"])
+        storage.read = AsyncMock(
+            side_effect=lambda path: {
+                ".git/HEAD": b"ref: refs/heads/main\n",
+                "workflows/test.py": b"print('ok')\n",
+            }[path]
+        )
+
+        with (
+            patch("src.services.repo_storage.RepoStorage", return_value=storage),
+            patch.object(azure_manager, "_run_aws_cli", new_callable=AsyncMock) as aws,
+        ):
+            await azure_manager.sync_down(tmp_path)
+
+        assert (tmp_path / ".git" / "HEAD").read_bytes() == b"ref: refs/heads/main\n"
+        assert (tmp_path / "workflows" / "test.py").read_bytes() == b"print('ok')\n"
+        aws.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sync_up_writes_changes_and_deletes_removed_objects(
+        self, azure_manager, tmp_path
+    ):
+        unchanged = tmp_path / ".git" / "HEAD"
+        unchanged.parent.mkdir(parents=True)
+        unchanged.write_bytes(b"main")
+        changed = tmp_path / "workflows" / "test.py"
+        changed.parent.mkdir(parents=True)
+        changed.write_bytes(b"changed")
+        azure_manager._downloaded_hashes = {
+            ".git/HEAD": hashlib.sha256(b"main").hexdigest(),
+            "workflows/test.py": hashlib.sha256(b"old").hexdigest(),
+            "deleted.py": hashlib.sha256(b"deleted").hexdigest(),
+        }
+        storage = MagicMock()
+        storage.list = AsyncMock(
+            return_value=[".git/HEAD", "workflows/test.py", "deleted.py"]
+        )
+        storage.write = AsyncMock()
+        storage.delete = AsyncMock()
+
+        with patch("src.services.repo_storage.RepoStorage", return_value=storage):
+            await azure_manager.sync_up(tmp_path)
+
+        storage.write.assert_awaited_once_with("workflows/test.py", b"changed")
+        storage.delete.assert_awaited_once_with("deleted.py")
+
+    @pytest.mark.asyncio
+    async def test_sync_down_rejects_path_traversal(self, azure_manager, tmp_path):
+        storage = MagicMock()
+        storage.list = AsyncMock(return_value=["../escape"])
+        storage.read = AsyncMock(return_value=b"bad")
+
+        with patch("src.services.repo_storage.RepoStorage", return_value=storage):
+            with pytest.raises(ValueError, match="Unsafe repository object path"):
+                await azure_manager.sync_down(tmp_path)
+
+        storage.read.assert_not_awaited()
+
+
 class TestCheckout:
     """Tests for checkout context manager lifecycle (persistent working dir)."""
 
@@ -236,9 +332,11 @@ class TestCheckout:
         async def mock_sync_up(source):
             call_order.append(("sync_up", source))
 
-        with patch.object(manager, "sync_down", side_effect=mock_sync_down), \
-             patch.object(manager, "sync_up", side_effect=mock_sync_up), \
-             patch.object(manager, "_acquire_lock") as mock_lock:
+        with (
+            patch.object(manager, "sync_down", side_effect=mock_sync_down),
+            patch.object(manager, "sync_up", side_effect=mock_sync_up),
+            patch.object(manager, "_acquire_lock") as mock_lock,
+        ):
             # Mock the lock as an async context manager that does nothing
             mock_lock.return_value.__aenter__ = AsyncMock()
             mock_lock.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -263,9 +361,11 @@ class TestCheckout:
 
     @pytest.mark.asyncio
     async def test_persistent_dir_survives_exception(self, manager):
-        with patch.object(manager, "sync_down", new_callable=AsyncMock), \
-             patch.object(manager, "sync_up", new_callable=AsyncMock), \
-             patch.object(manager, "_acquire_lock") as mock_lock:
+        with (
+            patch.object(manager, "sync_down", new_callable=AsyncMock),
+            patch.object(manager, "sync_up", new_callable=AsyncMock),
+            patch.object(manager, "_acquire_lock") as mock_lock,
+        ):
             mock_lock.return_value.__aenter__ = AsyncMock()
             mock_lock.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -278,12 +378,15 @@ class TestCheckout:
     @pytest.mark.asyncio
     async def test_sync_up_not_called_on_sync_down_failure(self, manager):
         """If sync_down fails, sync_up should not be called."""
-        with patch.object(
-            manager, "sync_down",
-            side_effect=RuntimeError("download failed"),
-        ), \
-             patch.object(manager, "sync_up", new_callable=AsyncMock) as mock_up, \
-             patch.object(manager, "_acquire_lock") as mock_lock:
+        with (
+            patch.object(
+                manager,
+                "sync_down",
+                side_effect=RuntimeError("download failed"),
+            ),
+            patch.object(manager, "sync_up", new_callable=AsyncMock) as mock_up,
+            patch.object(manager, "_acquire_lock") as mock_lock,
+        ):
             mock_lock.return_value.__aenter__ = AsyncMock()
             mock_lock.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -293,7 +396,9 @@ class TestCheckout:
             mock_up.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_readonly_checkout_skips_sync_up(self, manager, tmp_path, monkeypatch):
+    async def test_readonly_checkout_skips_sync_up(
+        self, manager, tmp_path, monkeypatch
+    ):
         work_dir = tmp_path / "git-work"
         monkeypatch.setattr(git_repo_manager, "PERSISTENT_WORK_DIR", work_dir)
 
@@ -312,7 +417,9 @@ class TestCheckout:
         mock_up.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_lock_yields_work_dir_without_s3_sync(self, manager, tmp_path, monkeypatch):
+    async def test_lock_yields_work_dir_without_s3_sync(
+        self, manager, tmp_path, monkeypatch
+    ):
         work_dir = tmp_path / "git-work"
         monkeypatch.setattr(git_repo_manager, "PERSISTENT_WORK_DIR", work_dir)
 

--- a/api/tests/unit/services/test_git_repo_manager.py
+++ b/api/tests/unit/services/test_git_repo_manager.py
@@ -1,6 +1,7 @@
 """Tests for GitRepoManager object-storage-backed persistent git worktree."""
 
 import importlib
+import asyncio
 import hashlib
 import logging
 from pathlib import Path
@@ -317,6 +318,41 @@ class TestAzureBlobSync:
                 await azure_manager.sync_down(tmp_path)
 
         storage.read.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sync_up_rejects_symlinks(self, azure_manager, tmp_path):
+        outside = tmp_path.parent / "outside-secret"
+        outside.write_bytes(b"secret")
+        (tmp_path / "linked-secret").symlink_to(outside)
+        storage = MagicMock()
+        storage.list = AsyncMock(return_value=[])
+        storage.write = AsyncMock()
+
+        with patch("src.services.repo_storage.RepoStorage", return_value=storage):
+            with pytest.raises(ValueError, match="Symlinks are not supported"):
+                await azure_manager.sync_up(tmp_path)
+
+        storage.write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_transfer_cancels_and_drains_siblings(self, azure_manager):
+        sibling_cancelled = asyncio.Event()
+
+        async def fail() -> None:
+            await asyncio.sleep(0)
+            raise RuntimeError("transfer failed")
+
+        async def wait_forever() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+
+        with pytest.raises(RuntimeError, match="transfer failed"):
+            await azure_manager._run_transfers([fail(), wait_forever()])
+
+        assert sibling_cancelled.is_set()
 
 
 class TestCheckout:


### PR DESCRIPTION
## Summary
- keep the existing AWS CLI fast path for S3-backed deployments
- sync Azure Blob-backed repository workspaces through the existing RepoStorage boundary
- preserve incremental uploads, remote deletion semantics, bounded concurrency, and reject unsafe object paths

## Why
The dev deployment is configured for Azure Blob, but GitRepoManager unconditionally invoked aws s3 sync against a stale S3 bucket setting. This caused every server-side Git fetch to fail before GitHub was contacted.

## Verification
- ruff check on changed files
- python bytecode compilation on changed files
- git diff --check
- focused unit coverage for Azure download, changed-only upload, deletion, S3 preservation, and traversal rejection
- full platform verification delegated to GitHub Actions per the repo's Linux-only test policy

## Scope
No deployment or live-state mutation is included. Production is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for synchronizing Git repositories with Azure Blob Storage.
  - Repository files now sync concurrently for improved performance.

- **Bug Fixes**
  - Avoided unnecessary uploads when repository content is unchanged.
  - Removed stale remote files during synchronization.
  - Strengthened protections against unsafe repository paths.

- **Compatibility**
  - Existing synchronization through Amazon S3 remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->