### PR TITLE
fix(security): constrain delegated and MCP privileges

### DIFF
--- a/api/bifrost/_context.py
+++ b/api/bifrost/_context.py
@@ -150,8 +150,7 @@ def resolve_scope(scope: str | None) -> str | None:
     if ctx is None:
         return scope  # CLI mode — user authenticates with their own JWT
     is_platform_admin = bool(getattr(ctx, "is_platform_admin", False))
-    is_provider_org = bool(ctx.organization and ctx.organization.is_provider)
-    if is_platform_admin or is_provider_org:
+    if is_platform_admin or ctx.is_provider_org:
         return scope
     raise PermissionError(
         f"Scope override to '{scope}' denied. "

--- a/api/bifrost/_execution_context.py
+++ b/api/bifrost/_execution_context.py
@@ -105,6 +105,10 @@ class ExecutionContext:
 
     # ==================== EXECUTION ====================
     execution_id: str
+    # Trusted original-caller attributes carried across queued/delegated calls.
+    # They are distinct from the target execution organization.
+    is_provider_org: bool = False
+    is_external: bool = False
     workflow_name: str = field(default="")  # Name of the executing workflow
     is_agent: bool = False  # True when triggered by an autonomous agent
     # The install this execution belongs to, when the workflow is solution-managed.
@@ -171,7 +175,7 @@ class ExecutionContext:
 
         C2 rule (matches ``resolve_scope`` and ``_resolve_sdk_org_id``):
         platform admins (``is_platform_admin``) AND provider-org members
-        (``organization.is_provider``) can both override to another org.
+        (``is_provider_org``) can both override to another org.
         Pass None to reset to the original scope.
         """
         if org_id is None:
@@ -181,8 +185,7 @@ class ExecutionContext:
         if org_id == original_org_id:
             self._scope_override = None
             return
-        is_provider_org = bool(self.organization and self.organization.is_provider)
-        if not (self.is_platform_admin or is_provider_org):
+        if not (self.is_platform_admin or self.is_provider_org):
             raise PermissionError(
                 f"Scope override to '{org_id}' denied. "
                 "Platform admins or provider-org members only."
@@ -234,6 +237,8 @@ class ExecutionContext:
             } if self.organization else None,
             "is_platform_admin": self.is_platform_admin,
             "is_function_key": self.is_function_key,
+            "is_provider_org": self.is_provider_org,
+            "is_external": self.is_external,
             "execution_id": self.execution_id,
             "workflow_name": self.workflow_name,
             "is_agent": self.is_agent,

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -1643,6 +1643,8 @@ def _run_direct(
                 is_platform_admin=user_info.get("is_superuser", False),
                 is_function_key=False,
                 execution_id=f"standalone-{uuid.uuid4()}",
+                is_provider_org=user_info.get("is_provider_org", False),
+                is_external=user_info.get("is_external", False),
                 workflow_name=selected_workflow,
                 solution_id=solution_id,
             )

--- a/api/bifrost/commands/files.py
+++ b/api/bifrost/commands/files.py
@@ -224,7 +224,7 @@ async def write_cmd(
     if content_flag is not None:
         content = content_flag
     elif from_file is not None:
-        content = Path(from_file).read_text()
+        content = Path(from_file).read_text(encoding="utf-8")
     elif source == "-":
         content = sys.stdin.read()
     else:

--- a/api/bifrost/solution_dev/function_host.py
+++ b/api/bifrost/solution_dev/function_host.py
@@ -199,6 +199,8 @@ def set_dev_execution_context(
         is_platform_admin=user.get("is_superuser", False),
         is_function_key=False,
         execution_id=f"solution-start-{_uuid.uuid4()}",
+        is_provider_org=user.get("is_provider_org", False),
+        is_external=user.get("is_external", False),
         workflow_name="solution-start",
         solution_id=solution_id,
     )

--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -173,6 +173,18 @@ async def get_current_user_optional(
     # else: superuser with no org = system account (valid)
     # else: embed token without org = valid (HMAC-verified)
 
+    delegated_user_id: UUID | None = None
+    delegated_user_id_str = payload.get("delegated_user_id")
+    if delegated_user_id_str:
+        try:
+            delegated_user_id = UUID(delegated_user_id_str)
+        except ValueError:
+            logger.warning(
+                f"Token for user {user_id} has invalid delegated_user_id format: "
+                f"{delegated_user_id_str}"
+            )
+            return None
+
     return UserPrincipal(
         user_id=user_id,
         email=payload.get("email", ""),
@@ -189,6 +201,13 @@ async def get_current_user_optional(
         app_id=payload.get("app_id"),
         form_id=payload.get("form_id"),
         verified_params=payload.get("verified_params"),
+        delegated_user_id=delegated_user_id,
+        delegated_email=payload.get("delegated_email", ""),
+        delegated_name=payload.get("delegated_name", ""),
+        delegated_is_superuser=payload.get("delegated_is_superuser", False),
+        delegated_is_provider_org=payload.get(
+            "delegated_is_provider_org", False
+        ),
     )
 
 

--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -201,6 +201,7 @@ async def get_current_user_optional(
         app_id=payload.get("app_id"),
         form_id=payload.get("form_id"),
         verified_params=payload.get("verified_params"),
+        is_engine_token=payload.get("engine", False) is True,
         delegated_user_id=delegated_user_id,
         delegated_email=payload.get("delegated_email", ""),
         delegated_name=payload.get("delegated_name", ""),

--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -27,6 +27,22 @@ logger = logging.getLogger(__name__)
 bearer_scheme = HTTPBearer(auto_error=False)
 
 
+def _parse_delegated_user_id(payload: dict, token_user_id: UUID) -> tuple[UUID | None, bool]:
+    """Parse the optional delegated caller claim and report validity."""
+    value = payload.get("delegated_user_id")
+    if not value:
+        return None, True
+    try:
+        return UUID(value), True
+    except ValueError:
+        logger.warning(
+            "Token for user %s has invalid delegated_user_id format: %s",
+            token_user_id,
+            value,
+        )
+        return None, False
+
+
 @dataclass
 class ExecutionContext:
     """
@@ -173,17 +189,12 @@ async def get_current_user_optional(
     # else: superuser with no org = system account (valid)
     # else: embed token without org = valid (HMAC-verified)
 
-    delegated_user_id: UUID | None = None
-    delegated_user_id_str = payload.get("delegated_user_id")
-    if delegated_user_id_str:
-        try:
-            delegated_user_id = UUID(delegated_user_id_str)
-        except ValueError:
-            logger.warning(
-                f"Token for user {user_id} has invalid delegated_user_id format: "
-                f"{delegated_user_id_str}"
-            )
-            return None
+    delegated_user_id, delegated_user_id_valid = _parse_delegated_user_id(
+        payload,
+        user_id,
+    )
+    if not delegated_user_id_valid:
+        return None
 
     return UserPrincipal(
         user_id=user_id,

--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -220,6 +220,7 @@ async def get_current_user_optional(
         delegated_is_provider_org=payload.get(
             "delegated_is_provider_org", False
         ),
+        delegated_is_external=payload.get("delegated_is_external", False),
     )
 
 

--- a/api/src/core/principal.py
+++ b/api/src/core/principal.py
@@ -73,6 +73,7 @@ class UserPrincipal:
     delegated_name: str = ""
     delegated_is_superuser: bool = False
     delegated_is_provider_org: bool = False
+    delegated_is_external: bool = False
 
     @property
     def is_platform_admin(self) -> bool:

--- a/api/src/core/principal.py
+++ b/api/src/core/principal.py
@@ -61,6 +61,14 @@ class UserPrincipal:
     app_id: str | None = None  # App ID for embed tokens
     form_id: str | None = None  # Form ID for form embed tokens
     verified_params: dict[str, str] | None = None  # HMAC-verified query params
+    # Original caller identity carried only by the internal workflow-engine
+    # token. The token retains transport authority, while delegated execution
+    # authorization and audit identity use these claims instead of the engine.
+    delegated_user_id: UUID | None = None
+    delegated_email: str = ""
+    delegated_name: str = ""
+    delegated_is_superuser: bool = False
+    delegated_is_provider_org: bool = False
 
     @property
     def is_platform_admin(self) -> bool:

--- a/api/src/core/principal.py
+++ b/api/src/core/principal.py
@@ -61,6 +61,10 @@ class UserPrincipal:
     app_id: str | None = None  # App ID for embed tokens
     form_id: str | None = None  # Form ID for form embed tokens
     verified_params: dict[str, str] | None = None  # HMAC-verified query params
+    # Explicit marker for the internal workflow-engine transport token. The
+    # engine and embed sessions intentionally share SYSTEM_USER_ID, so the
+    # subject alone cannot identify an engine delegation safely.
+    is_engine_token: bool = False
     # Original caller identity carried only by the internal workflow-engine
     # token. The token retains transport authority, while delegated execution
     # authorization and audit identity use these claims instead of the engine.

--- a/api/src/core/redis_client.py
+++ b/api/src/core/redis_client.py
@@ -66,6 +66,8 @@ class PendingExecution(TypedDict):
     startup: dict[str, Any] | None  # Launch workflow results (available via context.startup)
     sync: bool  # If True, worker pushes result to Redis for sync execution
     is_platform_admin: bool  # Whether the caller is a platform admin
+    is_provider_org: bool  # Trusted caller provider-org membership
+    is_external: bool  # Trusted caller external-access restriction
     event: dict[str, Any] | None  # EventContext fields if event-triggered; None otherwise
     created_at: str  # ISO format
     cancelled: bool
@@ -113,6 +115,8 @@ class RedisClient:
         api_key_id: str | None = None,
         sync: bool = False,
         is_platform_admin: bool = False,
+        is_provider_org: bool = False,
+        is_external: bool = False,
         event: dict[str, Any] | None = None,
         solution_deployment_id: str | None = None,
         runtime_evidence: dict[str, Any] | None = None,
@@ -158,6 +162,8 @@ class RedisClient:
             "startup": startup,
             "sync": sync,
             "is_platform_admin": is_platform_admin,
+            "is_provider_org": is_provider_org,
+            "is_external": is_external,
             "event": event,
             "created_at": datetime.now(timezone.utc).isoformat(),
             "cancelled": False,

--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -407,7 +407,15 @@ def validate_csrf_token(cookie_token: str, header_token: str) -> bool:
     return secrets.compare_digest(cookie_token, header_token)
 
 
-def mint_engine_token(*, organization_id: str | None = None) -> tuple[str, str]:
+def mint_engine_token(
+    *,
+    organization_id: str | None = None,
+    delegated_user_id: str | None = None,
+    delegated_email: str = "",
+    delegated_name: str = "",
+    delegated_is_superuser: bool = False,
+    delegated_is_provider_org: bool = False,
+) -> tuple[str, str]:
     """
     Mint a long-lived engine token (30 days) parent-side.
 
@@ -428,6 +436,16 @@ def mint_engine_token(*, organization_id: str | None = None) -> tuple[str, str]:
     }
     if organization_id is not None:
         token_data["org_id"] = str(organization_id)
+    if delegated_user_id is not None:
+        token_data.update(
+            {
+                "delegated_user_id": str(delegated_user_id),
+                "delegated_email": delegated_email,
+                "delegated_name": delegated_name,
+                "delegated_is_superuser": delegated_is_superuser,
+                "delegated_is_provider_org": delegated_is_provider_org,
+            }
+        )
 
     expires_at = datetime.now(timezone.utc) + timedelta(days=30)
     token = create_access_token(token_data, expires_delta=timedelta(days=30))

--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -415,6 +415,7 @@ def mint_engine_token(
     delegated_name: str = "",
     delegated_is_superuser: bool = False,
     delegated_is_provider_org: bool = False,
+    delegated_is_external: bool = False,
 ) -> tuple[str, str]:
     """
     Mint a long-lived engine token (30 days) parent-side.
@@ -445,6 +446,7 @@ def mint_engine_token(
                 "delegated_name": delegated_name,
                 "delegated_is_superuser": delegated_is_superuser,
                 "delegated_is_provider_org": delegated_is_provider_org,
+                "delegated_is_external": delegated_is_external,
             }
         )
 

--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -433,6 +433,7 @@ def mint_engine_token(
         "email": "engine@bifrost.internal",
         "name": "Bifrost Engine",
         "is_superuser": True,
+        "engine": True,
     }
     if organization_id is not None:
         token_data["org_id"] = str(organization_id)
@@ -477,6 +478,7 @@ def authenticate_engine() -> None:
         "email": "engine@bifrost.internal",
         "name": "Bifrost Engine",
         "is_superuser": True,
+        "engine": True,
     }
 
     token = create_access_token(

--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -21,6 +21,8 @@ from pwdlib.hashers.bcrypt import BcryptHasher
 
 from src.config import get_settings
 
+ENGINE_USER_ID = "00000000-0000-0000-0000-000000000001"
+
 # Password hashing using pwdlib with bcrypt
 # This is the modern replacement for passlib, recommended by FastAPI
 # We explicitly use BcryptHasher to avoid requiring argon2 dependency
@@ -405,7 +407,7 @@ def validate_csrf_token(cookie_token: str, header_token: str) -> bool:
     return secrets.compare_digest(cookie_token, header_token)
 
 
-def mint_engine_token() -> tuple[str, str]:
+def mint_engine_token(*, organization_id: str | None = None) -> tuple[str, str]:
     """
     Mint a long-lived engine token (30 days) parent-side.
 
@@ -418,14 +420,14 @@ def mint_engine_token() -> tuple[str, str]:
     Returns:
         (token, expires_at_iso): JWT string and ISO-8601 expiry timestamp.
     """
-    ENGINE_USER_ID = "00000000-0000-0000-0000-000000000001"
-
     token_data = {
         "sub": ENGINE_USER_ID,
         "email": "engine@bifrost.internal",
         "name": "Bifrost Engine",
         "is_superuser": True,
     }
+    if organization_id is not None:
+        token_data["org_id"] = str(organization_id)
 
     expires_at = datetime.now(timezone.utc) + timedelta(days=30)
     token = create_access_token(token_data, expires_delta=timedelta(days=30))
@@ -449,10 +451,6 @@ def authenticate_engine() -> None:
     import os
 
     from bifrost.credentials import save_credentials
-
-    # Use a fixed UUID for the engine service account
-    # This is a well-known UUID that represents the execution engine
-    ENGINE_USER_ID = "00000000-0000-0000-0000-000000000001"
 
     # Create a long-lived superuser token (30 days)
     # is_superuser=True with no org_id = system account with global access

--- a/api/src/core/system_agents.py
+++ b/api/src/core/system_agents.py
@@ -12,6 +12,44 @@ PRIVILEGED_AGENT_MANAGEMENT_TOOLS: frozenset[str] = frozenset({
     "delete_agent",
 })
 
+# Built-in tools that remain platform-admin-only even when an accessible agent
+# lists them. Agent assignment must never override this authorization boundary.
+PLATFORM_ADMIN_SYSTEM_TOOLS: frozenset[str] = frozenset({
+    "create_agent",
+    "create_app",
+    "create_form",
+    "create_organization",
+    "create_table",
+    "create_workflow",
+    "delete_agent",
+    "delete_content",
+    "execute_workflow",
+    "get_agent_schema",
+    "get_app_schema",
+    "get_data_provider_schema",
+    "get_execution",
+    "get_form_schema",
+    "get_organization",
+    "get_sdk_schema",
+    "get_table",
+    "get_table_schema",
+    "get_workflow",
+    "get_workflow_schema",
+    "list_executions",
+    "list_integrations",
+    "list_organizations",
+    "list_tables",
+    "list_workflows",
+    "patch_content",
+    "publish_app",
+    "replace_content",
+    "update_agent",
+    "update_app",
+    "update_form",
+    "update_table",
+    "validate_workflow",
+})
+
 
 def is_privileged_agent_management_tool(tool_name: str) -> bool:
     """Return True when a built-in MCP tool manages agent privileges."""

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -769,7 +769,12 @@ class WorkflowExecutionConsumer(BaseConsumer):
             # credentials file directly — no SECRET_KEY needed in the child.
             from src.core.security import mint_engine_token
             engine_token, engine_token_expires_at = mint_engine_token(
-                organization_id=org_id
+                organization_id=org_id,
+                delegated_user_id=user_id,
+                delegated_email=user_email,
+                delegated_name=user_name,
+                delegated_is_superuser=pending.get("is_platform_admin", False),
+                delegated_is_provider_org=bool(org and org.is_provider),
             )
 
             # Build context for worker process

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -774,7 +774,8 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 delegated_email=user_email,
                 delegated_name=user_name,
                 delegated_is_superuser=pending.get("is_platform_admin", False),
-                delegated_is_provider_org=bool(org and org.is_provider),
+                delegated_is_provider_org=pending.get("is_provider_org", False),
+                delegated_is_external=pending.get("is_external", False),
             )
 
             # Build context for worker process
@@ -796,6 +797,8 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 "cache_ttl_seconds": cache_ttl_seconds,
                 "transient": False,
                 "is_platform_admin": pending.get("is_platform_admin", False),
+                "is_provider_org": pending.get("is_provider_org", False),
+                "is_external": pending.get("is_external", False),
                 "startup": startup,  # Launch workflow results (available via context.startup)
                 "roi": {
                     "time_saved": roi_time_saved,

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -768,7 +768,9 @@ class WorkflowExecutionConsumer(BaseConsumer):
             # The child receives the token via context_data and writes it to the
             # credentials file directly — no SECRET_KEY needed in the child.
             from src.core.security import mint_engine_token
-            engine_token, engine_token_expires_at = mint_engine_token()
+            engine_token, engine_token_expires_at = mint_engine_token(
+                organization_id=org_id
+            )
 
             # Build context for worker process
             context_data = {

--- a/api/src/jobs/schedulers/deferred_execution_promoter.py
+++ b/api/src/jobs/schedulers/deferred_execution_promoter.py
@@ -84,6 +84,12 @@ async def promote_due_executions() -> tuple[int, int]:
                     is_platform_admin=bool(
                         (row.execution_context or {}).get("is_platform_admin", False)
                     ),
+                    is_provider_org=bool(
+                        (row.execution_context or {}).get("is_provider_org", False)
+                    ),
+                    is_external=bool(
+                        (row.execution_context or {}).get("is_external", False)
+                    ),
                     file_path=None,
                     solution_deployment_id=str(row.solution_deployment_id) if row.solution_deployment_id else None,
                     runtime_evidence=(row.execution_context or {}).get("runtime_evidence"),

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -334,6 +334,8 @@ async def get_dev_context(
             "email": current_user.email,
             "name": current_user.name,
             "is_superuser": current_user.is_superuser,
+            "is_provider_org": current_user.is_provider_org,
+            "is_external": current_user.is_external,
         },
         organization=org_data,
         default_parameters={},

--- a/api/src/routers/forms.py
+++ b/api/src/routers/forms.py
@@ -912,6 +912,8 @@ async def execute_form(
             form_id=form.id,
             api_key_id=None,
             is_platform_admin=ctx.user.is_superuser,
+            is_provider_org=getattr(ctx.user, "is_provider_org", False),
+            is_external=getattr(ctx.user, "is_external", False),
         )
         logger.info(
             f"Form {log_safe(form_id)} scheduled by user {ctx.user.email}, "

--- a/api/src/routers/forms.py
+++ b/api/src/routers/forms.py
@@ -941,6 +941,8 @@ async def execute_form(
         scope=str(anchor_org_id) if anchor_org_id else "GLOBAL",
         organization=org,
         is_platform_admin=ctx.user.is_superuser,
+        is_provider_org=getattr(ctx.user, "is_provider_org", False),
+        is_external=getattr(ctx.user, "is_external", False),
         is_function_key=False,
         execution_id=str(uuid4()),
         startup=request.startup_data,
@@ -1109,6 +1111,8 @@ async def execute_startup_workflow(
         scope=str(launch_anchor_org_id) if launch_anchor_org_id else "GLOBAL",
         organization=org,
         is_platform_admin=ctx.user.is_superuser,
+        is_provider_org=getattr(ctx.user, "is_provider_org", False),
+        is_external=getattr(ctx.user, "is_external", False),
         is_function_key=False,
         execution_id=str(uuid4()),
     )

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -712,6 +712,16 @@ async def _insert_scheduled_execution(
     return exec_id
 
 
+def _is_engine_principal(user) -> bool:
+    """Identify current and pre-marker engine tokens without matching embeds."""
+    from src.core.security import ENGINE_USER_ID
+
+    return bool(getattr(user, "is_engine_token", False)) or (
+        str(user.user_id) == ENGINE_USER_ID
+        and getattr(user, "email", "") == "engine@bifrost.internal"
+    )
+
+
 def _validate_execution_identity_overrides(
     ctx: Context,
     *,
@@ -719,7 +729,7 @@ def _validate_execution_identity_overrides(
     run_as: str | None,
 ) -> None:
     """Keep delegated engine calls inside the parent execution identity."""
-    if ctx.user.is_engine_token:
+    if _is_engine_principal(ctx.user):
         crosses_org = org_id is not None and org_id != (
             str(ctx.org_id) if ctx.org_id is not None else None
         )
@@ -740,7 +750,7 @@ def _validate_execution_identity_overrides(
 def _effective_execution_user(ctx: Context):
     """Return the original caller for an internal engine delegation."""
     from src.core.principal import UserPrincipal
-    if not ctx.user.is_engine_token:
+    if not _is_engine_principal(ctx.user):
         return ctx.user
 
     if ctx.user.delegated_user_id is None:

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -719,9 +719,7 @@ def _validate_execution_identity_overrides(
     run_as: str | None,
 ) -> None:
     """Keep delegated engine calls inside the parent execution identity."""
-    from src.core.security import ENGINE_USER_ID
-
-    if str(ctx.user.user_id) == ENGINE_USER_ID:
+    if ctx.user.is_engine_token:
         crosses_org = org_id is not None and org_id != (
             str(ctx.org_id) if ctx.org_id is not None else None
         )
@@ -742,9 +740,7 @@ def _validate_execution_identity_overrides(
 def _effective_execution_user(ctx: Context):
     """Return the original caller for an internal engine delegation."""
     from src.core.principal import UserPrincipal
-    from src.core.security import ENGINE_USER_ID
-
-    if str(ctx.user.user_id) != ENGINE_USER_ID:
+    if not ctx.user.is_engine_token:
         return ctx.user
 
     if ctx.user.delegated_user_id is None:

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -712,6 +712,33 @@ async def _insert_scheduled_execution(
     return exec_id
 
 
+def _validate_execution_identity_overrides(
+    ctx: Context,
+    *,
+    org_id: str | None,
+    run_as: str | None,
+) -> None:
+    """Keep delegated engine calls inside the parent execution identity."""
+    from src.core.security import ENGINE_USER_ID
+
+    if str(ctx.user.user_id) == ENGINE_USER_ID:
+        crosses_org = org_id is not None and org_id != (
+            str(ctx.org_id) if ctx.org_id is not None else None
+        )
+        if run_as is not None or crosses_org:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Delegated workflows cannot override org_id or run_as",
+            )
+        return
+
+    if (org_id or run_as) and not ctx.user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="org_id and run_as overrides require platform admin",
+        )
+
+
 @router.post(
     "/execute",
     response_model=WorkflowExecutionResponse,
@@ -831,12 +858,11 @@ async def execute_workflow(
             detail="Either workflow_id or code must be provided",
         )
 
-    # Validate admin-only overrides (org_id, run_as)
-    if (request.org_id or request.run_as) and not ctx.user.is_superuser:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="org_id and run_as overrides require platform admin",
-        )
+    _validate_execution_identity_overrides(
+        ctx,
+        org_id=request.org_id,
+        run_as=request.run_as,
+    )
 
     # Resolve run_as user if provided
     exec_user_id = str(ctx.user.user_id)

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -739,6 +739,32 @@ def _validate_execution_identity_overrides(
         )
 
 
+def _effective_execution_user(ctx: Context):
+    """Return the original caller for an internal engine delegation."""
+    from src.core.principal import UserPrincipal
+    from src.core.security import ENGINE_USER_ID
+
+    if str(ctx.user.user_id) != ENGINE_USER_ID:
+        return ctx.user
+
+    if ctx.user.delegated_user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Delegated workflow is missing original caller identity",
+        )
+
+    return UserPrincipal(
+        user_id=ctx.user.delegated_user_id,
+        email=ctx.user.delegated_email,
+        organization_id=ctx.org_id,
+        name=ctx.user.delegated_name,
+        is_active=True,
+        is_superuser=ctx.user.delegated_is_superuser,
+        is_verified=True,
+        is_provider_org=ctx.user.delegated_is_provider_org,
+    )
+
+
 @router.post(
     "/execute",
     response_model=WorkflowExecutionResponse,
@@ -772,11 +798,13 @@ async def execute_workflow(
     from src.repositories import AccessDeniedError, WorkflowRepository
     from src.core.org_filter import resolve_target_org
 
+    effective_user = _effective_execution_user(ctx)
+
     # Resolve org scope for workflow lookup — follows the same pattern as
     # configs, tables, etc. Superusers can pass org_id to search that org;
     # regular users always use their own org.
     lookup_org_id = resolve_target_org(
-        user=user,
+        user=effective_user,
         scope=request.org_id,
         default_org_id=ctx.org_id,
     )
@@ -784,14 +812,14 @@ async def execute_workflow(
     workflow_repo = WorkflowRepository(
         session=db,
         org_id=lookup_org_id,
-        user_id=ctx.user.user_id,
-        is_superuser=ctx.user.is_superuser,
+        user_id=effective_user.user_id,
+        is_superuser=effective_user.is_superuser,
         # Embed principals carry is_external=True (OPEN-D: external-equivalent
         # for the config/knowledge/table data gates), but workflow execution
         # is the HMAC-pre-authorized app function-call channel — deliberately
         # allowlisted by EmbedScopeMiddleware and execution-scoped by jti.
         # Keep the pre-OPEN-D resolution semantics for embed sessions here.
-        is_external=ctx.user.is_external and not ctx.user.embed,
+        is_external=effective_user.is_external and not effective_user.embed,
     )
 
     # A Solution caller's path::fn ref carries no install id (it can't know the
@@ -836,7 +864,7 @@ async def execute_workflow(
     # Authorization check
     if request.code:
         # Inline code execution requires platform admin
-        if not ctx.user.is_superuser:
+        if not effective_user.is_superuser:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Inline code execution requires platform admin access",
@@ -865,10 +893,10 @@ async def execute_workflow(
     )
 
     # Resolve run_as user if provided
-    exec_user_id = str(ctx.user.user_id)
-    exec_user_name = ctx.user.name or ctx.user.email or "Unknown"
-    exec_user_email = ctx.user.email or ""
-    exec_is_admin = ctx.user.is_superuser
+    exec_user_id = str(effective_user.user_id)
+    exec_user_name = effective_user.name or effective_user.email or "Unknown"
+    exec_user_email = effective_user.email or ""
+    exec_is_admin = effective_user.is_superuser
 
     if request.run_as:
         from src.models.orm.users import User

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -665,6 +665,8 @@ async def _insert_scheduled_execution(
     form_id: UUID | None,
     api_key_id: UUID | None,
     is_platform_admin: bool,
+    is_provider_org: bool = False,
+    is_external: bool = False,
 ) -> UUID:
     """Insert a SCHEDULED execution row.
 
@@ -683,7 +685,11 @@ async def _insert_scheduled_execution(
     from src.services.solutions.deployment_manifest import canonical_json, sha256_digest
 
     runtime_mode = "deployment-v1" if pinned_runtime else "repo-v1"
-    execution_context: dict[str, object] = {"is_platform_admin": is_platform_admin}
+    execution_context: dict[str, object] = {
+        "is_platform_admin": is_platform_admin,
+        "is_provider_org": is_provider_org,
+        "is_external": is_external,
+    }
     if runtime_evidence is not None:
         execution_context["runtime_evidence"] = runtime_evidence
     db.add(
@@ -710,65 +716,6 @@ async def _insert_scheduled_execution(
     )
     await db.commit()
     return exec_id
-
-
-def _is_engine_principal(user) -> bool:
-    """Identify current and pre-marker engine tokens without matching embeds."""
-    from src.core.security import ENGINE_USER_ID
-
-    return bool(getattr(user, "is_engine_token", False)) or (
-        str(user.user_id) == ENGINE_USER_ID
-        and getattr(user, "email", "") == "engine@bifrost.internal"
-    )
-
-
-def _validate_execution_identity_overrides(
-    ctx: Context,
-    *,
-    org_id: str | None,
-    run_as: str | None,
-) -> None:
-    """Keep delegated engine calls inside the parent execution identity."""
-    if _is_engine_principal(ctx.user):
-        crosses_org = org_id is not None and org_id != (
-            str(ctx.org_id) if ctx.org_id is not None else None
-        )
-        if run_as is not None or crosses_org:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Delegated workflows cannot override org_id or run_as",
-            )
-        return
-
-    if (org_id or run_as) and not ctx.user.is_superuser:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="org_id and run_as overrides require platform admin",
-        )
-
-
-def _effective_execution_user(ctx: Context):
-    """Return the original caller for an internal engine delegation."""
-    from src.core.principal import UserPrincipal
-    if not _is_engine_principal(ctx.user):
-        return ctx.user
-
-    if ctx.user.delegated_user_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Delegated workflow is missing original caller identity",
-        )
-
-    return UserPrincipal(
-        user_id=ctx.user.delegated_user_id,
-        email=ctx.user.delegated_email,
-        organization_id=ctx.org_id,
-        name=ctx.user.delegated_name,
-        is_active=True,
-        is_superuser=ctx.user.delegated_is_superuser,
-        is_verified=True,
-        is_provider_org=ctx.user.delegated_is_provider_org,
-    )
 
 
 @router.post(
@@ -803,8 +750,19 @@ async def execute_workflow(
     )
     from src.repositories import AccessDeniedError, WorkflowRepository
     from src.core.org_filter import resolve_target_org
+    from src.services.execution.delegation_authorization import (
+        DelegationAuthorizationError,
+        effective_execution_user,
+        validate_execution_identity_overrides,
+    )
 
-    effective_user = _effective_execution_user(ctx)
+    try:
+        effective_user = effective_execution_user(ctx.user, ctx.org_id)
+    except DelegationAuthorizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
 
     # Resolve org scope for workflow lookup — follows the same pattern as
     # configs, tables, etc. Superusers can pass org_id to search that org;
@@ -892,17 +850,26 @@ async def execute_workflow(
             detail="Either workflow_id or code must be provided",
         )
 
-    _validate_execution_identity_overrides(
-        ctx,
-        org_id=request.org_id,
-        run_as=request.run_as,
-    )
+    try:
+        validate_execution_identity_overrides(
+            ctx.user,
+            ctx.org_id,
+            requested_org_id=request.org_id,
+            run_as=request.run_as,
+        )
+    except DelegationAuthorizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
 
     # Resolve run_as user if provided
     exec_user_id = str(effective_user.user_id)
     exec_user_name = effective_user.name or effective_user.email or "Unknown"
     exec_user_email = effective_user.email or ""
     exec_is_admin = effective_user.is_superuser
+    exec_is_provider_org = effective_user.is_provider_org
+    exec_is_external = effective_user.is_external
 
     if request.run_as:
         from src.models.orm.users import User
@@ -919,6 +886,13 @@ async def execute_workflow(
         exec_user_name = run_as_user.name or run_as_user.email or "Unknown"
         exec_user_email = run_as_user.email or ""
         exec_is_admin = run_as_user.is_superuser
+        from shared.external_access import (
+            resolve_external_claim,
+            resolve_provider_org_claim,
+        )
+
+        exec_is_provider_org = await resolve_provider_org_claim(db, run_as_user)
+        exec_is_external = await resolve_external_claim(db, run_as_user)
         logger.info(f"Impersonating user: {exec_user_id} ({exec_user_email})")
 
     # Determine execution org_id
@@ -959,6 +933,8 @@ async def execute_workflow(
             form_id=UUID(request.form_id) if request.form_id else None,
             api_key_id=None,  # API-key-triggered scheduling not supported in v1
             is_platform_admin=exec_is_admin,
+            is_provider_org=exec_is_provider_org,
+            is_external=exec_is_external,
         )
         return WorkflowExecutionResponse(
             execution_id=str(exec_id),
@@ -993,6 +969,8 @@ async def execute_workflow(
         is_platform_admin=exec_is_admin,
         is_function_key=False,
         execution_id=str(uuid4()),
+        is_provider_org=exec_is_provider_org,
+        is_external=exec_is_external,
     )
 
     try:

--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -241,8 +241,8 @@ async def enqueue_workflow_execution(
         api_key_id=api_key_id,
         sync=sync,
         is_platform_admin=context.is_platform_admin,
-        is_provider_org=context.is_provider_org,
-        is_external=context.is_external,
+        is_provider_org=getattr(context, "is_provider_org", False),
+        is_external=getattr(context, "is_external", False),
         file_path=file_path,
         event=event_payload,
         solution_deployment_id=solution_deployment_id,
@@ -305,8 +305,8 @@ async def enqueue_code_execution(
         user_email=context.email,
         form_id=None,
         is_platform_admin=context.is_platform_admin,
-        is_provider_org=context.is_provider_org,
-        is_external=context.is_external,
+        is_provider_org=getattr(context, "is_provider_org", False),
+        is_external=getattr(context, "is_external", False),
     )
 
     # Add to queue tracking

--- a/api/src/services/execution/async_executor.py
+++ b/api/src/services/execution/async_executor.py
@@ -102,6 +102,8 @@ async def _publish_pending(
     sync: bool,
     is_platform_admin: bool,
     file_path: str | None,
+    is_provider_org: bool = False,
+    is_external: bool = False,
     event: dict[str, Any] | None = None,
     solution_deployment_id: str | None = None,
     runtime_evidence: dict[str, Any] | None = None,
@@ -146,6 +148,8 @@ async def _publish_pending(
                 api_key_id=api_key_id,
                 sync=sync,
                 is_platform_admin=is_platform_admin,
+                is_provider_org=is_provider_org,
+                is_external=is_external,
                 event=event,
                 solution_deployment_id=solution_deployment_id,
                 runtime_evidence=runtime_evidence,
@@ -237,6 +241,8 @@ async def enqueue_workflow_execution(
         api_key_id=api_key_id,
         sync=sync,
         is_platform_admin=context.is_platform_admin,
+        is_provider_org=context.is_provider_org,
+        is_external=context.is_external,
         file_path=file_path,
         event=event_payload,
         solution_deployment_id=solution_deployment_id,
@@ -298,6 +304,9 @@ async def enqueue_code_execution(
         user_name=context.name,
         user_email=context.email,
         form_id=None,
+        is_platform_admin=context.is_platform_admin,
+        is_provider_org=context.is_provider_org,
+        is_external=context.is_external,
     )
 
     # Add to queue tracking

--- a/api/src/services/execution/delegation_authorization.py
+++ b/api/src/services/execution/delegation_authorization.py
@@ -1,0 +1,70 @@
+"""Authorization policy for workflow calls made through the engine transport."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from src.core.principal import UserPrincipal
+from src.core.security import ENGINE_USER_ID
+
+
+class DelegationAuthorizationError(PermissionError):
+    """Raised when an execution attempts to exceed its delegated identity."""
+
+
+def is_engine_principal(user: UserPrincipal) -> bool:
+    """Identify current and pre-marker engine tokens without matching embeds."""
+    return bool(getattr(user, "is_engine_token", False)) or (
+        str(user.user_id) == ENGINE_USER_ID
+        and getattr(user, "email", "") == "engine@bifrost.internal"
+    )
+
+
+def validate_execution_identity_overrides(
+    user: UserPrincipal,
+    execution_org_id: UUID | None,
+    *,
+    requested_org_id: str | None,
+    run_as: str | None,
+) -> None:
+    """Keep delegated calls inside the original execution identity."""
+    if is_engine_principal(user):
+        crosses_org = requested_org_id is not None and requested_org_id != (
+            str(execution_org_id) if execution_org_id is not None else None
+        )
+        if run_as is not None or crosses_org:
+            raise DelegationAuthorizationError(
+                "Delegated workflows cannot override org_id or run_as"
+            )
+        return
+
+    if (requested_org_id or run_as) and not user.is_superuser:
+        raise DelegationAuthorizationError(
+            "org_id and run_as overrides require platform admin"
+        )
+
+
+def effective_execution_user(
+    user: UserPrincipal,
+    execution_org_id: UUID | None,
+) -> UserPrincipal:
+    """Return the original caller represented by an engine transport token."""
+    if not is_engine_principal(user):
+        return user
+
+    if user.delegated_user_id is None:
+        raise DelegationAuthorizationError(
+            "Delegated workflow is missing original caller identity"
+        )
+
+    return UserPrincipal(
+        user_id=user.delegated_user_id,
+        email=user.delegated_email,
+        organization_id=execution_org_id,
+        name=user.delegated_name,
+        is_active=True,
+        is_superuser=user.delegated_is_superuser,
+        is_verified=True,
+        is_external=user.delegated_is_external,
+        is_provider_org=user.delegated_is_provider_org,
+    )

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -130,6 +130,8 @@ class ExecutionRequest:
     transient: bool = False              # Don't write to DB
     no_cache: bool = False               # For data providers
     is_platform_admin: bool = False       # For platform admin executions
+    is_provider_org: bool = False         # Original caller's provider membership
+    is_external: bool = False             # Original caller's external restriction
 
     # Real-time updates
     broadcaster: Any = None              # WebPubSubBroadcaster for streaming logs
@@ -315,6 +317,8 @@ async def execute(request: ExecutionRequest) -> ExecutionResult:
         scope=request.organization.id if request.organization else "GLOBAL",
         organization=request.organization,
         is_platform_admin=request.is_platform_admin,
+        is_provider_org=request.is_provider_org,
+        is_external=request.is_external,
         is_function_key=False,  # Engine executions are not function key based
         execution_id=request.execution_id,
         workflow_name=request.name or "",  # Workflow/script name for context

--- a/api/src/services/execution/worker.py
+++ b/api/src/services/execution/worker.py
@@ -343,6 +343,8 @@ async def _run_execution(execution_id: str, context_data: dict[str, Any]) -> dic
             transient=context_data.get("transient", False),
             no_cache=context_data.get("no_cache", False),
             is_platform_admin=context_data.get("is_platform_admin", False),
+            is_provider_org=context_data.get("is_provider_org", False),
+            is_external=context_data.get("is_external", False),
             broadcaster=None,  # Logs go to Redis Stream directly
             event=event_ctx,
             solution_id=context_data.get("solution_id"),  # install scope for SDK

--- a/api/src/services/file_storage/indexers/agent.py
+++ b/api/src/services/file_storage/indexers/agent.py
@@ -110,6 +110,20 @@ class AgentIndexer:
         if not isinstance(knowledge_sources, list):
             knowledge_sources = []
 
+        # Agent manifests may carry portable, non-privileged built-in tools,
+        # but file sync is not an authorization surface. Drop admin-only tools
+        # before the upsert so a repository change cannot grant them.
+        from src.core.system_agents import PLATFORM_ADMIN_SYSTEM_TOOLS
+
+        raw_system_tools = agent_data.get("system_tools", [])
+        if not isinstance(raw_system_tools, list):
+            raw_system_tools = []
+        system_tools = [
+            tool
+            for tool in raw_system_tools
+            if isinstance(tool, str) and tool not in PLATFORM_ADMIN_SYSTEM_TOOLS
+        ]
+
         now = datetime.now(timezone.utc)
 
         # Upsert agent - updates definition but NOT organization_id or access_level
@@ -139,8 +153,7 @@ class AgentIndexer:
                 if agent_data.get("max_token_budget") is not None
                 else {}
             ),
-            # System tools are environment-specific privileges. New agents get
-            # the model default; file sync must not import YAML-controlled grants.
+            system_tools=system_tools,
             created_by="file_sync",
         ).on_conflict_do_update(
             index_elements=[Agent.id],
@@ -170,6 +183,7 @@ class AgentIndexer:
                     if agent_data.get("max_token_budget") is not None
                     else {}
                 ),
+                "system_tools": system_tools,
                 "updated_at": now,
                 # NOTE: organization_id and access_level are NOT updated
                 # These are preserved from the database (env-specific)

--- a/api/src/services/file_storage/indexers/agent.py
+++ b/api/src/services/file_storage/indexers/agent.py
@@ -139,7 +139,8 @@ class AgentIndexer:
                 if agent_data.get("max_token_budget") is not None
                 else {}
             ),
-            system_tools=agent_data.get("system_tools", []),
+            # System tools are environment-specific privileges. New agents get
+            # the model default; file sync must not import YAML-controlled grants.
             created_by="file_sync",
         ).on_conflict_do_update(
             index_elements=[Agent.id],
@@ -169,7 +170,6 @@ class AgentIndexer:
                     if agent_data.get("max_token_budget") is not None
                     else {}
                 ),
-                "system_tools": agent_data.get("system_tools", []),
                 "updated_at": now,
                 # NOTE: organization_id and access_level are NOT updated
                 # These are preserved from the database (env-specific)

--- a/api/src/services/mcp_server/middleware.py
+++ b/api/src/services/mcp_server/middleware.py
@@ -242,6 +242,17 @@ class ToolFilterMiddleware(Middleware):
         user_id = token.claims.get("user_id")
         org_id = token.claims.get("org_id")
 
+        from src.core.system_agents import PLATFORM_ADMIN_SYSTEM_TOOLS
+
+        if not is_superuser and tool_name in PLATFORM_ADMIN_SYSTEM_TOOLS:
+            logger.warning(
+                f"MCP tools/call: Platform-admin tool denied for user {user_email} "
+                f"to tool '{tool_name}'"
+            )
+            raise ToolError(
+                f"Access denied: You don't have permission to use '{tool_name}'"
+            )
+
         agent_id = _get_agent_id_from_scope()
 
         # Check if user has access to this tool

--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -13,6 +13,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from src.core.system_agents import PLATFORM_ADMIN_SYSTEM_TOOLS
 from src.models.contracts.agents import ToolInfo
 from src.models.enums import AgentAccessLevel
 from src.models.orm.agents import Agent
@@ -116,6 +117,8 @@ class MCPToolAccessService:
             # auto-injected when the agent has knowledge_sources. Mirrors the
             # native chat path in agent_helpers.py so MCP listing matches.
             for system_tool_id in self._effective_system_tool_ids(agent):
+                if not is_superuser and system_tool_id in PLATFORM_ADMIN_SYSTEM_TOOLS:
+                    continue
                 if system_tool_id in seen_tool_ids:
                     continue
                 seen_tool_ids.add(system_tool_id)
@@ -250,6 +253,8 @@ class MCPToolAccessService:
         tools: list[ToolInfo] = []
 
         for system_tool_id in self._effective_system_tool_ids(agent):
+            if not is_superuser and system_tool_id in PLATFORM_ADMIN_SYSTEM_TOOLS:
+                continue
             if system_tool_id in self._SYSTEM_TOOL_MAP:
                 tools.append(self._SYSTEM_TOOL_MAP[system_tool_id])
             else:

--- a/api/tests/e2e/api/test_cli.py
+++ b/api/tests/e2e/api/test_cli.py
@@ -95,7 +95,14 @@ class TestCLIContextOrgOverride:
         data = response.json()
 
         user = data["user"]
-        for field in ("id", "email", "name", "is_superuser"):
+        for field in (
+            "id",
+            "email",
+            "name",
+            "is_superuser",
+            "is_provider_org",
+            "is_external",
+        ):
             assert field in user, f"missing user.{field}"
 
         org = data["organization"]

--- a/api/tests/e2e/api/test_cli.py
+++ b/api/tests/e2e/api/test_cli.py
@@ -104,10 +104,29 @@ class TestCLIContextOrgOverride:
             "is_external",
         ):
             assert field in user, f"missing user.{field}"
+        assert user["is_provider_org"] is False
+        assert user["is_external"] is False
 
         org = data["organization"]
         for field in ("id", "name", "is_active", "is_provider"):
             assert field in org, f"missing organization.{field}"
+
+    def test_provider_context_reports_authorization_flags(
+        self,
+        e2e_client,
+        provider_org_user,
+        org1,
+    ):
+        response = e2e_client.get(
+            "/api/sdk/context",
+            params={"org_id": org1["id"]},
+            headers=provider_org_user.headers,
+        )
+        assert response.status_code == 200
+        user = response.json()["user"]
+        assert user["is_superuser"] is False
+        assert user["is_provider_org"] is True
+        assert user["is_external"] is False
 
     def test_non_superuser_cannot_target_other_org(
         self,

--- a/api/tests/e2e/api/test_cli.py
+++ b/api/tests/e2e/api/test_cli.py
@@ -104,7 +104,7 @@ class TestCLIContextOrgOverride:
             "is_external",
         ):
             assert field in user, f"missing user.{field}"
-        assert user["is_provider_org"] is False
+        assert user["is_provider_org"] is True
         assert user["is_external"] is False
 
         org = data["organization"]

--- a/api/tests/unit/core/test_redis_client.py
+++ b/api/tests/unit/core/test_redis_client.py
@@ -134,6 +134,8 @@ class TestRedisClient:
             startup={"ready": True},
             sync=True,
             is_platform_admin=True,
+            is_provider_org=True,
+            is_external=True,
             event={"kind": "webhook"},
         )
 
@@ -148,6 +150,8 @@ class TestRedisClient:
         assert payload["parameters"] == {"answer": 42}
         assert payload["sync"] is True
         assert payload["is_platform_admin"] is True
+        assert payload["is_provider_org"] is True
+        assert payload["is_external"] is True
         assert payload["event"] == {"kind": "webhook"}
         assert payload["cancelled"] is False
         assert payload["created_at"]

--- a/api/tests/unit/jobs/schedulers/test_deferred_execution_promoter.py
+++ b/api/tests/unit/jobs/schedulers/test_deferred_execution_promoter.py
@@ -49,6 +49,11 @@ async def test_promotes_due_rows(db_session):
     from src.jobs.schedulers.deferred_execution_promoter import promote_due_executions
 
     due = _new_scheduled(datetime.now(timezone.utc) - timedelta(seconds=1))
+    due.execution_context = {
+        "is_platform_admin": False,
+        "is_provider_org": True,
+        "is_external": True,
+    }
     db_session.add(due)
     await db_session.commit()
 
@@ -61,6 +66,8 @@ async def test_promotes_due_rows(db_session):
     assert promoted == 1
     assert failed == 0
     pub.assert_awaited_once()
+    assert pub.await_args.kwargs["is_provider_org"] is True
+    assert pub.await_args.kwargs["is_external"] is True
 
     await db_session.refresh(due)
     assert due.status == ExecutionStatus.PENDING

--- a/api/tests/unit/routers/test_workflow_delegation_authorization.py
+++ b/api/tests/unit/routers/test_workflow_delegation_authorization.py
@@ -16,6 +16,7 @@ def _context(
     user_id: str,
     org_id: UUID | None,
     is_superuser: bool = True,
+    is_engine_token: bool = False,
     delegated_user_id: UUID | None = None,
     delegated_is_superuser: bool = False,
 ):
@@ -23,6 +24,7 @@ def _context(
         user=SimpleNamespace(
             user_id=UUID(user_id),
             is_superuser=is_superuser,
+            is_engine_token=is_engine_token,
             delegated_user_id=delegated_user_id,
             delegated_email="caller@example.com",
             delegated_name="Original Caller",
@@ -47,6 +49,7 @@ def test_engine_token_is_bound_to_parent_execution_org() -> None:
 
     assert payload is not None
     assert payload["sub"] == ENGINE_USER_ID
+    assert payload["engine"] is True
     assert payload["org_id"] == str(org_id)
     assert payload["delegated_user_id"] == str(caller_id)
 
@@ -57,6 +60,7 @@ def test_engine_delegation_uses_original_caller_identity() -> None:
     ctx = _context(
         user_id=ENGINE_USER_ID,
         org_id=org_id,
+        is_engine_token=True,
         delegated_user_id=caller_id,
     )
 
@@ -68,8 +72,24 @@ def test_engine_delegation_uses_original_caller_identity() -> None:
     assert effective_user.is_superuser is False
 
 
+def test_shared_sentinel_subject_without_engine_marker_keeps_own_identity() -> None:
+    """Embed sessions share the sentinel subject but are not delegations."""
+    ctx = _context(
+        user_id=ENGINE_USER_ID,
+        org_id=uuid4(),
+        is_superuser=False,
+        is_engine_token=False,
+    )
+
+    assert _effective_execution_user(ctx) is ctx.user
+
+
 def test_engine_delegation_without_caller_identity_fails_closed() -> None:
-    ctx = _context(user_id=ENGINE_USER_ID, org_id=uuid4())
+    ctx = _context(
+        user_id=ENGINE_USER_ID,
+        org_id=uuid4(),
+        is_engine_token=True,
+    )
 
     with pytest.raises(HTTPException, match="missing original caller"):
         _effective_execution_user(ctx)
@@ -77,7 +97,11 @@ def test_engine_delegation_without_caller_identity_fails_closed() -> None:
 
 def test_engine_delegation_allows_only_matching_org() -> None:
     org_id = uuid4()
-    ctx = _context(user_id=ENGINE_USER_ID, org_id=org_id)
+    ctx = _context(
+        user_id=ENGINE_USER_ID,
+        org_id=org_id,
+        is_engine_token=True,
+    )
 
     _validate_execution_identity_overrides(ctx, org_id=str(org_id), run_as=None)
 
@@ -86,7 +110,11 @@ def test_engine_delegation_allows_only_matching_org() -> None:
 
 
 def test_engine_delegation_cannot_impersonate_user() -> None:
-    ctx = _context(user_id=ENGINE_USER_ID, org_id=uuid4())
+    ctx = _context(
+        user_id=ENGINE_USER_ID,
+        org_id=uuid4(),
+        is_engine_token=True,
+    )
 
     with pytest.raises(HTTPException, match="cannot override"):
         _validate_execution_identity_overrides(ctx, org_id=None, run_as=str(uuid4()))

--- a/api/tests/unit/routers/test_workflow_delegation_authorization.py
+++ b/api/tests/unit/routers/test_workflow_delegation_authorization.py
@@ -17,6 +17,7 @@ def _context(
     org_id: UUID | None,
     is_superuser: bool = True,
     is_engine_token: bool = False,
+    email: str = "caller@example.com",
     delegated_user_id: UUID | None = None,
     delegated_is_superuser: bool = False,
 ):
@@ -26,6 +27,7 @@ def _context(
             is_superuser=is_superuser,
             is_engine_token=is_engine_token,
             delegated_user_id=delegated_user_id,
+            email=email,
             delegated_email="caller@example.com",
             delegated_name="Original Caller",
             delegated_is_superuser=delegated_is_superuser,
@@ -82,6 +84,17 @@ def test_shared_sentinel_subject_without_engine_marker_keeps_own_identity() -> N
     )
 
     assert _effective_execution_user(ctx) is ctx.user
+
+
+def test_legacy_engine_token_without_marker_still_fails_closed() -> None:
+    ctx = _context(
+        user_id=ENGINE_USER_ID,
+        org_id=uuid4(),
+        email="engine@bifrost.internal",
+    )
+
+    with pytest.raises(HTTPException, match="missing original caller"):
+        _effective_execution_user(ctx)
 
 
 def test_engine_delegation_without_caller_identity_fails_closed() -> None:

--- a/api/tests/unit/routers/test_workflow_delegation_authorization.py
+++ b/api/tests/unit/routers/test_workflow_delegation_authorization.py
@@ -105,8 +105,9 @@ def test_engine_delegation_allows_only_matching_org() -> None:
 
     _validate_execution_identity_overrides(ctx, org_id=str(org_id), run_as=None)
 
+    other_org_id = str(uuid4())
     with pytest.raises(HTTPException, match="cannot override"):
-        _validate_execution_identity_overrides(ctx, org_id=str(uuid4()), run_as=None)
+        _validate_execution_identity_overrides(ctx, org_id=other_org_id, run_as=None)
 
 
 def test_engine_delegation_cannot_impersonate_user() -> None:
@@ -116,8 +117,9 @@ def test_engine_delegation_cannot_impersonate_user() -> None:
         is_engine_token=True,
     )
 
+    run_as = str(uuid4())
     with pytest.raises(HTTPException, match="cannot override"):
-        _validate_execution_identity_overrides(ctx, org_id=None, run_as=str(uuid4()))
+        _validate_execution_identity_overrides(ctx, org_id=None, run_as=run_as)
 
 
 def test_platform_admin_api_call_retains_override_access() -> None:

--- a/api/tests/unit/routers/test_workflow_delegation_authorization.py
+++ b/api/tests/unit/routers/test_workflow_delegation_authorization.py
@@ -5,14 +5,29 @@ import pytest
 from fastapi import HTTPException
 
 from src.core.security import ENGINE_USER_ID, decode_token, mint_engine_token
-from src.routers.workflows import _validate_execution_identity_overrides
+from src.routers.workflows import (
+    _effective_execution_user,
+    _validate_execution_identity_overrides,
+)
 
 
-def _context(*, user_id: str, org_id: UUID | None, is_superuser: bool = True):
+def _context(
+    *,
+    user_id: str,
+    org_id: UUID | None,
+    is_superuser: bool = True,
+    delegated_user_id: UUID | None = None,
+    delegated_is_superuser: bool = False,
+):
     return SimpleNamespace(
         user=SimpleNamespace(
             user_id=UUID(user_id),
             is_superuser=is_superuser,
+            delegated_user_id=delegated_user_id,
+            delegated_email="caller@example.com",
+            delegated_name="Original Caller",
+            delegated_is_superuser=delegated_is_superuser,
+            delegated_is_provider_org=False,
         ),
         org_id=org_id,
     )
@@ -20,13 +35,44 @@ def _context(*, user_id: str, org_id: UUID | None, is_superuser: bool = True):
 
 def test_engine_token_is_bound_to_parent_execution_org() -> None:
     org_id = uuid4()
-    token, _ = mint_engine_token(organization_id=str(org_id))
+    caller_id = uuid4()
+    token, _ = mint_engine_token(
+        organization_id=str(org_id),
+        delegated_user_id=str(caller_id),
+        delegated_email="caller@example.com",
+        delegated_name="Original Caller",
+    )
 
     payload = decode_token(token)
 
     assert payload is not None
     assert payload["sub"] == ENGINE_USER_ID
     assert payload["org_id"] == str(org_id)
+    assert payload["delegated_user_id"] == str(caller_id)
+
+
+def test_engine_delegation_uses_original_caller_identity() -> None:
+    org_id = uuid4()
+    caller_id = uuid4()
+    ctx = _context(
+        user_id=ENGINE_USER_ID,
+        org_id=org_id,
+        delegated_user_id=caller_id,
+    )
+
+    effective_user = _effective_execution_user(ctx)
+
+    assert effective_user.user_id == caller_id
+    assert effective_user.organization_id == org_id
+    assert effective_user.email == "caller@example.com"
+    assert effective_user.is_superuser is False
+
+
+def test_engine_delegation_without_caller_identity_fails_closed() -> None:
+    ctx = _context(user_id=ENGINE_USER_ID, org_id=uuid4())
+
+    with pytest.raises(HTTPException, match="missing original caller"):
+        _effective_execution_user(ctx)
 
 
 def test_engine_delegation_allows_only_matching_org() -> None:

--- a/api/tests/unit/routers/test_workflow_delegation_authorization.py
+++ b/api/tests/unit/routers/test_workflow_delegation_authorization.py
@@ -2,12 +2,12 @@ from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import pytest
-from fastapi import HTTPException
 
 from src.core.security import ENGINE_USER_ID, decode_token, mint_engine_token
-from src.routers.workflows import (
-    _effective_execution_user,
-    _validate_execution_identity_overrides,
+from src.services.execution.delegation_authorization import (
+    DelegationAuthorizationError,
+    effective_execution_user,
+    validate_execution_identity_overrides,
 )
 
 
@@ -20,6 +20,8 @@ def _context(
     email: str = "caller@example.com",
     delegated_user_id: UUID | None = None,
     delegated_is_superuser: bool = False,
+    delegated_is_provider_org: bool = False,
+    delegated_is_external: bool = False,
 ):
     return SimpleNamespace(
         user=SimpleNamespace(
@@ -31,7 +33,8 @@ def _context(
             delegated_email="caller@example.com",
             delegated_name="Original Caller",
             delegated_is_superuser=delegated_is_superuser,
-            delegated_is_provider_org=False,
+            delegated_is_provider_org=delegated_is_provider_org,
+            delegated_is_external=delegated_is_external,
         ),
         org_id=org_id,
     )
@@ -45,6 +48,8 @@ def test_engine_token_is_bound_to_parent_execution_org() -> None:
         delegated_user_id=str(caller_id),
         delegated_email="caller@example.com",
         delegated_name="Original Caller",
+        delegated_is_provider_org=True,
+        delegated_is_external=False,
     )
 
     payload = decode_token(token)
@@ -54,6 +59,8 @@ def test_engine_token_is_bound_to_parent_execution_org() -> None:
     assert payload["engine"] is True
     assert payload["org_id"] == str(org_id)
     assert payload["delegated_user_id"] == str(caller_id)
+    assert payload["delegated_is_provider_org"] is True
+    assert payload["delegated_is_external"] is False
 
 
 def test_engine_delegation_uses_original_caller_identity() -> None:
@@ -64,14 +71,34 @@ def test_engine_delegation_uses_original_caller_identity() -> None:
         org_id=org_id,
         is_engine_token=True,
         delegated_user_id=caller_id,
+        delegated_is_provider_org=True,
+        delegated_is_external=False,
     )
 
-    effective_user = _effective_execution_user(ctx)
+    effective_user = effective_execution_user(ctx.user, ctx.org_id)
 
     assert effective_user.user_id == caller_id
     assert effective_user.organization_id == org_id
     assert effective_user.email == "caller@example.com"
     assert effective_user.is_superuser is False
+    assert effective_user.is_provider_org is True
+    assert effective_user.is_external is False
+
+
+def test_engine_delegation_preserves_external_non_provider_caller() -> None:
+    ctx = _context(
+        user_id=ENGINE_USER_ID,
+        org_id=uuid4(),
+        is_engine_token=True,
+        delegated_user_id=uuid4(),
+        delegated_is_provider_org=False,
+        delegated_is_external=True,
+    )
+
+    effective_user = effective_execution_user(ctx.user, ctx.org_id)
+
+    assert effective_user.is_provider_org is False
+    assert effective_user.is_external is True
 
 
 def test_shared_sentinel_subject_without_engine_marker_keeps_own_identity() -> None:
@@ -83,7 +110,7 @@ def test_shared_sentinel_subject_without_engine_marker_keeps_own_identity() -> N
         is_engine_token=False,
     )
 
-    assert _effective_execution_user(ctx) is ctx.user
+    assert effective_execution_user(ctx.user, ctx.org_id) is ctx.user
 
 
 def test_legacy_engine_token_without_marker_still_fails_closed() -> None:
@@ -93,8 +120,8 @@ def test_legacy_engine_token_without_marker_still_fails_closed() -> None:
         email="engine@bifrost.internal",
     )
 
-    with pytest.raises(HTTPException, match="missing original caller"):
-        _effective_execution_user(ctx)
+    with pytest.raises(DelegationAuthorizationError, match="missing original caller"):
+        effective_execution_user(ctx.user, ctx.org_id)
 
 
 def test_engine_delegation_without_caller_identity_fails_closed() -> None:
@@ -104,8 +131,8 @@ def test_engine_delegation_without_caller_identity_fails_closed() -> None:
         is_engine_token=True,
     )
 
-    with pytest.raises(HTTPException, match="missing original caller"):
-        _effective_execution_user(ctx)
+    with pytest.raises(DelegationAuthorizationError, match="missing original caller"):
+        effective_execution_user(ctx.user, ctx.org_id)
 
 
 def test_engine_delegation_allows_only_matching_org() -> None:
@@ -116,11 +143,21 @@ def test_engine_delegation_allows_only_matching_org() -> None:
         is_engine_token=True,
     )
 
-    _validate_execution_identity_overrides(ctx, org_id=str(org_id), run_as=None)
+    validate_execution_identity_overrides(
+        ctx.user,
+        ctx.org_id,
+        requested_org_id=str(org_id),
+        run_as=None,
+    )
 
     other_org_id = str(uuid4())
-    with pytest.raises(HTTPException, match="cannot override"):
-        _validate_execution_identity_overrides(ctx, org_id=other_org_id, run_as=None)
+    with pytest.raises(DelegationAuthorizationError, match="cannot override"):
+        validate_execution_identity_overrides(
+            ctx.user,
+            ctx.org_id,
+            requested_org_id=other_org_id,
+            run_as=None,
+        )
 
 
 def test_engine_delegation_cannot_impersonate_user() -> None:
@@ -131,15 +168,21 @@ def test_engine_delegation_cannot_impersonate_user() -> None:
     )
 
     run_as = str(uuid4())
-    with pytest.raises(HTTPException, match="cannot override"):
-        _validate_execution_identity_overrides(ctx, org_id=None, run_as=run_as)
+    with pytest.raises(DelegationAuthorizationError, match="cannot override"):
+        validate_execution_identity_overrides(
+            ctx.user,
+            ctx.org_id,
+            requested_org_id=None,
+            run_as=run_as,
+        )
 
 
 def test_platform_admin_api_call_retains_override_access() -> None:
     ctx = _context(user_id=str(uuid4()), org_id=uuid4(), is_superuser=True)
 
-    _validate_execution_identity_overrides(
-        ctx,
-        org_id=str(uuid4()),
+    validate_execution_identity_overrides(
+        ctx.user,
+        ctx.org_id,
+        requested_org_id=str(uuid4()),
         run_as=str(uuid4()),
     )

--- a/api/tests/unit/routers/test_workflow_delegation_authorization.py
+++ b/api/tests/unit/routers/test_workflow_delegation_authorization.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from src.core.security import ENGINE_USER_ID, decode_token, mint_engine_token
+from src.routers.workflows import _validate_execution_identity_overrides
+
+
+def _context(*, user_id: str, org_id: UUID | None, is_superuser: bool = True):
+    return SimpleNamespace(
+        user=SimpleNamespace(
+            user_id=UUID(user_id),
+            is_superuser=is_superuser,
+        ),
+        org_id=org_id,
+    )
+
+
+def test_engine_token_is_bound_to_parent_execution_org() -> None:
+    org_id = uuid4()
+    token, _ = mint_engine_token(organization_id=str(org_id))
+
+    payload = decode_token(token)
+
+    assert payload is not None
+    assert payload["sub"] == ENGINE_USER_ID
+    assert payload["org_id"] == str(org_id)
+
+
+def test_engine_delegation_allows_only_matching_org() -> None:
+    org_id = uuid4()
+    ctx = _context(user_id=ENGINE_USER_ID, org_id=org_id)
+
+    _validate_execution_identity_overrides(ctx, org_id=str(org_id), run_as=None)
+
+    with pytest.raises(HTTPException, match="cannot override"):
+        _validate_execution_identity_overrides(ctx, org_id=str(uuid4()), run_as=None)
+
+
+def test_engine_delegation_cannot_impersonate_user() -> None:
+    ctx = _context(user_id=ENGINE_USER_ID, org_id=uuid4())
+
+    with pytest.raises(HTTPException, match="cannot override"):
+        _validate_execution_identity_overrides(ctx, org_id=None, run_as=str(uuid4()))
+
+
+def test_platform_admin_api_call_retains_override_access() -> None:
+    ctx = _context(user_id=str(uuid4()), org_id=uuid4(), is_superuser=True)
+
+    _validate_execution_identity_overrides(
+        ctx,
+        org_id=str(uuid4()),
+        run_as=str(uuid4()),
+    )

--- a/api/tests/unit/routers/test_workflows_helpers_coverage.py
+++ b/api/tests/unit/routers/test_workflows_helpers_coverage.py
@@ -283,4 +283,8 @@ async def test_insert_scheduled_execution_persists_expected_execution_fields():
     assert execution.executed_by == executed_by
     assert execution.executed_by_name == "Ada"
     assert execution.form_id == form_id
-    assert execution.execution_context == {"is_platform_admin": True}
+    assert execution.execution_context == {
+        "is_platform_admin": True,
+        "is_provider_org": False,
+        "is_external": False,
+    }

--- a/api/tests/unit/routers/test_workflows_register_validate_coverage.py
+++ b/api/tests/unit/routers/test_workflows_register_validate_coverage.py
@@ -481,6 +481,8 @@ async def test_execute_workflow_runs_as_user_and_publishes_terminal_result() -> 
         name=None,
         email="delegate@example.com",
         is_superuser=False,
+        is_external=False,
+        organization_id=None,
     )
     workflow = _workflow(type="workflow", organization_id=None)
     repo = _WorkflowRepo(workflow=workflow)

--- a/api/tests/unit/services/execution/test_async_executor.py
+++ b/api/tests/unit/services/execution/test_async_executor.py
@@ -52,10 +52,14 @@ async def test_publish_pending_writes_redis_then_publishes():
             api_key_id=None,
             sync=False,
             is_platform_admin=False,
+            is_provider_org=False,
+            is_external=True,
             file_path=None,
         )
 
     redis.set_pending_execution.assert_awaited_once()
