### PR TITLE
fix(security): prevent secret-bearing execution-variable persistence

### DIFF
--- a/api/src/core/execution_variable_safety.py
+++ b/api/src/core/execution_variable_safety.py
@@ -43,7 +43,7 @@ _SCRIPT_CONTENT_PATTERNS = (
     re.compile(r"(?m)^\s*(?:import|from)\s+[A-Za-z_]"),
     re.compile(r"(?m)^\s*(?:CREATE\s+LOGIN|ALTER\s+SERVER\s+ROLE)\b", re.IGNORECASE),
     re.compile(r"\$(?:ErrorActionPreference|ProgressPreference)\b", re.IGNORECASE),
-    re.compile(r"\b(?:ConvertFrom-Base64String|Invoke-[A-Za-z]+|New-Object)\b", re.IGNORECASE),
+    re.compile(r"\b(?:ConvertFrom-Base64String|Invoke-[a-z]+|New-Object)\b", re.IGNORECASE),
 )
 
 
@@ -56,9 +56,10 @@ def _key_tokens(key: Any) -> set[str]:
 
 def _is_sensitive_key(key: Any) -> bool:
     tokens = _key_tokens(key)
+    compact_key = "".join(re.findall(r"[A-Za-z0-9]+", str(key))).casefold()
     return bool(
         tokens & _SENSITIVE_KEY_TOKENS
-        or tokens & _SENSITIVE_COMPACT_KEYS
+        or compact_key in _SENSITIVE_COMPACT_KEYS
     )
 
 

--- a/api/src/core/execution_variable_safety.py
+++ b/api/src/core/execution_variable_safety.py
@@ -44,6 +44,9 @@ _SCRIPT_CONTENT_PATTERNS = (
     re.compile(r"(?m)^\s*(?:CREATE\s+LOGIN|ALTER\s+SERVER\s+ROLE)\b", re.IGNORECASE),
     re.compile(r"\$(?:ErrorActionPreference|ProgressPreference)\b", re.IGNORECASE),
     re.compile(r"\b(?:ConvertFrom-Base64String|Invoke-[a-z]+|New-Object)\b", re.IGNORECASE),
+    re.compile(
+        r"(?im)^\s*(?:curl|wget|pwsh|powershell|bash|sh|cmd(?:\.exe)?|python(?:3)?)\b"
+    ),
 )
 
 
@@ -68,26 +71,39 @@ def _looks_like_script(value: str) -> bool:
     return any(pattern.search(value) for pattern in _SCRIPT_CONTENT_PATTERNS)
 
 
-def sanitize_execution_variables(value: Any) -> Any:
-    """Remove secret-bearing/script content before execution-history persistence.
-
-    Variable names remain available for debugging, but values under sensitive
-    names and executable text are replaced. The traversal is recursive so a
-    script cannot bypass the boundary by being nested in a payload container.
-    """
+def _sanitize_execution_variables(value: Any, active_container_ids: set[int]) -> Any:
+    """Recursively sanitize one value while rejecting active-path cycles."""
     if isinstance(value, SecretString):
         return REDACTED
