### PR TITLE
fix(api): single-flight SDK fingerprint builds

### DIFF
--- a/api/src/routers/version.py
+++ b/api/src/routers/version.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import threading
 
 from fastapi import APIRouter
 from pydantic import BaseModel
@@ -11,6 +12,10 @@ from src.services.sdk_package import sdk_contract_version, sdk_fingerprint
 router = APIRouter(prefix="/api/version", tags=["version"])
 
 logger = logging.getLogger(__name__)
+
+_SDK_FINGERPRINT_UNSET = object()
+_sdk_fingerprint_value: str | object = _SDK_FINGERPRINT_UNSET
+_sdk_fingerprint_lock = threading.Lock()
 
 
 class VersionResponse(BaseModel):
@@ -32,11 +37,23 @@ def get_sdk_fingerprint() -> str:
     the same way, and the exception is logged so the underlying cause is
     still visible.
     """
-    try:
-        return sdk_fingerprint(get_version())
-    except Exception:  # noqa: BLE001 - build-toolchain failure must degrade, not 500 /api/version; logged below
-        logger.exception("failed to compute SDK fingerprint")
-        return "unavailable"
+    global _sdk_fingerprint_value
+
+    if _sdk_fingerprint_value is not _SDK_FINGERPRINT_UNSET:
+        return str(_sdk_fingerprint_value)
+
+    # functools.lru_cache does not coalesce concurrent misses and does not
+    # cache failures. Keep the expensive Node/esbuild cold path single-flight
+    # and memoize its degraded result for the lifetime of this API process.
+    with _sdk_fingerprint_lock:
+        if _sdk_fingerprint_value is not _SDK_FINGERPRINT_UNSET:
+            return str(_sdk_fingerprint_value)
+        try:
+            _sdk_fingerprint_value = sdk_fingerprint(get_version())
+        except Exception:  # noqa: BLE001 - build-toolchain failure must degrade, not 500 /api/version; logged below
+            logger.exception("failed to compute SDK fingerprint")
+            _sdk_fingerprint_value = "unavailable"
+        return str(_sdk_fingerprint_value)
 
 
 @router.get("", response_model=VersionResponse)

--- a/api/tests/unit/test_version_endpoint.py
+++ b/api/tests/unit/test_version_endpoint.py
@@ -7,6 +7,9 @@ source of truth.
 
 from __future__ import annotations
 
+import concurrent.futures
+import time
+
 import pytest
 
 from shared.contract_version import CONTRACT_VERSION
@@ -21,3 +24,42 @@ async def test_version_endpoint_reports_contract_version() -> None:
     assert result.contract_version == CONTRACT_VERSION
     # The build version string is still present (unchanged behavior).
     assert isinstance(result.version, str)
+
+
+def test_sdk_fingerprint_cold_build_is_single_flight(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.routers import version
+
+    calls = 0
+
+    def build(_version: str) -> str:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.05)
+        return "fingerprint"
+
+    monkeypatch.setattr(version, "_sdk_fingerprint_value", version._SDK_FINGERPRINT_UNSET)
+    monkeypatch.setattr(version, "sdk_fingerprint", build)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: version.get_sdk_fingerprint(), range(8)))
+
+    assert results == ["fingerprint"] * 8
+    assert calls == 1
+
+
+def test_sdk_fingerprint_failure_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.routers import version
+
+    calls = 0
+
+    def fail(_version: str) -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("broken toolchain")
+
+    monkeypatch.setattr(version, "_sdk_fingerprint_value", version._SDK_FINGERPRINT_UNSET)
+    monkeypatch.setattr(version, "sdk_fingerprint", fail)
+
+    assert version.get_sdk_fingerprint() == "unavailable"
+    assert version.get_sdk_fingerprint() == "unavailable"
+    assert calls == 1


### PR DESCRIPTION
## Summary
- serialize the public SDK fingerprint cold build
- cache both success and degraded failure outcomes per API process
- cover concurrent cold requests and persistent toolchain failure

## Cloud Security finding
- 1d983e2596348191a481d951d80b0734

## Verification
- pytest -q api/tests/unit/test_version_endpoint.py: 3 passed