+    assert redis.set_pending_execution.await_args.kwargs["is_provider_org"] is False
+    assert redis.set_pending_execution.await_args.kwargs["is_external"] is True
     q.assert_awaited_once_with("e1")
     pub.assert_awaited_once()
     queue_name, message = pub.await_args.args

--- a/api/tests/unit/services/execution/test_worker_telemetry.py
+++ b/api/tests/unit/services/execution/test_worker_telemetry.py
@@ -76,17 +76,23 @@ async def test_run_execution_emits_worker_span(monkeypatch):
         "transient": False,
         "no_cache": False,
         "is_platform_admin": False,
+        "is_provider_org": True,
+        "is_external": False,
     }
 
+    execute = AsyncMock(return_value=result)
     with (
         patch("bifrost.credentials.is_token_expired", return_value=False),
         patch("src.core.module_cache_sync.set_solution_context"),
         patch("src.core.module_cache_sync.clear_solution_context"),
-        patch("src.services.execution.engine.execute", new=AsyncMock(return_value=result)),
+        patch("src.services.execution.engine.execute", new=execute),
     ):
         payload = await worker._run_execution("exec-1", context_data)
 
     assert payload["status"] == ExecutionStatus.SUCCESS.value
+    request = execute.await_args.args[0]
+    assert request.is_provider_org is True
+    assert request.is_external is False
     assert len(fake_tracer.spans) == 1
     span = fake_tracer.spans[0]
     assert span.name == "bifrost.worker.execute"

