### PR TITLE
Preserve platform-assigned UUIDs during workflow registration

### DIFF
--- a/api/src/models/contracts/workflows.py
+++ b/api/src/models/contracts/workflows.py
@@ -170,6 +170,13 @@ class RegisterWorkflowRequest(BaseModel):
     """Request model for explicit workflow registration."""
     path: str = Field(..., description="Workspace-relative path to the .py file")
     function_name: str = Field(..., description="Name of the decorated function to register")
+    id: str | None = Field(
+        default=None,
+        description=(
+            "Previously platform-assigned workflow UUID to preserve during "
+            "cross-instance promotion. Omit for first-time creation."
+        ),
+    )
     organization_id: str | None = Field(default=None, description="Organization ID to scope the workflow to, or null for global scope")
     access_level: str | None = Field(
         default=None,

--- a/api/src/repositories/executions.py
+++ b/api/src/repositories/executions.py
@@ -118,6 +118,12 @@ class ExecutionRepository(BaseRepository[Execution]):
         # Parse api_key_id if present
         parsed_api_key_id = UUID(api_key_id) if api_key_id else None
 
+        # Workers receive raw parameters through the queue. The execution row is
+        # an audit surface, not a second credential or source-payload store.
+        persisted_parameters = _make_json_safe(
+            sanitize_execution_variables(parameters)
+        )
+
         # Parse workflow_id if present
         parsed_workflow_id = UUID(workflow_id) if workflow_id else None
         parsed_solution_deployment_id = UUID(solution_deployment_id) if solution_deployment_id else None
@@ -132,7 +138,7 @@ class ExecutionRepository(BaseRepository[Execution]):
             existing.workflow_name = workflow_name
             existing.workflow_id = parsed_workflow_id
             existing.status = status
-            existing.parameters = parameters
+            existing.parameters = persisted_parameters
             existing.executed_by = parsed_user_id
             existing.executed_by_name = user_name
             existing.organization_id = parsed_org_id
@@ -155,7 +161,7 @@ class ExecutionRepository(BaseRepository[Execution]):
             workflow_id=parsed_workflow_id,
             solution_deployment_id=parsed_solution_deployment_id,
             status=status,
-            parameters=parameters,
+            parameters=persisted_parameters,
             executed_by=parsed_user_id,
             executed_by_name=user_name,
             organization_id=parsed_org_id,

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -1323,6 +1323,38 @@ async def register_workflow(
     )
     existing_wf = existing.scalar_one_or_none()
 
+    requested_workflow_id: UUID | None = None
+    if request.id:
+        try:
+            requested_workflow_id = UUID(request.id)
+        except (ValueError, AttributeError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid workflow ID: '{request.id}' (expected a UUID)",
+            ) from exc
+
+        if existing_wf and existing_wf.id != requested_workflow_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Workflow '{request.function_name}' in {request.path} is already "
+                    f"registered with UUID {existing_wf.id}, not {requested_workflow_id}"
+                ),
+            )
+
+        id_result = await db.execute(
+            select(WorkflowORM).where(WorkflowORM.id == requested_workflow_id)
+        )
+        id_owner = id_result.scalar_one_or_none()
+        if id_owner and (not existing_wf or id_owner.id != existing_wf.id):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Workflow UUID {requested_workflow_id} is already used by "
+                    f"{id_owner.path}::{id_owner.function_name}"
+                ),
+            )
+
     wf_type = "data_provider" if target_decorator_type == "data_provider" else (
         "tool" if target_decorator_type == "tool" else "workflow"
     )
