### PR TITLE
fix(mcp): enforce private agent ownership

### DIFF
--- a/api/src/services/mcp_server/tools/agents.py
+++ b/api/src/services/mcp_server/tools/agents.py
@@ -58,6 +58,73 @@ def _reference_in_agent_scope(reference_org_id: Any, agent_org_id: UUID | None) 
     return reference_org_id is None or reference_org_id == agent_org_id
 
 
+def _agent_repository(context: Any, db: Any) -> Any:
+    """Build the canonical access-aware repository for an MCP caller."""
+    from src.repositories.agents import AgentRepository
+
+    org_id = UUID(str(context.org_id)) if context.org_id else None
+    user_id = UUID(str(context.user_id)) if context.user_id else None
+    return AgentRepository(
+        session=db,
+        org_id=org_id,
+        user_id=user_id,
+        is_superuser=bool(context.is_platform_admin),
+        is_external=bool(getattr(context, "is_external", False)),
+    )
+
+
+async def _load_accessible_agent(
+    context: Any,
+    db: Any,
+    *,
+    agent_id: UUID | None = None,
+    agent_name: str | None = None,
+) -> Any | None:
+    """Load one agent through the same access policy as REST and execution."""
+    from src.core.org_filter import OrgFilterType
+
+    repo = _agent_repository(context, db)
+    if agent_id is not None:
+        return await repo.get_agent_with_access_check(agent_id)
+
+    if context.is_platform_admin:
+        candidates = await repo.list_all_in_scope(
+            OrgFilterType.ALL,
+            active_only=False,
+        )
+    else:
+        candidates = await repo.list_agents(active_only=False)
+
+    matches = [agent for agent in candidates if agent.name == agent_name]
+    if not matches:
+        return None
+
+    context_org_id = UUID(str(context.org_id)) if context.org_id else None
+    matches.sort(
+        key=lambda agent: (
+            agent.organization_id == context_org_id,
+            agent.organization_id is None,
+        ),
+        reverse=True,
+    )
+    return matches[0]
+
+
+def _can_manage_agent(context: Any, agent: Any) -> bool:
+    """Regular MCP callers may mutate only private agents they own."""
+    if context.is_platform_admin:
+        return True
+
+    from src.models.enums import AgentAccessLevel
+
+    return (
+        agent.access_level == AgentAccessLevel.PRIVATE
+        and agent.owner_user_id is not None
+        and context.user_id is not None
+        and str(agent.owner_user_id) == str(context.user_id)
+    )
+
+
 # ==================== SCHEMA TOOL ====================
 
 