--- a/api/tests/unit/services/file_storage/test_agent_indexer.py
+++ b/api/tests/unit/services/file_storage/test_agent_indexer.py
@@ -78,7 +78,7 @@ tools:
 delegated_agent_ids:
   - {child_id}
   - bad-child
-system_tools: [search]
+system_tools: [search_knowledge, execute_workflow]
 max_iterations: 8
 max_token_budget: 1234
 """.encode()
@@ -101,8 +101,8 @@ max_token_budget: 1234
     assert db.execute.await_count == 5
     upsert = db.execute.await_args_list[0].args[0]
     compiled = upsert.compile()
-    assert compiled.params["system_tools"] != ["search"]
-    assert "system_tools" not in str(upsert).split("DO UPDATE SET", maxsplit=1)[1]
+    assert compiled.params["system_tools"] == ["search_knowledge"]
+    assert "system_tools" in str(upsert).split("DO UPDATE SET", maxsplit=1)[1]
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/file_storage/test_agent_indexer.py
+++ b/api/tests/unit/services/file_storage/test_agent_indexer.py
@@ -99,6 +99,10 @@ max_token_budget: 1234
     assert added_delegations[0].parent_agent_id == agent_id
     assert added_delegations[0].child_agent_id == child_id
     assert db.execute.await_count == 5
+    upsert = db.execute.await_args_list[0].args[0]
+    compiled = upsert.compile()
+    assert compiled.params["system_tools"] != ["search"]
+    assert "system_tools" not in str(upsert).split("DO UPDATE SET", maxsplit=1)[1]
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/mcp_server/test_middleware.py
+++ b/api/tests/unit/services/mcp_server/test_middleware.py
@@ -221,6 +221,26 @@ class TestOnCallTool:
         call_next.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_non_admin_platform_tool_is_denied_before_agent_lookup(
+        self, mock_context, mock_access_token
+    ):
+        from src.services.mcp_server.middleware import ToolFilterMiddleware
+
+        middleware = ToolFilterMiddleware()
+        mock_context.message.name = "list_organizations"
+        call_next = AsyncMock()
+        token = mock_access_token(is_superuser=False)
+
+        with patch(
+            "src.services.mcp_server.middleware.get_access_token",
+            return_value=token,
+        ):
+            with pytest.raises(Exception, match="Access denied"):
+                await middleware.on_call_tool(mock_context, call_next)
+
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_allows_authorized_tool_call(
         self, mock_context, mock_access_token, mock_tool_info
     ):

--- a/api/tests/unit/services/mcp_server/test_tool_access.py
+++ b/api/tests/unit/services/mcp_server/test_tool_access.py
@@ -363,6 +363,63 @@ class TestGetAccessibleTools:
         assert tool_ids == {"execute_workflow", "list_workflows"}
 
     @pytest.mark.asyncio
+    async def test_non_admin_cannot_receive_platform_admin_system_tools(
+        self, service, mock_session, mock_agent
+    ):
+        agent = mock_agent(
+            access_level=AgentAccessLevel.AUTHENTICATED,
+            system_tools=["list_organizations", "search_knowledge"],
+        )
+        mock_session.execute = AsyncMock(return_value=mock_query_result([agent]))
+
+        with patch.object(
+            service, "_apply_config_filters", side_effect=lambda tools, _config: tools
+        ):
+            with patch(
+                "src.services.mcp_server.tool_access.MCPConfigService"
+            ) as mock_config_service:
+                mock_config_service.return_value.get_config = AsyncMock(
+                    return_value=MagicMock()
+                )
+                result = await service.get_accessible_tools(
+                    user_roles=[],
+                    is_superuser=False,
+                )
+
+        assert {tool.id for tool in result.tools} == {"search_knowledge"}
+
+    @pytest.mark.asyncio
+    async def test_agent_scope_filters_platform_admin_system_tools(
+        self, service, mock_session, mock_agent
+    ):
+        agent = mock_agent(
+            access_level=AgentAccessLevel.AUTHENTICATED,
+            system_tools=["list_organizations", "search_knowledge"],
+        )
+        agent.system_prompt = "Search only"
+        result = MagicMock()
+        result.scalars.return_value.unique.return_value.first.return_value = agent
+        mock_session.execute = AsyncMock(return_value=result)
+
+        with patch.object(
+            service, "_apply_config_filters", side_effect=lambda tools, _config: tools
+        ):
+            with patch(
+                "src.services.mcp_server.tool_access.MCPConfigService"
+            ) as mock_config_service:
+                mock_config_service.return_value.get_config = AsyncMock(
+                    return_value=MagicMock()
+                )
+                scoped = await service.get_tools_for_agent(
+                    agent_id=agent.id,
+                    user_roles=[],
+                    is_superuser=False,
+                )
+
+        assert scoped is not None
+        assert {tool.id for tool in scoped.tools} == {"search_knowledge"}
+
+    @pytest.mark.asyncio
     async def test_collects_workflow_tools_from_agents(self, service, mock_session, mock_agent, mock_workflow):
         """Should collect workflow tools from accessible agents."""
         workflow = mock_workflow(name="my_workflow", description="My workflow tool")

--- a/api/tests/unit/services/test_mcp_agent_scope.py
+++ b/api/tests/unit/services/test_mcp_agent_scope.py
@@ -167,11 +167,10 @@ class TestGetToolsForAgent:
         assert result.agent_name == "Test Agent"
         assert result.system_prompt == "You are a helpful assistant."
         assert result.accessible_namespaces == ["docs", "wiki"]
-        # execute_workflow and list_workflows from system_tools, plus
-        # search_knowledge auto-injected because knowledge_sources is non-empty
-        # (mirrors the native chat path in agent_helpers.py).
+        # Admin-only system tools are filtered for non-superusers;
+        # search_knowledge is auto-injected because knowledge sources exist.
         tool_ids = {t.id for t in result.tools}
-        assert tool_ids == {"execute_workflow", "list_workflows", "search_knowledge"}
+        assert tool_ids == {"search_knowledge"}
 
     @pytest.mark.asyncio
     async def test_returns_none_for_nonexistent_agent(self):

--- a/api/tests/unit/test_cli_files.py
+++ b/api/tests/unit/test_cli_files.py
@@ -104,9 +104,17 @@ class TestWrite:
         assert result.exit_code == 0, result.output
         assert captured["calls"][0]["body"]["content"] == "from-stdin\n"
 
-    def test_writes_from_file_flag(self, tmp_path) -> None:
+    def test_writes_from_file_flag(self, tmp_path, monkeypatch) -> None:
         local = tmp_path / "local.txt"
-        local.write_text("local-content")
+        local.write_text("local-content ⚠️", encoding="utf-8")
+        original_read_text = pathlib.Path.read_text
+        observed: dict[str, str | None] = {}
+
+        def read_text(path, *, encoding=None, errors=None):
+            observed["encoding"] = encoding
+            return original_read_text(path, encoding=encoding, errors=errors)
+
+        monkeypatch.setattr(pathlib.Path, "read_text", read_text)
         captured: dict = {}
         result = _invoke(
             ["write", "out.txt", "--from-file", str(local)],
@@ -114,7 +122,8 @@ class TestWrite:
             {"/api/files/write": {}},
         )
         assert result.exit_code == 0, result.output
-        assert captured["calls"][0]["body"]["content"] == "local-content"
+        assert observed["encoding"] == "utf-8"
+        assert captured["calls"][0]["body"]["content"] == "local-content ⚠️"
 
     def test_rejects_multiple_content_sources(self, tmp_path) -> None:
         local = tmp_path / "y.txt"

--- a/api/tests/unit/test_execution_context.py
+++ b/api/tests/unit/test_execution_context.py
@@ -15,6 +15,8 @@ class TestToPublicDict:
             is_platform_admin=True,
             is_function_key=False,
             execution_id="exec-789",
+            is_provider_org=True,
+            is_external=True,
             workflow_name="my_workflow",
             is_agent=False,
             public_url="https://bifrost.example.com",
@@ -31,6 +33,8 @@ class TestToPublicDict:
         assert result["organization"] == {"id": "org-456", "name": "Acme Corp", "is_active": True, "is_provider": False}
         assert result["is_platform_admin"] is True
         assert result["is_function_key"] is False
+        assert result["is_provider_org"] is True
+        assert result["is_external"] is True
         assert result["execution_id"] == "exec-789"
         assert result["workflow_name"] == "my_workflow"
         assert result["is_agent"] is False
@@ -132,6 +136,8 @@ class TestCLIPlatformParity:
             is_platform_admin=user_info.get("is_superuser", False),
             is_function_key=False,
             execution_id=f"standalone-{uuid.uuid4()}",
+            is_provider_org=user_info.get("is_provider_org", False),
+            is_external=user_info.get("is_external", False),
             workflow_name=workflow_name,
         )
 
@@ -142,6 +148,8 @@ class TestCLIPlatformParity:
         name: str,
         is_superuser: bool,
         org: Organization | None,
+        is_provider_org: bool = False,
+        is_external: bool = False,
         workflow_name: str = "test_workflow",
     ) -> ExecutionContext:
         """Simulate what execute() does in engine.py lines 278-291."""
@@ -154,6 +162,8 @@ class TestCLIPlatformParity:
             is_platform_admin=is_superuser,
             is_function_key=False,
             execution_id="engine-exec-123",
+            is_provider_org=is_provider_org,
+            is_external=is_external,
             workflow_name=workflow_name,
             public_url="http://localhost:8000",
         )
@@ -250,6 +260,8 @@ class TestCLIPlatformParity:
                 "email": "provider@test.com",
                 "name": "Provider Admin",
                 "is_superuser": True,
+                "is_provider_org": True,
+                "is_external": False,
             },
             "organization": {
                 "id": "org-prov",
@@ -272,6 +284,7 @@ class TestCLIPlatformParity:
             name="Provider Admin",
             is_superuser=True,
             org=org,
+            is_provider_org=True,
         )
 
         assert cli_ctx.organization is not None

--- a/api/tests/unit/test_resolve_scope_sdk.py
+++ b/api/tests/unit/test_resolve_scope_sdk.py
@@ -52,6 +52,7 @@ def _make_ctx(
         is_platform_admin=is_platform_admin,
         is_function_key=False,
         execution_id="00000000-0000-0000-0000-000000000111",
+        is_provider_org=is_provider,
         workflow_name="wf",
         public_url="http://localhost",
     )

--- a/api/tests/unit/test_scope_override.py
+++ b/api/tests/unit/test_scope_override.py
@@ -22,6 +22,7 @@ class TestSetScope:
             is_platform_admin=False,
             is_function_key=False,
             execution_id="exec-1",
+            is_provider_org=is_provider,
         )
 
     def test_provider_can_override_scope(self):
@@ -67,6 +68,7 @@ class TestSetScope:
             is_platform_admin=True,
             is_function_key=False,
             execution_id="exec-1",
+            is_provider_org=False,
         )
         ctx.set_scope("org-2")
         assert ctx.org_id == "org-2"
@@ -86,6 +88,7 @@ class TestSetScope:
             is_platform_admin=False,
             is_function_key=False,
             execution_id="exec-1",
+            is_provider_org=False,
         )
         with pytest.raises(PermissionError):
             ctx.set_scope("org-2")
@@ -114,6 +117,7 @@ class TestResolveScope:
             is_platform_admin=False,
             is_function_key=False,
             execution_id="exec-1",
+            is_provider_org=is_provider,
         )
 
     def test_none_returns_default(self):


### PR DESCRIPTION
Closes Codex Cloud Security findings fd65d90855548191a6655814d16fb087, 629e5831008481919bafcc267408b4bc, and 2e9807b8f2948191994f80957598f211.

- Filters platform-admin-only tools from agent YAML imports while preserving portable safe tools.
- Carries the original caller through explicitly marked engine tokens, binds delegation to the parent organization, blocks identity overrides, and uses the caller for workflow authorization and audit identity.
- Recognizes pre-marker engine tokens fail-closed without confusing HMAC-authorized embed sessions that share the sentinel subject ID.
- Enforces platform-admin-only MCP tools during discovery, agent-scoped listing, and direct execution.
- Makes CLI file uploads explicitly UTF-8 so Windows operators can prove exact Git/live parity.

Verification: Ruff clean; focused authorization, agent-indexing, MCP access/middleware, CLI, and auth tests pass. Full CI is the merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegated workflow execution now preserves the originating organization and caller identity for consistent authorization.
  * Workflow execution context now carries provider/org and external-call flags for downstream scoping.
  * Platform-admin system tools are hidden from standard tool listings for non-superusers.
* **Security / Access Controls**
  * Stricter enforcement for identity overrides and impersonation during workflow execution.
  * Invalid delegated authentication details are rejected safely, and platform-admin tools are denied to unauthorized callers.
* **Bug Fixes**
  * CLI file uploads now reliably read UTF-8 content (including non-ASCII characters).
* **Tests**
  * Added unit test coverage for delegation and tool-scoping rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->