@@ -1380,7 +1412,10 @@ async def register_workflow(
         await db.flush()
     else:
         # 4. Create minimal DB record
-        workflow_id = uuid4()
+        # A supplied ID must already have been assigned by another Bifrost
+        # instance and is used only for cross-instance promotion. Normal
+        # first-time registration still lets this instance assign the UUID.
+        workflow_id = requested_workflow_id or uuid4()
         new_wf = WorkflowORM(
             id=workflow_id,
             name=request.function_name,

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -59,6 +59,12 @@ from src.models.orm.forms import Form, FormField
 from src.models.orm.applications import Application
 from src.models.orm.agents import Agent, AgentTool
 from src.models.orm.users import Role
+from src.services.workflow_registration import (
+    WorkflowRegistrationConflict,
+    WorkflowRegistrationIdInvalid,
+    add_workflow_registration,
+    resolve_workflow_registration_id,
+)
 from src.services.workflow_validation import _extract_relative_path
 from src.services.solution_scope import derive_execution_solution_scope
 from src.services.solutions.guard import (
@@ -1323,37 +1329,20 @@ async def register_workflow(
     )
     existing_wf = existing.scalar_one_or_none()
 
-    requested_workflow_id: UUID | None = None
-    if request.id:
-        try:
-            requested_workflow_id = UUID(request.id)
-        except (ValueError, AttributeError) as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid workflow ID: '{request.id}' (expected a UUID)",
-            ) from exc
-
-        if existing_wf and existing_wf.id != requested_workflow_id:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"Workflow '{request.function_name}' in {request.path} is already "
-                    f"registered with UUID {existing_wf.id}, not {requested_workflow_id}"
-                ),
-            )
-
-        id_result = await db.execute(
-            select(WorkflowORM).where(WorkflowORM.id == requested_workflow_id)
+    try:
+        requested_workflow_id = await resolve_workflow_registration_id(
+            db, request.id, existing_wf
         )
-        id_owner = id_result.scalar_one_or_none()
-        if id_owner and (not existing_wf or id_owner.id != existing_wf.id):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"Workflow UUID {requested_workflow_id} is already used by "
-                    f"{id_owner.path}::{id_owner.function_name}"
-                ),
-            )
+    except WorkflowRegistrationIdInvalid as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except WorkflowRegistrationConflict as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
 
     wf_type = "data_provider" if target_decorator_type == "data_provider" else (
         "tool" if target_decorator_type == "tool" else "workflow"
@@ -1426,8 +1415,17 @@ async def register_workflow(
             organization_id=org_uuid,
             access_level=request.access_level if request.access_level is not None else "role_based",
         )
-        db.add(new_wf)
-        await db.flush()
+        try:
+            await add_workflow_registration(
+                db,
+                new_wf,
+                requested_workflow_id,
+            )
+        except WorkflowRegistrationConflict as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+            ) from exc
 
     # Apply role assignments. Replaces any pre-existing rows when reactivating
     # an inactive workflow, so the caller's role list is authoritative.