@@ -178,12 +245,6 @@ async def get_agent(
     Returns:
         ToolResult with agent details
     """
-    from sqlalchemy import select
-    from sqlalchemy.orm import selectinload
-
-    from src.models.orm import Agent
-    from src.services.mcp_server.tools._org_scope import apply_mcp_org_scope
-
     logger.info(f"MCP get_agent called: agent_id={agent_id}, agent_name={agent_name}")
 
     if not agent_id and not agent_name:
@@ -191,34 +252,22 @@ async def get_agent(
 
     try:
         async with get_tool_db(context) as db:
-            # Build query
-            query = select(Agent).options(
-                selectinload(Agent.tools),
-                selectinload(Agent.delegated_agents),
-                selectinload(Agent.roles),
-            )
-
             if agent_id:
-                # ID-based lookup: IDs are unique, so cascade filter is safe
                 try:
                     uuid_id = UUID(agent_id)
                 except ValueError:
                     return error_result(f"'{agent_id}' is not a valid UUID")
-                query = query.where(Agent.id == uuid_id)
-                # Apply org scoping for non-admins (cascade filter for ID lookups)
-                query = apply_mcp_org_scope(query, Agent, context)
+                agent = await _load_accessible_agent(
+                    context,
+                    db,
+                    agent_id=uuid_id,
+                )
             else:
-                # Name-based lookup: use prioritized lookup (org-specific > global)
-                query = query.where(Agent.name == agent_name)
-                query = apply_mcp_org_scope(query, Agent, context)
-                if not context.is_platform_admin and context.org_id:
-                    # Prioritize org-specific over global (nulls come last)
-                    query = query.order_by(
-                        Agent.organization_id.desc().nulls_last()
-                    ).limit(1)
-
-            result = await db.execute(query)
-            agent = result.scalar_one_or_none()
+                agent = await _load_accessible_agent(
+                    context,
+                    db,
+                    agent_name=agent_name,
+                )
 
             if not agent:
                 identifier = agent_id or agent_name
@@ -536,16 +585,11 @@ async def update_agent(
     try:
         async with get_tool_db(context) as db:
             # Get existing agent
-            result = await db.execute(
-                select(Agent)
-                .options(
-                    selectinload(Agent.tools),
-                    selectinload(Agent.delegated_agents),
-                    selectinload(Agent.roles),
-                )
-                .where(Agent.id == uuid_id)
+            agent = await _load_accessible_agent(
+                context,
+                db,
+                agent_id=uuid_id,
             )
-            agent = result.scalar_one_or_none()
 
             if not agent:
                 return error_result(f"Agent '{agent_id}' not found. Use list_agents to see available agents.")
@@ -562,6 +606,9 @@ async def update_agent(
 
             if is_solution_managed(agent):
                 return error_result(SOLUTION_MANAGED_MESSAGE)
+
+            if not _can_manage_agent(context, agent):
+                return error_result("You can only update your own private agents.")
 
             # Check access for non-admins
             if not context.is_platform_admin:
@@ -723,10 +770,6 @@ async def delete_agent(
     Returns:
         ToolResult with deletion confirmation
     """
-    from sqlalchemy import select
-
-    from src.models.orm import Agent
-
     logger.info(f"MCP delete_agent called: agent_id={agent_id}")
 
     if not agent_id:
@@ -740,10 +783,11 @@ async def delete_agent(
 
     try:
         async with get_tool_db(context) as db:
-            result = await db.execute(
-                select(Agent).where(Agent.id == uuid_id)
+            agent = await _load_accessible_agent(
+                context,
+                db,
+                agent_id=uuid_id,
             )
-            agent = result.scalar_one_or_none()
 
             if not agent:
                 return error_result(f"Agent '{agent_id}' not found. Use list_agents to see available agents.")
@@ -759,14 +803,8 @@ async def delete_agent(
             if is_solution_managed(agent):
                 return error_result(SOLUTION_MANAGED_MESSAGE)
 
-            # Check access for non-admins
-            if not context.is_platform_admin:
-                if agent.organization_id:
-                    if context.org_id and str(agent.organization_id) != str(context.org_id):
-                        return error_result("You don't have permission to delete this agent.")
-                # Global agents can only be deleted by admins
-                if agent.organization_id is None:
-                    return error_result("Only platform admins can delete global agents.")
+            if not _can_manage_agent(context, agent):
+                return error_result("You can only delete your own private agents.")
 
             # Soft delete
             agent.is_active = False

--- a/api/src/services/mcp_server/tools/agents.py
+++ b/api/src/services/mcp_server/tools/agents.py
@@ -610,15 +610,6 @@ async def update_agent(
             if not _can_manage_agent(context, agent):
                 return error_result("You can only update your own private agents.")
 
-            # Check access for non-admins
-            if not context.is_platform_admin:
-                if agent.organization_id:
-                    if context.org_id and str(agent.organization_id) != str(context.org_id):
-                        return error_result("You don't have permission to update this agent.")
-                # Global agents can only be updated by admins
-                if agent.organization_id is None:
-                    return error_result("Only platform admins can update global agents.")
-
             updates_made = []
 
             # Apply updates

--- a/api/tests/e2e/mcp/test_mcp_scoped_lookups.py
+++ b/api/tests/e2e/mcp/test_mcp_scoped_lookups.py
@@ -101,7 +101,7 @@ async def global_agent(db_session: AsyncSession) -> AsyncGenerator[Agent, None]:
         description="A global agent accessible to all orgs",
         system_prompt="You are a helpful assistant",
         channels=["chat"],
-        access_level=AgentAccessLevel.ROLE_BASED,
+        access_level=AgentAccessLevel.AUTHENTICATED,
         organization_id=None,  # Global
         is_active=True,
         knowledge_sources=[],
@@ -132,7 +132,7 @@ async def org_agent(
         description="An org-specific agent",
         system_prompt="You are an org-specific assistant",
         channels=["chat"],
-        access_level=AgentAccessLevel.ROLE_BASED,
+        access_level=AgentAccessLevel.AUTHENTICATED,
         organization_id=test_org_id,  # Org-scoped
         is_active=True,
 
@@ -162,7 +162,7 @@ async def global_only_agent(db_session: AsyncSession) -> AsyncGenerator[Agent, N
         description="A global agent with unique name",
         system_prompt="You are a unique global assistant",
         channels=["chat"],
-        access_level=AgentAccessLevel.ROLE_BASED,
+        access_level=AgentAccessLevel.AUTHENTICATED,
         organization_id=None,  # Global
         is_active=True,
         knowledge_sources=[],

--- a/api/tests/unit/services/mcp_server/test_agent_tools_coverage.py
+++ b/api/tests/unit/services/mcp_server/test_agent_tools_coverage.py
@@ -586,6 +586,32 @@ class TestUpdateAgentTool:
         db.flush.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_update_agent_allows_private_owner(self):
+        context = _context(admin=False)
+        agent = _agent_detail(
+            access_level=AgentAccessLevel.PRIVATE,
+            owner_user_id=context.user_id,
+            organization_id=context.org_id,
+        )
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_Result(agent))
+
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=agent)),
+            patch("src.services.solutions.guard.is_solution_managed", return_value=False),
+        ):
+            result = await agents.update_agent(
+                context,
+                agent_id=str(agent.id),
+                name="Owned private agent",
+            )
+
+        assert result.structured_content["success"] is True
+        assert result.structured_content["updates"] == ["name"]
+        db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_update_agent_rejects_solution_managed_and_missing_updates(self):
         org_id = uuid4()
         agent_id = uuid4()

--- a/api/tests/unit/services/mcp_server/test_agent_tools_coverage.py
+++ b/api/tests/unit/services/mcp_server/test_agent_tools_coverage.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from src.models.enums import AgentAccessLevel
 from src.services.mcp_server.tools import agents
 
 
@@ -52,6 +53,7 @@ def _agent_detail(**overrides):
         system_prompt="Route work carefully",
         channels=["chat", "teams"],
         access_level=SimpleNamespace(value="role_based"),
+        owner_user_id=None,
         organization_id=uuid4(),
         is_active=True,
         created_by="creator@example.com",
@@ -123,6 +125,38 @@ class TestAgentToolHelpers:
         assert agents._reference_in_agent_scope(None, org_id)
         assert agents._reference_in_agent_scope(org_id, org_id)
         assert not agents._reference_in_agent_scope(uuid4(), org_id)
+
+    def test_regular_user_can_manage_only_owned_private_agents(self):
+        user_id = uuid4()
+        context = _context(user_id=user_id)
+
+        assert agents._can_manage_agent(
+            context,
+            _agent_detail(access_level=AgentAccessLevel.PRIVATE, owner_user_id=user_id),
+        )
+        assert not agents._can_manage_agent(
+            context,
+            _agent_detail(access_level=AgentAccessLevel.PRIVATE, owner_user_id=uuid4()),
+        )
+        assert not agents._can_manage_agent(
+            context,
+            _agent_detail(access_level=AgentAccessLevel.AUTHENTICATED),
+        )
+
+    @pytest.mark.asyncio
+    async def test_agent_loader_uses_access_checked_repository(self):
+        agent_id = uuid4()
+        expected = _agent_detail(id=agent_id)
+        repo = MagicMock()
+        repo.get_agent_with_access_check = AsyncMock(return_value=expected)
+
+        with patch.object(agents, "_agent_repository", return_value=repo):
+            actual = await agents._load_accessible_agent(
+                _context(), AsyncMock(), agent_id=agent_id
+            )
+
+        assert actual is expected
+        repo.get_agent_with_access_check.assert_awaited_once_with(agent_id)
 
     @pytest.mark.asyncio
     async def test_schema_tool_returns_agent_documentation(self):
@@ -206,9 +240,11 @@ class TestGetAgentTool:
     async def test_get_agent_by_id_shapes_full_agent_details(self):
         agent = _agent_detail()
         db = AsyncMock()
-        db.execute = AsyncMock(return_value=_Result(agent))
 
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=agent)),
+        ):
             result = await agents.get_agent(_context(), agent_id=str(agent.id))
 
         content = result.structured_content
