### PR TITLE
test: honor SDK contract source fallback

### DIFF
--- a/api/tests/unit/test_sdk_package_fingerprint.py
+++ b/api/tests/unit/test_sdk_package_fingerprint.py
@@ -56,16 +56,20 @@ def test_sdk_contract_version_matches_json_file():
     from src.services import sdk_package as sdkpkg
 
     contract_path = next(
-        path
-        for path in (
-            sdkpkg._SDK_SRC / sdkpkg._SDK_CONTRACT_FILENAME,
-            *(
-                candidate / sdkpkg._SDK_CONTRACT_FILENAME
-                for candidate in sdkpkg._client_sdk_candidates()
-            ),
-        )
-        if path.is_file()
+        (
+            path
+            for path in (
+                sdkpkg._SDK_SRC / sdkpkg._SDK_CONTRACT_FILENAME,
+                *(
+                    candidate / sdkpkg._SDK_CONTRACT_FILENAME
+                    for candidate in sdkpkg._client_sdk_candidates()
+                ),
+            )
+            if path.is_file()
+        ),
+        None,
     )
+    assert contract_path is not None, "sdk-contract.json is missing from all supported sources"
     contract = _json.loads(contract_path.read_text())
     assert sdkpkg.sdk_contract_version() == contract["version"]
 

--- a/api/tests/unit/test_sdk_package_fingerprint.py
+++ b/api/tests/unit/test_sdk_package_fingerprint.py
@@ -55,7 +55,18 @@ def test_sdk_contract_version_matches_json_file():
 
     from src.services import sdk_package as sdkpkg
 
-    contract = _json.loads((sdkpkg._SDK_SRC / "sdk-contract.json").read_text())
+    contract_path = next(
+        path
+        for path in (
+            sdkpkg._SDK_SRC / sdkpkg._SDK_CONTRACT_FILENAME,
+            *(
+                candidate / sdkpkg._SDK_CONTRACT_FILENAME
+                for candidate in sdkpkg._client_sdk_candidates()
+            ),
+        )
+        if path.is_file()
+    )
+    contract = _json.loads(contract_path.read_text())
     assert sdkpkg.sdk_contract_version() == contract["version"]
 
 


### PR DESCRIPTION
## Summary
- make the SDK contract-version test follow the runtime's baked-source/client-source fallback
- fix the main-only failure seen when CI pulls the published API test image

## Evidence
- main CI failure: `test_sdk_contract_version_matches_json_file` read `/app/src/services/sdk_package/sdk_src/sdk-contract.json` directly
- `sdk_contract_version()` itself passed in the same image by resolving the supported client-source fallback
- local Ruff, AST parse, diff check, and MTG CI boundary check pass

## Scope
Test-only. No runtime, image, deployment, README, badge, or fork CI-boundary behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of the SDK contract version across supported source locations.
  * Added checks to ensure a valid contract file is found before comparing its version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->