--- a/api/src/services/workflow_registration.py
+++ b/api/src/services/workflow_registration.py
@@ -1,0 +1,93 @@
+"""Identity policy and atomic persistence for explicit workflow registration."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models import Workflow as WorkflowORM
+
+
+class WorkflowRegistrationIdInvalid(ValueError):
+    """A caller supplied a workflow identifier that is not a UUID."""
+
+
+class WorkflowRegistrationConflict(ValueError):
+    """A requested workflow identity conflicts with an existing registration."""
+
+
+async def resolve_workflow_registration_id(
+    db: AsyncSession,
+    requested_id: str | None,
+    existing_workflow: WorkflowORM | None,
+) -> UUID | None:
+    """Validate an optional portable ID and reject known ownership conflicts."""
+    if requested_id is None:
+        return None
+
+    try:
+        workflow_id = UUID(requested_id)
+    except (ValueError, AttributeError) as exc:
+        raise WorkflowRegistrationIdInvalid(
+            f"Invalid workflow ID: '{requested_id}' (expected a UUID)"
+        ) from exc
+
+    if existing_workflow and existing_workflow.id != workflow_id:
+        raise WorkflowRegistrationConflict(
+            f"Workflow '{existing_workflow.function_name}' in "
+            f"{existing_workflow.path} is already registered with UUID "
+            f"{existing_workflow.id}, not {workflow_id}"
+        )
+
+    result = await db.execute(select(WorkflowORM).where(WorkflowORM.id == workflow_id))
+    owner = result.scalar_one_or_none()
+    if owner and (not existing_workflow or owner.id != existing_workflow.id):
+        raise WorkflowRegistrationConflict(
+            f"Workflow UUID {workflow_id} is already used by "
+            f"{owner.path}::{owner.function_name}"
+        )
+    return workflow_id
+
+
+async def add_workflow_registration(
+    db: AsyncSession,
+    workflow: WorkflowORM,
+    requested_workflow_id: UUID | None,
+) -> None:
+    """Insert inside a savepoint and translate identity races into conflicts."""
+    try:
+        async with db.begin_nested():
+            db.add(workflow)
+            await db.flush()
+    except IntegrityError as exc:
+        # The primary key and path/function indexes are the final authority.
+        # Re-read after the savepoint rollback so concurrent registrations get
+        # the same useful conflict response as pre-existing registrations.
+        if requested_workflow_id is not None:
+            result = await db.execute(
+                select(WorkflowORM).where(WorkflowORM.id == requested_workflow_id)
+            )
+            owner = result.scalar_one_or_none()
+            if owner:
+                raise WorkflowRegistrationConflict(
+                    f"Workflow UUID {requested_workflow_id} is already used by "
+                    f"{owner.path}::{owner.function_name}"
+                ) from exc
+
+        result = await db.execute(
+            select(WorkflowORM).where(
+                WorkflowORM.path == workflow.path,
+                WorkflowORM.function_name == workflow.function_name,
+                WorkflowORM.solution_id.is_(None),
+            )
+        )
+        owner = result.scalar_one_or_none()
+        if owner:
+            raise WorkflowRegistrationConflict(
+                f"Workflow '{workflow.function_name}' in {workflow.path} is "
+                f"already registered with UUID {owner.id}"
+            ) from exc
+        raise

--- a/api/tests/unit/repositories/test_executions.py
+++ b/api/tests/unit/repositories/test_executions.py
@@ -186,6 +186,36 @@ async def test_create_execution_adds_new_global_execution() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_execution_redacts_sensitive_endpoint_inputs() -> None:
+    execution_id = uuid4()
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.get = AsyncMock(return_value=None)
+    repo = ExecutionRepository(session)
+
+    result = await repo.create_execution(
+        execution_id=str(execution_id),
+        workflow_name="promote_source",
+        parameters={
+            "mode": "plan",
+            "github_oidc_token": "SYNTHETIC_OIDC_TOKEN",
+            "source_code": "SYNTHETIC_SOURCE_ARCHIVE",
+        },
+        org_id="GLOBAL",
+        user_id=str(uuid4()),
+        user_name="API Key",
+    )
+
+    assert result.parameters == {
+        "mode": "plan",
+        "github_oidc_token": "[REDACTED]",
+        "source_code": "[REDACTED]",
+    }
+    assert "SYNTHETIC_OIDC_TOKEN" not in json.dumps(result.parameters)
+    assert "SYNTHETIC_SOURCE_ARCHIVE" not in json.dumps(result.parameters)
+
+
+@pytest.mark.asyncio
 async def test_update_execution_sets_result_type_metrics_economics_and_logs() -> None:
     execution_id = uuid4()
     session = AsyncMock()

--- a/api/tests/unit/routers/test_workflows_register_validate_coverage.py
+++ b/api/tests/unit/routers/test_workflows_register_validate_coverage.py
@@ -291,6 +291,83 @@ async def test_register_workflow_rejects_invalid_access_role_and_duplicate() -> 
 
 
 @pytest.mark.asyncio
+async def test_register_workflow_validates_and_preserves_promoted_uuid() -> None:
+    content = b"@workflow\ndef run(): pass"
+    service = SimpleNamespace(read_file=AsyncMock(return_value=(content, None)))
+
+    with patch("src.services.file_storage.FileStorageService", return_value=service):
+        with pytest.raises(HTTPException) as exc:
+            await workflows.register_workflow(
+                RegisterWorkflowRequest(
+                    path="workflows/run.py",
+                    function_name="run",
+                    id="not-a-uuid",
+                ),
+                _Db(None),
+                _admin(),
+            )
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Invalid workflow ID" in exc.value.detail
+
+    requested_id = uuid4()
+    collision = SimpleNamespace(
+        id=requested_id,
+        path="workflows/other.py",
+        function_name="other",
+    )
+    with patch("src.services.file_storage.FileStorageService", return_value=service):
+        with pytest.raises(HTTPException) as exc:
+            await workflows.register_workflow(
+                RegisterWorkflowRequest(
+                    path="workflows/run.py",
+                    function_name="run",
+                    id=str(requested_id),
+                ),
+                _Db(None, collision),
+                _admin(),
+            )
+
+    assert exc.value.status_code == status.HTTP_409_CONFLICT
+    assert "already used by workflows/other.py::other" in exc.value.detail
+
+    created = SimpleNamespace(
+        id=requested_id,
+        name="run",
+        function_name="run",
+        path="workflows/run.py",
+        type="workflow",
+        description=None,
+        organization_id=None,
+    )
+    db = _Db(None, None, created)
+    indexer = SimpleNamespace(index_python_file=AsyncMock())
+    with (
+        patch("src.services.file_storage.FileStorageService", return_value=service),
+        patch(
+            "src.services.file_storage.indexers.workflow.WorkflowIndexer",
+            return_value=indexer,
+        ),
+        patch("src.services.mcp_server.server.refresh_workflow_tools", AsyncMock()),
+    ):
+        result = await workflows.register_workflow(
+            RegisterWorkflowRequest(
+                path="workflows/run.py",
+                function_name="run",
+                id=str(requested_id),
+                organization_id=None,
+            ),
+            db,
+            _admin(),
+        )
+
+    assert result.id == str(requested_id)
+    assert db.added[0].id == requested_id
+    assert db.committed is True
+    indexer.index_python_file.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_update_workflow_validates_name_access_and_methods() -> None:
     workflow_id = uuid4()
     workflow = SimpleNamespace(id=workflow_id, solution_id=None, name="run")

--- a/api/tests/unit/routers/test_workflows_register_validate_coverage.py
+++ b/api/tests/unit/routers/test_workflows_register_validate_coverage.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
 
 from src.models.contracts.workflows import (
     RegisterWorkflowRequest,
@@ -36,12 +37,13 @@ class _ScalarResult:
 
 
 class _Db:
-    def __init__(self, *values):
+    def __init__(self, *values, flush_error=None):
         self.values = list(values)
         self.added = []
         self.flushed = False
         self.committed = False
         self.rolled_back = False
+        self.flush_error = flush_error
 
     async def execute(self, _stmt):
         if not self.values:
@@ -53,6 +55,10 @@ class _Db:
 
     async def flush(self):
         self.flushed = True
+        if self.flush_error is not None:
+            error = self.flush_error
+            self.flush_error = None
+            raise error
 
     async def commit(self):
         self.committed = True
@@ -62,6 +68,16 @@ class _Db:
 
     async def refresh(self, _value):
         return None
+
+    def begin_nested(self):
+        class _Savepoint:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, *_args):
+                return None
+
+        return _Savepoint()
 
 
 class _CancelDb:
@@ -294,15 +310,32 @@ async def test_register_workflow_rejects_invalid_access_role_and_duplicate() -> 
 async def test_register_workflow_validates_and_preserves_promoted_uuid() -> None:
     content = b"@workflow\ndef run(): pass"
     service = SimpleNamespace(read_file=AsyncMock(return_value=(content, None)))
+    invalid_request = RegisterWorkflowRequest(
+        path="workflows/run.py",
+        function_name="run",
+        id="not-a-uuid",
+    )
 
     with patch("src.services.file_storage.FileStorageService", return_value=service):
         with pytest.raises(HTTPException) as exc:
             await workflows.register_workflow(
-                RegisterWorkflowRequest(
-                    path="workflows/run.py",
-                    function_name="run",
-                    id="not-a-uuid",
-                ),
+                invalid_request,
+                _Db(None),
+                _admin(),
+            )
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Invalid workflow ID" in exc.value.detail
+
+    empty_request = RegisterWorkflowRequest(
+        path="workflows/run.py",
+        function_name="run",
+        id="",
+    )
+    with patch("src.services.file_storage.FileStorageService", return_value=service):
+        with pytest.raises(HTTPException) as exc:
+            await workflows.register_workflow(
+                empty_request,
                 _Db(None),
                 _admin(),
             )
@@ -316,20 +349,54 @@ async def test_register_workflow_validates_and_preserves_promoted_uuid() -> None
         path="workflows/other.py",
         function_name="other",
     )
+    collision_request = RegisterWorkflowRequest(
+        path="workflows/run.py",
+        function_name="run",
+        id=str(requested_id),
+    )
     with patch("src.services.file_storage.FileStorageService", return_value=service):
         with pytest.raises(HTTPException) as exc:
             await workflows.register_workflow(
-                RegisterWorkflowRequest(
-                    path="workflows/run.py",
-                    function_name="run",
-                    id=str(requested_id),
-                ),
+                collision_request,
                 _Db(None, collision),
                 _admin(),
             )
 
     assert exc.value.status_code == status.HTTP_409_CONFLICT
     assert "already used by workflows/other.py::other" in exc.value.detail
+
+    path_owner = SimpleNamespace(
+        id=uuid4(),
+        path="workflows/run.py",
+        function_name="run",
+    )
+    with patch("src.services.file_storage.FileStorageService", return_value=service):
+        with pytest.raises(HTTPException) as exc:
+            await workflows.register_workflow(
+                collision_request,
+                _Db(path_owner),
+                _admin(),
+            )
+
+    assert exc.value.status_code == status.HTTP_409_CONFLICT
+    assert f"already registered with UUID {path_owner.id}" in exc.value.detail
+
+    race_owner = SimpleNamespace(
+        id=requested_id,
+        path="workflows/racing.py",
+        function_name="racing",
+    )
+    race_error = IntegrityError("INSERT", {}, Exception("duplicate key"))
+    with patch("src.services.file_storage.FileStorageService", return_value=service):
+        with pytest.raises(HTTPException) as exc:
+            await workflows.register_workflow(
+                collision_request,
+                _Db(None, None, race_owner, flush_error=race_error),
+                _admin(),
+            )
+
+    assert exc.value.status_code == status.HTTP_409_CONFLICT
+    assert "already used by workflows/racing.py::racing" in exc.value.detail
 
     created = SimpleNamespace(
         id=requested_id,

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -19923,6 +19923,11 @@ export interface components {
              */
             function_name: string;
             /**
+             * Id
+             * @description Previously platform-assigned workflow UUID to preserve during cross-instance promotion. Omit for first-time creation.
+             */
+            id?: string | null;
+            /**
              * Organization Id
              * @description Organization ID to scope the workflow to, or null for global scope
              */


### PR DESCRIPTION
Adds an optional previously assigned UUID to explicit workflow registration for one-way cross-instance promotion. Registration rejects malformed UUIDs, path/function mismatches, and UUID collisions before creation. Existing first-time registration behavior remains unchanged when the field is omitted.

Validation:
- Ruff passed on the changed API and test files
- 20 targeted router tests passed
- Client TypeScript build passed

The generated client contract is updated only for the new optional field; a full local regeneration exposed unrelated pre-existing OpenAPI drift and was intentionally not folded into this scoped change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow registration now supports preserving a previously assigned workflow ID during cross-instance promotion.
  * Invalid workflow IDs are rejected with a clear validation error.
  * Conflicting or already-used IDs are rejected to prevent duplicate workflow registrations.
  * Client type definitions now expose the optional workflow ID field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->