@@ -222,7 +258,6 @@ class TestGetAgentTool:
         assert content["knowledge_sources"] == ["kb"]
         assert content["system_tools"] == ["list_agents"]
         assert content["llm_max_tokens"] == 2048
-        db.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_get_agent_by_name_returns_prioritized_lookup_result(self):
@@ -238,9 +273,11 @@ class TestGetAgentTool:
             system_tools=None,
         )
         db = AsyncMock()
-        db.execute = AsyncMock(return_value=_Result(agent))
 
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=agent)),
+        ):
             result = await agents.get_agent(_context(admin=False), agent_name="Dispatcher")
 
         assert result.structured_content["access_level"] == "role_based"
@@ -259,13 +296,21 @@ class TestGetAgentTool:
             result = await agents.get_agent(_context(), agent_id="bad")
         assert "not a valid UUID" in result.structured_content["error"]
 
-        db.execute = AsyncMock(return_value=_Result(None))
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=None)),
+        ):
             result = await agents.get_agent(_context(), agent_id=str(uuid4()))
         assert "not found" in result.structured_content["error"]
 
-        db.execute = AsyncMock(side_effect=RuntimeError("query failed"))
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(
+                agents,
+                "_load_accessible_agent",
+                AsyncMock(side_effect=RuntimeError("query failed")),
+            ),
+        ):
             result = await agents.get_agent(_context(), agent_id=str(uuid4()))
         assert "Error getting agent" in result.structured_content["error"]
         assert "query failed" in result.structured_content["error"]