-    if isinstance(value, dict):
-        return {
-            key: REDACTED if _is_sensitive_key(key) else sanitize_execution_variables(item)
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [sanitize_execution_variables(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(sanitize_execution_variables(item) for item in value)
-    if isinstance(value, set):
-        return {sanitize_execution_variables(item) for item in value}
+    if isinstance(value, (dict, list, tuple, set)):
+        container_id = id(value)
+        if container_id in active_container_ids:
+            return REDACTED
+        active_container_ids.add(container_id)
+        try:
+            if isinstance(value, dict):
+                return {
+                    key: REDACTED
+                    if _is_sensitive_key(key)
+                    else _sanitize_execution_variables(item, active_container_ids)
+                    for key, item in value.items()
+                }
+            if isinstance(value, list):
+                return [
+                    _sanitize_execution_variables(item, active_container_ids)
+                    for item in value
+                ]
+            if isinstance(value, tuple):
+                return tuple(
+                    _sanitize_execution_variables(item, active_container_ids)
+                    for item in value
+                )
+            return {
+                _sanitize_execution_variables(item, active_container_ids)
+                for item in value
+            }
+        finally:
+            active_container_ids.remove(container_id)
     if isinstance(value, (bytes, bytearray, memoryview)):
         return REDACTED
     if isinstance(value, str) and _looks_like_script(value):
@@ -95,3 +111,13 @@ def sanitize_execution_variables(value: Any) -> Any:
     if not isinstance(value, (str, int, float, bool, type(None))):
         return f"<{type(value).__name__}>"
     return value
+
+
+def sanitize_execution_variables(value: Any) -> Any:
+    """Remove secret-bearing/script content before execution-history persistence.
+
+    Variable names remain available for debugging, but values under sensitive
+    names and executable text are replaced. The traversal is recursive so a
+    script cannot bypass the boundary by being nested in a payload container.
+    """
+    return _sanitize_execution_variables(value, set())

--- a/api/src/core/execution_variable_safety.py
+++ b/api/src/core/execution_variable_safety.py
@@ -1,0 +1,96 @@
+"""Fail-closed sanitization for durably persisted execution variables."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from src.core.secret_string import REDACTED, SecretString
+
+
+_SENSITIVE_KEY_TOKENS = frozenset(
+    {
+        "authorization",
+        "command",
+        "cookie",
+        "credential",
+        "password",
+        "passwd",
+        "powershell",
+        "privatekey",
+        "script",
+        "secret",
+        "token",
+    }
+)
+_SENSITIVE_COMPACT_KEYS = frozenset(
+    {
+        "apikey",
+        "clientsecret",
+        "code",
+        "connectionstring",
+        "privatekey",
+        "powershellcode",
+        "pythoncode",
+        "scriptcode",
+        "sourcecode",
+    }
+)
+
+_SCRIPT_CONTENT_PATTERNS = (
+    re.compile(r"(?m)^\s*#!"),
+    re.compile(r"(?m)^\s*(?:async\s+)?def\s+\w+\s*\("),
+    re.compile(r"(?m)^\s*(?:import|from)\s+[A-Za-z_]"),
+    re.compile(r"(?m)^\s*(?:CREATE\s+LOGIN|ALTER\s+SERVER\s+ROLE)\b", re.IGNORECASE),
+    re.compile(r"\$(?:ErrorActionPreference|ProgressPreference)\b", re.IGNORECASE),
+    re.compile(r"\b(?:ConvertFrom-Base64String|Invoke-[A-Za-z]+|New-Object)\b", re.IGNORECASE),
+)
+
+
+def _key_tokens(key: Any) -> set[str]:
+    """Split snake/kebab/camel keys without substring false positives."""
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", str(key))
+    parts = re.findall(r"[A-Za-z0-9]+", text.casefold())
+    return set(parts) | ({"".join(parts)} if parts else set())
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    tokens = _key_tokens(key)
+    return bool(
+        tokens & _SENSITIVE_KEY_TOKENS
+        or tokens & _SENSITIVE_COMPACT_KEYS
+    )
+
+
+def _looks_like_script(value: str) -> bool:
+    """Conservatively recognize executable text even under a generic key."""
+    return any(pattern.search(value) for pattern in _SCRIPT_CONTENT_PATTERNS)
+
+
+def sanitize_execution_variables(value: Any) -> Any:
+    """Remove secret-bearing/script content before execution-history persistence.
+
+    Variable names remain available for debugging, but values under sensitive
+    names and executable text are replaced. The traversal is recursive so a
+    script cannot bypass the boundary by being nested in a payload container.
+    """
+    if isinstance(value, SecretString):
+        return REDACTED
+    if isinstance(value, dict):
+        return {
+            key: REDACTED if _is_sensitive_key(key) else sanitize_execution_variables(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [sanitize_execution_variables(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_execution_variables(item) for item in value)
+    if isinstance(value, set):
+        return {sanitize_execution_variables(item) for item in value}
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return REDACTED
+    if isinstance(value, str) and _looks_like_script(value):
+        return REDACTED
+    if not isinstance(value, (str, int, float, bool, type(None))):
+        return f"<{type(value).__name__}>"
+    return value

--- a/api/src/repositories/executions.py
+++ b/api/src/repositories/executions.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.principal import UserPrincipal
+from src.core.execution_variable_safety import sanitize_execution_variables
 from src.core.log_safety import log_safe
 from src.models import (
     AIUsage,
@@ -235,7 +236,9 @@ class ExecutionRepository(BaseRepository[Execution]):
             update_values["completed_at"] = datetime.now(timezone.utc)
 
         if variables is not None:
-            update_values["variables"] = _make_json_safe(variables)
+            update_values["variables"] = _make_json_safe(
+                sanitize_execution_variables(variables)
+            )
 
         if execution_context is not None:
             update_values["execution_context"] = _make_json_safe(execution_context)

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -25,6 +25,7 @@ from src.sdk.error_handling import WorkflowError
 from src.sdk.errors import UserError, WorkflowExecutionException
 from src.models.enums import ExecutionStatus
 from src.core.cache import get_cached_data_provider, cache_data_provider_result
+from src.core.execution_variable_safety import sanitize_execution_variables
 from src.core.secret_string import redact_secrets
 
 logger = logging.getLogger(__name__)
@@ -249,12 +250,17 @@ def _scrub_outputs(
     error_message: str | None = None,
 ) -> tuple[Any, dict[str, Any] | None, list[dict[str, Any]] | None, str | None]:
     """Scrub secret values from execution outputs before returning."""
+    safe_variables = (
+        sanitize_execution_variables(variables) if variables is not None else None
+    )
     secret_values = context._collect_secret_values()
     if not secret_values:
-        return result, variables, logs, error_message
+        return result, safe_variables, logs, error_message
     return (
         redact_secrets(result, secret_values) if result is not None else None,
-        redact_secrets(variables, secret_values) if variables is not None else None,
+        redact_secrets(safe_variables, secret_values)
+        if safe_variables is not None
+        else None,
         redact_secrets(logs, secret_values) if logs is not None else None,
         redact_secrets(error_message, secret_values) if error_message is not None else None,
     )

--- a/api/tests/unit/core/test_execution_variable_safety.py
+++ b/api/tests/unit/core/test_execution_variable_safety.py
@@ -70,3 +70,30 @@ def test_description_is_not_misclassified_as_script() -> None:
         "description": "safe",
         "status_code": 200,
     }
+
+
+def test_authorization_code_remains_sensitive() -> None:
+    assert sanitize_execution_variables(
+        {"authorization_code": SYNTHETIC_CREDENTIAL_MARKER}
+    ) == {"authorization_code": REDACTED}
+
+
+def test_nested_container_and_opaque_values_fail_safe() -> None:
+    class OpaqueValue:
+        pass
+
+    sanitized = sanitize_execution_variables(
+        {
+            "tuple_value": ("safe",),
+            "set_value": {7},
+            "binary_value": b"not-persisted",
+            "opaque_value": OpaqueValue(),
+        }
+    )
+
+    assert sanitized == {
+        "tuple_value": ("safe",),
+        "set_value": {7},
+        "binary_value": REDACTED,
+        "opaque_value": "<OpaqueValue>",
+    }

--- a/api/tests/unit/core/test_execution_variable_safety.py
+++ b/api/tests/unit/core/test_execution_variable_safety.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+from src.core.execution_variable_safety import sanitize_execution_variables
+from src.core.secret_string import REDACTED, SecretString
+
+
+SYNTHETIC_SCRIPT_MARKER = "SYNTHETIC_EXECUTION_SCRIPT_MARKER"
+SYNTHETIC_CREDENTIAL_MARKER = "SYNTHETIC_CREDENTIAL_MARKER"
+
+
+def test_sensitive_variable_names_are_redacted_recursively() -> None:
+    variables = {
+        "status": "safe",
+        "script": SYNTHETIC_SCRIPT_MARKER,
+        "nested": {
+            "clientSecret": SYNTHETIC_CREDENTIAL_MARKER,
+            "description": "safe description",
+        },
+        "items": [{"powerShellScript": SYNTHETIC_SCRIPT_MARKER}],
+    }
+
+    sanitized = sanitize_execution_variables(variables)
+
+    assert sanitized == {
+        "status": "safe",
+        "script": REDACTED,
+        "nested": {
+            "clientSecret": REDACTED,
+            "description": "safe description",
+        },
+        "items": [{"powerShellScript": REDACTED}],
+    }
+    serialized = json.dumps(sanitized)
+    assert SYNTHETIC_SCRIPT_MARKER not in serialized
+    assert SYNTHETIC_CREDENTIAL_MARKER not in serialized
+
+
+def test_executable_text_is_redacted_under_a_generic_container() -> None:
+    generated = f"$ErrorActionPreference = 'Stop'\nWrite-Output '{SYNTHETIC_SCRIPT_MARKER}'"
+
+    sanitized = sanitize_execution_variables({"payload": [generated]})
+
+    assert sanitized == {"payload": [REDACTED]}
+    assert SYNTHETIC_SCRIPT_MARKER not in json.dumps(sanitized)
+
+
+def test_single_line_command_is_redacted_under_a_generic_container() -> None:
+    generated = f"Invoke-Expression '{SYNTHETIC_SCRIPT_MARKER}'"
+
+    assert sanitize_execution_variables({"payload": generated}) == {
+        "payload": REDACTED
+    }
+
+
+def test_secret_string_is_redacted_without_plaintext_recovery() -> None:
+    sanitized = sanitize_execution_variables(
+        {"value": SecretString(SYNTHETIC_CREDENTIAL_MARKER)}
+    )
+
+    assert sanitized == {"value": REDACTED}
+    assert SYNTHETIC_CREDENTIAL_MARKER not in json.dumps(sanitized)
+
+
+def test_description_is_not_misclassified_as_script() -> None:
+    assert sanitize_execution_variables(
+        {"description": "safe", "status_code": 200}
+    ) == {
+        "description": "safe",
+        "status_code": 200,
+    }

--- a/api/tests/unit/core/test_execution_variable_safety.py
+++ b/api/tests/unit/core/test_execution_variable_safety.py
@@ -54,6 +54,18 @@ def test_single_line_command_is_redacted_under_a_generic_container() -> None:
     }
 
 
+def test_shell_command_with_synthetic_authorization_is_redacted() -> None:
+    generated = (
+        "curl https://example.invalid -H "
+        f"'Authorization: Bearer {SYNTHETIC_CREDENTIAL_MARKER}'"
+    )
+
+    sanitized = sanitize_execution_variables({"payload": generated})
+
+    assert sanitized == {"payload": REDACTED}
+    assert SYNTHETIC_CREDENTIAL_MARKER not in json.dumps(sanitized)
+
+
 def test_secret_string_is_redacted_without_plaintext_recovery() -> None:
     sanitized = sanitize_execution_variables(
         {"value": SecretString(SYNTHETIC_CREDENTIAL_MARKER)}
@@ -96,4 +108,22 @@ def test_nested_container_and_opaque_values_fail_safe() -> None:
         "set_value": {7},
         "binary_value": REDACTED,
         "opaque_value": "<OpaqueValue>",
+    }
+
+
+def test_container_cycles_are_redacted_without_rejecting_shared_values() -> None:
+    cyclic: dict[str, object] = {}
+    cyclic["self"] = cyclic
+    shared = {"description": "safe"}
+
+    sanitized = sanitize_execution_variables(
+        {"cyclic": cyclic, "shared_values": [shared, shared]}
+    )
+
+    assert sanitized == {
+        "cyclic": {"self": REDACTED},
+        "shared_values": [
+            {"description": "safe"},
+            {"description": "safe"},
+        ],
     }

--- a/api/tests/unit/repositories/test_executions.py
+++ b/api/tests/unit/repositories/test_executions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -237,6 +238,45 @@ async def test_update_execution_sets_result_type_metrics_economics_and_logs() ->
     assert first_log.log_metadata == {"step": 1}
     assert second_log.sequence == 1
     session.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_execution_redacts_generated_script_before_persistence() -> None:
+    marker = "SYNTHETIC_EXECUTION_SCRIPT_MARKER"
+    session = AsyncMock()
+    session.add = MagicMock()
+    repo = ExecutionRepository(session)
+
+    await repo.update_execution(
+        execution_id=str(uuid4()),
+        status=ExecutionStatus.SUCCESS,
+        variables={
+            "script": marker,
+            "nested": {
+                "credential": "SYNTHETIC_CREDENTIAL_MARKER",
+                "status": "safe",
+            },
+        },
+    )
+
+    statement = session.execute.await_args.args[0]
+    persisted = statement.compile().params["variables"]
+    assert persisted == {
+        "script": "[REDACTED]",
+        "nested": {"credential": "[REDACTED]", "status": "safe"},
+    }
+    serialized = json.dumps(persisted)
+    assert marker not in serialized
+    assert "SYNTHETIC_CREDENTIAL_MARKER" not in serialized
+
+    raw_admin = repo._to_pydantic(
+        _execution(variables=persisted),
+        _user(is_superuser=True),
+    )
+    admin_serialized = json.dumps(raw_admin.variables)
+    assert raw_admin.variables == persisted
+    assert marker not in admin_serialized
+    assert "SYNTHETIC_CREDENTIAL_MARKER" not in admin_serialized
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/execution/test_engine_helpers.py
+++ b/api/tests/unit/services/execution/test_engine_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -62,6 +63,28 @@ def test_scrub_outputs_redacts_context_secret_values():
     assert variables == {"seen": "[REDACTED]"}
     assert logs == [{"message": "used [REDACTED]"}]
     assert error == "failed with [REDACTED]"
+
+
+def test_scrub_outputs_redacts_generated_scripts_without_registered_secrets():
+    context = ExecutionContext(
+        execution_id="exec-1",
+        user_id="user-1",
+        email="user@example.com",
+        name="User One",
+        scope="org-1",
+        organization=Organization(id="org-1", name="Org One"),
+        is_platform_admin=False,
+        is_function_key=False,
+    )
+    marker = "SYNTHETIC_EXECUTION_SCRIPT_MARKER"
+
+    _, variables, _, _ = engine._scrub_outputs(
+        context,
+        variables={"script": marker, "status": "safe"},
+    )
+
+    assert variables == {"script": "[REDACTED]", "status": "safe"}
+    assert marker not in json.dumps(variables)
 
 
 def test_build_cached_result_normalizes_expiry_and_marks_cached():

--- a/docs/security/execution-variable-secret-persistence-2026-07-22.md
+++ b/docs/security/execution-variable-secret-persistence-2026-07-22.md
@@ -35,21 +35,14 @@ admin-readback shape cannot recover the markers.
 
 ## Affected active records
 
-Metadata-only queries found 11 successful executions. No affected parameters,
-results, variables, or log payloads were opened during the inventory.
+Metadata-only queries found 11 successful executions spanning 2026-07-11
+through 2026-07-22. No affected parameters, results, variables, or log payloads
+were opened during the inventory.
 
-| Customer / device / SQL instance | Execution IDs |
-| --- | --- |
-| Dr. Dayton Dawson DDS / Ninja 2870 `SERVER` / `SIDEXIS_SQL` | `9df9b93e-1432-4204-b074-a32a30e0b2f2` |
-| Dr. Jimmy Lutz DDS / Ninja 1322 `SERVER` / `SIDEXIS_SQL` | `499c891a-8306-47c1-a1fd-a340916ea485`, `8f63976c-06c6-40ee-a5f4-6d4fd5856178`, `2360bcda-790d-4696-9541-2aabd8087812` |
-| Blue River Dental Care / Ninja 836 `HIGHSERVER1` / `SIDEXIS_SQL` | `6c661b9a-f1aa-4b39-b374-de6664850c2b`, `3c8a9608-7e58-4735-9aaf-3a10d3e4ccba`, `24b0ecb1-19f5-4cac-a913-291990199f4c` |
-| Generations in Dentistry / Ninja 1021 `DEDICATED2` / `SIDEXIS_SQL` | `3388e4e2-4a49-4646-9885-abfdc6d63619`, `273cbbce-bd20-45fa-995f-519af1d5607c`, `591c5ea7-5974-442e-a565-defdcb619c98` |
-| Aspen Dental Group / Ninja 289 `DATASERVER` / `SIDEXIS_SQL` | `6c029e48-5516-4729-be2c-023062f1a731` |
-
-The span is 2026-07-11 01:37:11 UTC through 2026-07-22 22:01:47 UTC.
-Ninja 2870 also has `PDATA_SQLEXPRESS`; the durable SQL inventory shows that
-instance separately, and it is not part of this workflow's affected SIDEXIS
-credential lane.
+Customer, endpoint, SQL-instance, and execution-ID mappings are intentionally
+excluded from this repository. The exact list is held in access-controlled
+incident record `P0-BIFROST-EXECVAR-2026-07-22`. That record is the only
+authority for remediation binding and credential-rotation scope.
 
 ## Storage and retention map
 
@@ -60,7 +53,7 @@ This is a 2026-07-22 metadata-only production snapshot.
 | Primary PostgreSQL | `psql-mtg-bifrost-poc-01`, PostgreSQL 16, primary role, no HA, no read replicas. All 11 rows have non-null `variables` and the affected key. | Exact active rows can be transactionally replaced with a redaction sentinel. |
 | PostgreSQL automated backup/PITR | Seven automatic daily full backups are currently listed, 2026-07-16 through 2026-07-22. Retention is 7 days; geo-redundant backup is disabled. WAL supports PITR inside that window. | Managed snapshots and WAL cannot be surgically edited. A restore to a time before active-row redaction will resurrect the old values. Let them expire naturally, and require the redaction runbook before any restored database is made accessible. |
 | Separate PostgreSQL backup/replica | No Azure PostgreSQL replica, Azure Backup item, Data Protection item, long-term-retention job, or operator-created backup was found. | No separately managed database copy was identified. |
-| Redis execution context | Managed Redis AOF is enabled at one-second frequency; RDB is disabled. Ten IDs had no current key. The latest execution had one `bifrost:exec:{id}:context` key with the source-defined one-hour TTL when inspected. | The live key expires automatically. Managed AOF is resilience storage, not a user-addressable backup or PITR surface; its files cannot be surgically edited. |
+| Redis execution context | Managed Redis AOF is enabled at one-second frequency; RDB is disabled. Ten IDs had no current key. The latest execution had one `bifrost:exec:{id}:context` key with the source-defined one-hour TTL when inspected. | The live key expires automatically, but key expiry alone is not proof that old bytes have been eliminated from provider-managed AOF storage. Azure does not expose AOF files, rewrite timing, or a supported surgical-erasure operation to this operator. Treat historical AOF bytes as provider-controlled until normal rewrite/storage lifecycle completes; obtain Microsoft support confirmation if an elimination attestation is required. No provider-side deletion is currently authorized. |
 | RabbitMQ | All workflow, retry, and poison queues had zero ready, unacknowledged, and total messages. | No queued copy remains. |
 | Kubernetes container logs | Current API logs contained short execution-ID/status lines only; no matching long payload-shaped line was found. Other current app/worker logs had no matches. | Node/container rotation applies. No Azure diagnostic setting exports AKS logs. |
 | OpenTelemetry / Tempo | Trace and log export goes to the in-cluster collector and Tempo. Tempo block retention is 168 hours. Searches for all 11 execution IDs returned zero traces; collector matches were short metadata lines only. | No affected trace was identified. Existing blocks expire at 7 days and are not a surgical record-edit surface. |
@@ -83,10 +76,24 @@ the execution records and all non-variable history.
 
 1. Confirm prevention is deployed and the synthetic canary passes.
 2. Freeze admin read access to the 11 records for the maintenance window.
-3. Open one database transaction and lock exactly the 11 rows by ID and the
-   affected workflow ID. Select counts and booleans only; do not return JSONB.
-4. Require `row_count = 11`, `workflow_count = 11`, and
-   `variables_nonnull_count = 11`. Any mismatch rolls back and stops.
+3. Load the exact 11 UUIDs from access-controlled incident record
+   `P0-BIFROST-EXECVAR-2026-07-22` into an asyncpg `list[UUID]`; do not paste
+   them into shell history. Open one database transaction and lock the rows
+   with this bound query. Select counts and booleans only; do not return JSONB:
+
+   ```sql
+   SELECT id
+   FROM executions
+   WHERE workflow_id = 'a2e75961-9f0e-4a96-9ee5-a9d240cdda08'::uuid
+     AND id = ANY($1::uuid[])
+   ORDER BY id
+   FOR UPDATE;
+   ```
+
+4. Define `matching_row_count` as the number of rows returned by that query.
+   Separately count locked rows with non-null variables. Require
+   `matching_row_count = 11` and `variables_nonnull_count = 11`. Any mismatch
+   rolls back and stops.
 5. Replace the whole `variables` document, rather than trying to find every
    nested secret-bearing local:
 
@@ -96,9 +103,12 @@ the execution records and all non-variable history.
        'redacted', true,
        'reason', 'security_incident_2026_07_22'
    )
-   WHERE workflow_id = 'a2e75961-9f0e-4a96-9ee5-a9d240cdda08'
-     AND id = ANY(:exact_11_execution_ids);
+   WHERE workflow_id = 'a2e75961-9f0e-4a96-9ee5-a9d240cdda08'::uuid
+     AND id = ANY($1::uuid[]);
    ```
+
+   Execute this with asyncpg and bind the same access-controlled `list[UUID]`
+   as parameter `$1`; no manual SQL substitution is permitted.
 
 6. Before commit, verify by count/boolean only that all 11 rows equal the
    sentinel and that no other row changed. Roll back on any contradiction.
@@ -128,9 +138,9 @@ authored source, Git history, execution history, operator notes, or deployment
 logs. Future automation should resolve a per-customer/per-instance record from
 the approved Keeper/IT Glue lane and pass it as an in-memory secret type.
 
-Rotation scope is the five `SIDEXIS_SQL` instances in the affected-record table.
-Do not include Ninja 2870 `PDATA_SQLEXPRESS` without separate evidence that it
-uses the same login.
+Rotation scope is the five `SIDEXIS_SQL` bindings in the access-controlled
+incident record. Do not add any other instance without separate evidence that
+it used the affected credential.
 
 For each instance, strictly one at a time:
 
@@ -181,4 +191,3 @@ Required communication:
    of broader backup destruction/retention changes.
 4. Approve the five-site credential rotation and customer/vendor communication
    windows.
-

--- a/docs/security/execution-variable-secret-persistence-2026-07-22.md
+++ b/docs/security/execution-variable-secret-persistence-2026-07-22.md
@@ -1,0 +1,184 @@
+# Execution-variable secret persistence incident (2026-07-22)
+
+## Status
+
+- Severity: P0
+- Endpoint rollout: paused
+- Affected workflow: `a2e75961-9f0e-4a96-9ee5-a9d240cdda08`
+- Prevention: implemented in PR #477; deployment proof pending
+- Existing history remediation: not authorized
+- SIDEXIS credential rotation: not authorized
+
+This note contains identifiers and metadata only. It intentionally excludes
+execution parameters, results, variables, generated scripts, credentials,
+connection strings, and authentication material.
+
+## Summary
+
+The execution engine captures workflow locals for operator diagnostics. Before
+this repair, those locals were scrubbed only against secrets dynamically
+registered in the execution context. A locally composed endpoint script could
+therefore pass through the worker result and repository unchanged and be stored
+in PostgreSQL `executions.variables` JSONB. Platform-admin execution readback
+then returned the stored variables.
+
+The repair adds two independent pre-persistence boundaries:
+
+1. sanitize captured variables before the worker/Redis result handoff; and
+2. sanitize again in the execution repository immediately before JSON
+   serialization and the PostgreSQL update.
+
+The sanitizer recursively redacts secret-bearing names, executable text,
+`SecretString` values, and binary values. Regression tests use synthetic marker
+strings only and prove that worker output, repository parameters, and the
+admin-readback shape cannot recover the markers.
+
+## Affected active records
+
+Metadata-only queries found 11 successful executions. No affected parameters,
+results, variables, or log payloads were opened during the inventory.
+
+| Customer / device / SQL instance | Execution IDs |
+| --- | --- |
+| Dr. Dayton Dawson DDS / Ninja 2870 `SERVER` / `SIDEXIS_SQL` | `9df9b93e-1432-4204-b074-a32a30e0b2f2` |
+| Dr. Jimmy Lutz DDS / Ninja 1322 `SERVER` / `SIDEXIS_SQL` | `499c891a-8306-47c1-a1fd-a340916ea485`, `8f63976c-06c6-40ee-a5f4-6d4fd5856178`, `2360bcda-790d-4696-9541-2aabd8087812` |
+| Blue River Dental Care / Ninja 836 `HIGHSERVER1` / `SIDEXIS_SQL` | `6c661b9a-f1aa-4b39-b374-de6664850c2b`, `3c8a9608-7e58-4735-9aaf-3a10d3e4ccba`, `24b0ecb1-19f5-4cac-a913-291990199f4c` |
+| Generations in Dentistry / Ninja 1021 `DEDICATED2` / `SIDEXIS_SQL` | `3388e4e2-4a49-4646-9885-abfdc6d63619`, `273cbbce-bd20-45fa-995f-519af1d5607c`, `591c5ea7-5974-442e-a565-defdcb619c98` |
+| Aspen Dental Group / Ninja 289 `DATASERVER` / `SIDEXIS_SQL` | `6c029e48-5516-4729-be2c-023062f1a731` |
+
+The span is 2026-07-11 01:37:11 UTC through 2026-07-22 22:01:47 UTC.
+Ninja 2870 also has `PDATA_SQLEXPRESS`; the durable SQL inventory shows that
+instance separately, and it is not part of this workflow's affected SIDEXIS
+credential lane.
+
+## Storage and retention map
+
+This is a 2026-07-22 metadata-only production snapshot.
+
+| Surface | Current evidence | Remediation/expiry behavior |
+| --- | --- | --- |
+| Primary PostgreSQL | `psql-mtg-bifrost-poc-01`, PostgreSQL 16, primary role, no HA, no read replicas. All 11 rows have non-null `variables` and the affected key. | Exact active rows can be transactionally replaced with a redaction sentinel. |
+| PostgreSQL automated backup/PITR | Seven automatic daily full backups are currently listed, 2026-07-16 through 2026-07-22. Retention is 7 days; geo-redundant backup is disabled. WAL supports PITR inside that window. | Managed snapshots and WAL cannot be surgically edited. A restore to a time before active-row redaction will resurrect the old values. Let them expire naturally, and require the redaction runbook before any restored database is made accessible. |
+| Separate PostgreSQL backup/replica | No Azure PostgreSQL replica, Azure Backup item, Data Protection item, long-term-retention job, or operator-created backup was found. | No separately managed database copy was identified. |
+| Redis execution context | Managed Redis AOF is enabled at one-second frequency; RDB is disabled. Ten IDs had no current key. The latest execution had one `bifrost:exec:{id}:context` key with the source-defined one-hour TTL when inspected. | The live key expires automatically. Managed AOF is resilience storage, not a user-addressable backup or PITR surface; its files cannot be surgically edited. |
+| RabbitMQ | All workflow, retry, and poison queues had zero ready, unacknowledged, and total messages. | No queued copy remains. |
+| Kubernetes container logs | Current API logs contained short execution-ID/status lines only; no matching long payload-shaped line was found. Other current app/worker logs had no matches. | Node/container rotation applies. No Azure diagnostic setting exports AKS logs. |
+| OpenTelemetry / Tempo | Trace and log export goes to the in-cluster collector and Tempo. Tempo block retention is 168 hours. Searches for all 11 execution IDs returned zero traces; collector matches were short metadata lines only. | No affected trace was identified. Existing blocks expire at 7 days and are not a surgical record-edit surface. |
+| Log Analytics | Workspace default retention is 30 days; `BifrostObserver_CL` is 31 days. A 14-day exact-ID query returned zero records. PostgreSQL, Redis, and AKS have no diagnostic settings. | No matching record exists to purge. If later evidence changes that conclusion, use the supported Log Analytics purge process under separate approval. |
+| Azure Storage / exports | The platform object account exposes `autotask-ticket-attachments` and `bifrost-objects`; the GitHub-events account exposes only its function containers. Repo and live configuration show no PostgreSQL or execution-history export job. Current operator identity cannot enumerate blob names without a Data Reader role. | No export is evidenced. Do not use account keys merely to widen discovery; grant time-bounded metadata read access only if an operator requires a stronger blob-name inventory. |
+| Recovery Services / Data Protection | Recovery Services protects a legacy VM only. Data Protection protects the platform blob account only. | Neither vault is a copy of managed PostgreSQL execution rows. |
+| Downstream APM | No Sentry DSN is configured. The only Application Insights resource is the unrelated GitHub-events function. | No affected downstream APM copy was identified. |
+
+Azure PostgreSQL backup behavior is documented at
+<https://learn.microsoft.com/azure/postgresql/backup-restore/concepts-backup-restore>.
+Managed Redis persistence behavior is documented at
+<https://learn.microsoft.com/azure/redis/how-to-persistence>.
+Log Analytics retention behavior is documented at
+<https://learn.microsoft.com/azure/azure-monitor/logs/data-retention-configure>.
+
+## Active-row remediation procedure (not authorized)
+
+Preferred action: redact `variables` for exactly the 11 IDs while preserving
+the execution records and all non-variable history.
+
+1. Confirm prevention is deployed and the synthetic canary passes.
+2. Freeze admin read access to the 11 records for the maintenance window.
+3. Open one database transaction and lock exactly the 11 rows by ID and the
+   affected workflow ID. Select counts and booleans only; do not return JSONB.
+4. Require `row_count = 11`, `workflow_count = 11`, and
+   `variables_nonnull_count = 11`. Any mismatch rolls back and stops.
+5. Replace the whole `variables` document, rather than trying to find every
+   nested secret-bearing local:
+
+   ```sql
+   UPDATE executions
+   SET variables = jsonb_build_object(
+       'redacted', true,
+       'reason', 'security_incident_2026_07_22'
+   )
+   WHERE workflow_id = 'a2e75961-9f0e-4a96-9ee5-a9d240cdda08'
+     AND id = ANY(:exact_11_execution_ids);
+   ```
+
+6. Before commit, verify by count/boolean only that all 11 rows equal the
+   sentinel and that no other row changed. Roll back on any contradiction.
+7. Commit, then verify the public/admin API returns only the sentinel for each
+   ID. Do not print the complete execution objects.
+8. Record the transaction time. Treat all PITR restore points before that time
+   as contaminated until the same exact-ID redaction is applied to the restored
+   database. Retain normal recovery posture and let those restore points expire
+   after the configured seven-day window.
+
+The procedure is fully reversible until step 7 by transaction rollback. After
+commit, deliberate redaction should not be made reversible by creating another
+secret-bearing copy. If legal or evidentiary requirements demand post-commit
+reversal, that is a separate operator decision: restore a pre-redaction PITR
+point into an isolated server with access logging and no application ingress,
+then destroy that server when the approved evidence task ends. A point-in-time
+restore is server-wide, not a surgical edit.
+
+Deleting all 11 execution rows is an alternative, but it removes audit history
+and is not recommended while exact-field redaction is sufficient.
+
+## SIDEXIS credential rotation plan (not authorized)
+
+The current credential authority is a vendor-documented SIDEXIS 4.3 default
+embedded in the authored workspace workflow. The value must not remain in
+authored source, Git history, execution history, operator notes, or deployment
+logs. Future automation should resolve a per-customer/per-instance record from
+the approved Keeper/IT Glue lane and pass it as an in-memory secret type.
+
+Rotation scope is the five `SIDEXIS_SQL` instances in the affected-record table.
+Do not include Ninja 2870 `PDATA_SQLEXPRESS` without separate evidence that it
+uses the same login.
+
+For each instance, strictly one at a time:
+
+1. Re-prove customer, device, hostname, and `SIDEXIS_SQL` binding; require the
+   device online and no active Ninja job.
+2. Locate or create the exact customer Keeper record. Generate a unique random
+   per-instance credential directly into the vault; never stage it in a file,
+   shell history, workflow input, or ticket.
+3. Validate a separate customer-specific break-glass/sysadmin login before
+   changing the vendor login. Stop if no independent recovery login works.
+4. Inventory service/application dependencies on the vendor login using
+   metadata-only configuration checks. Coordinate with the dental application
+   owner/vendor if SIDEXIS services still consume it.
+5. Schedule a customer maintenance window and notify the assigned MTG owner/NOC
+   of the exact instance and rollback contact.
+6. Change only the login on that exact SQL instance, update every proven
+   dependent secret store in the same window, and read back login validity and
+   sysadmin membership without returning credential material.
+7. Validate, in order: SIDEXIS application login, dependent Windows services,
+   SQLWriter/VSS health, backup health, customer smoke test, and the
+   non-mutating FRK health verifier.
+8. Soak the instance before proceeding to the next customer.
+
+Rollback requires the independently validated sysadmin login. During the
+maintenance window only, keep the previous credential in a restricted,
+time-limited Keeper rollback field. If application validation fails, restore
+the old login credential and dependent configuration, revalidate the
+application, stop the wave, and involve the vendor. Delete the rollback field
+after the agreed soak period.
+
+Required communication:
+
+- customer maintenance notice describing possible brief SIDEXIS interruption;
+- internal assignment of one owner, verifier, and rollback authority per site;
+- vendor coordination where the default is product-managed or undocumented
+  consumers are found; and
+- completion notice recording only instance identity, timestamps, validation
+  state, and vault record reference, never credential material.
+
+## Operator decisions still required
+
+1. Approve exact-field active-row redaction for the 11 IDs, or choose full-row
+   deletion instead.
+2. Accept transaction/PITR-only reversibility (recommended), or separately
+   authorize creation of a new restricted evidence copy.
+3. Keep the seven-day PostgreSQL recovery window and let contaminated restore
+   points expire naturally (recommended), or accept the recovery-risk tradeoff
+   of broader backup destruction/retention changes.
+4. Approve the five-site credential rotation and customer/vendor communication
+   windows.
+


### PR DESCRIPTION
## Summary
- sanitize captured execution variables before they leave the execution engine
- repeat sanitization at the repository boundary immediately before PostgreSQL persistence
- redact sensitive variable names and executable script/command content recursively
- add synthetic-only regression coverage through the platform-admin readback shape

## Security context
This is a Lane 3 P0 prevention change. A bounded metadata-only review identified 11 historical executions of one affected workflow. This PR does not inspect or mutate those payloads, change credentials, or alter endpoint state. Historical remediation and credential rotation are separate approval-gated plans.

## Verification
- ruff check on all touched Python files
- Python syntax compilation on all touched Python files
- git diff --check
- focused GitHub CI and review pending

## Deployment / rollback
No schema or API contract changes. Deploy the normal API/worker image. Rollback is a revert of this PR, although rollback would reopen the persistence risk and should only occur after an equivalent replacement is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Sensitive execution variables, credentials, scripts, commands, binary data, and unsupported values are now redacted before storage and output.
  * Redaction applies recursively across nested data structures and protects secrets even when they were not previously registered.
  * Preserves non-sensitive values while preventing plaintext secret recovery.

* **Documentation**
  * Added security incident documentation covering affected records, storage considerations, remediation guidance, and credential rotation planning.

* **Tests**
  * Added coverage for recursive redaction, generated scripts, commands, credentials, nested containers, and safe value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->