@@ -545,10 +590,11 @@ class TestUpdateAgentTool:
         org_id = uuid4()
         agent_id = uuid4()
         db = AsyncMock()
-        db.execute = AsyncMock(return_value=_Result(_agent_detail(id=agent_id, organization_id=org_id)))
+        existing = _agent_detail(id=agent_id, organization_id=org_id)
 
         with (
             patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=existing)),
             patch("src.services.solutions.guard.is_solution_managed", return_value=True),
             patch("src.services.solutions.guard.SOLUTION_MANAGED_MESSAGE", "locked"),
         ):
@@ -560,13 +606,13 @@ class TestUpdateAgentTool:
         assert result.structured_content["error"] == "locked"
         db.flush.assert_not_called()
 
-        db.execute = AsyncMock(return_value=_Result(_agent_detail(id=agent_id, organization_id=org_id)))
         with (
             patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=existing)),
             patch("src.services.solutions.guard.is_solution_managed", return_value=False),
         ):
             result = await agents.update_agent(
-                _context(admin=False, org_id=org_id),
+                _context(admin=True, org_id=org_id),
                 agent_id=str(agent_id),
             )
         assert "No updates provided" in result.structured_content["error"]
@@ -576,9 +622,11 @@ class TestUpdateAgentTool:
         org_id = uuid4()
         agent_id = uuid4()
         db = AsyncMock()
-        db.execute = AsyncMock(return_value=_Result(None))
 
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=None)),
+        ):
             result = await agents.update_agent(
                 _context(admin=True, org_id=None),
                 agent_id=str(agent_id),
@@ -586,9 +634,10 @@ class TestUpdateAgentTool:
             )
         assert "not found" in result.structured_content["error"]
 
-        db.execute = AsyncMock(return_value=_Result(_agent_detail(id=agent_id, organization_id=uuid4())))
+        inaccessible = _agent_detail(id=agent_id, organization_id=uuid4())
         with (
             patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=inaccessible)),
             patch("src.services.solutions.guard.is_solution_managed", return_value=False),
         ):
             result = await agents.update_agent(
@@ -596,10 +645,16 @@ class TestUpdateAgentTool:
                 agent_id=str(agent_id),
                 name="Wrong Org",
             )
-        assert "permission" in result.structured_content["error"]
+        assert "own private agents" in result.structured_content["error"]
 
-        db.execute = AsyncMock(side_effect=RuntimeError("update query failed"))
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(
+                agents,
+                "_load_accessible_agent",
+                AsyncMock(side_effect=RuntimeError("update query failed")),
+            ),
+        ):
             result = await agents.update_agent(
                 _context(admin=True, org_id=None),
                 agent_id=str(agent_id),
@@ -613,16 +668,21 @@ class TestDeleteAgentTool:
     @pytest.mark.asyncio
     async def test_delete_agent_soft_deletes_and_shapes_response(self):
         org_id = uuid4()
-        agent = _agent_detail(organization_id=org_id)
+        context = _context(admin=False, org_id=org_id)
+        agent = _agent_detail(
+            organization_id=org_id,
+            access_level=AgentAccessLevel.PRIVATE,
+            owner_user_id=context.user_id,
+        )
         db = AsyncMock()
-        db.execute = AsyncMock(return_value=_Result(agent))
 
         with (
             patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=agent)),
             patch("src.services.solutions.guard.is_solution_managed", return_value=False),
         ):
             result = await agents.delete_agent(
-                _context(admin=False, org_id=org_id),
+                context,
                 agent_id=str(agent.id),
             )
 
@@ -636,32 +696,41 @@ class TestDeleteAgentTool:
     async def test_delete_agent_reports_not_found_locked_access_and_db_errors(self):
         agent_id = uuid4()
         db = AsyncMock()
-        db.execute = AsyncMock(return_value=_Result(None))
 
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=None)),
+        ):
             result = await agents.delete_agent(_context(admin=True, org_id=None), str(agent_id))
         assert "not found" in result.structured_content["error"]
 
         locked_agent = _agent_detail(id=agent_id)
-        db.execute = AsyncMock(return_value=_Result(locked_agent))
         with (
             patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=locked_agent)),
             patch("src.services.solutions.guard.is_solution_managed", return_value=True),
             patch("src.services.solutions.guard.SOLUTION_MANAGED_MESSAGE", "locked"),
         ):
             result = await agents.delete_agent(_context(admin=True, org_id=None), str(agent_id))
         assert result.structured_content["error"] == "locked"
 
-        db.execute = AsyncMock(return_value=_Result(_agent_detail(id=agent_id, organization_id=None)))
+        global_agent = _agent_detail(id=agent_id, organization_id=None)
         with (
             patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(agents, "_load_accessible_agent", AsyncMock(return_value=global_agent)),
             patch("src.services.solutions.guard.is_solution_managed", return_value=False),
         ):
             result = await agents.delete_agent(_context(admin=False), str(agent_id))
-        assert "Only platform admins" in result.structured_content["error"]
+        assert "own private agents" in result.structured_content["error"]
 
-        db.execute = AsyncMock(side_effect=RuntimeError("delete query failed"))
-        with patch.object(agents, "get_tool_db", _fake_tool_db(db)):
+        with (
+            patch.object(agents, "get_tool_db", _fake_tool_db(db)),
+            patch.object(
+                agents,
+                "_load_accessible_agent",
+                AsyncMock(side_effect=RuntimeError("delete query failed")),
+            ),
+        ):
             result = await agents.delete_agent(_context(admin=True, org_id=None), str(agent_id))
         assert "Error deleting agent" in result.structured_content["error"]
         assert "delete query failed" in result.structured_content["error"]


### PR DESCRIPTION
## Summary
- route MCP get/update/delete agent lookups through AgentRepository access checks
- prevent non-admin MCP callers from mutating shared agents or private agents they do not own
- preserve platform-admin access and deterministic org-over-global name resolution
- add focused regression coverage for the access-checked loader and private-owner mutation gate

## Verification
- 47 focused MCP/repository authorization tests pass
- Ruff checks pass on both changed files
- git diff --check passes

Sensitive path: MCP object-level authorization.

Resolves Codex Cloud Security finding 33c1388b4c108191ac4c1c8e7b48c0de.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent access checks across viewing, updating, and deleting agents.
  * Regular users can now modify or remove only private agents they own.
  * Unified access handling for agent lookup by ID or name.
  * Improved permission and not-found error behavior.

* **Tests**
  * Expanded coverage for ownership, access levels, cross-scope access, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->