### PR TITLE
Expose raw workspace snapshot hashes

### DIFF
--- a/api/src/models/contracts/workspace_repo_changesets.py
+++ b/api/src/models/contracts/workspace_repo_changesets.py
@@ -26,6 +26,7 @@ class WorkspaceRepoStateResponse(BaseModel):
     scope: str
     revision: str
     file_count: int
+    file_hashes: dict[str, str] = Field(default_factory=dict)
     dirty: bool
     open_changesets: int
     git_status: dict | None = None

--- a/api/src/services/workspace_repo_changesets.py
+++ b/api/src/services/workspace_repo_changesets.py
@@ -129,6 +129,7 @@ class WorkspaceRepoChangesetService:
             scope=scope,
             revision=revision,
             file_count=len(files),
+            file_hashes=files,
             dirty=workspace_dirty or count > 0,
             open_changesets=count,
             git_status=git_status,

--- a/api/tests/unit/services/test_workspace_repo_changesets.py
+++ b/api/tests/unit/services/test_workspace_repo_changesets.py
@@ -104,6 +104,10 @@ async def test_begin_uses_canonical_revision_and_rejects_stale_revision():
     )
     state = await svc.state("features")
     assert state.storage_root == "_repo"
+    assert state.file_hashes == {
+        "features/a.py": "7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add73ff431ed",
+        "features/b.py": "3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0dbe685e2f3",
+    }
     row = await svc.begin(
         WorkspaceRepoChangesetBegin(
             scope="features", base_revision=state.revision, worker_id="worker-1"


### PR DESCRIPTION
## Summary
- expose per-file SHA-256 hashes from the raw workspace repository changeset snapshot
- let callers plan against the same bytes protected by changeset compare-and-swap
- cover the state response with exact hash assertions

## Why
The first production workspace promotion safely stopped before activation because planning used the indexed file view while changesets guarded the raw repository view. Returning the raw snapshot hashes removes that split-brain without weakening CAS protection.

## Verification
- focused changeset service tests: 11 passed
- focused Ruff check: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace repository state now includes content hashes for individual files.
  * File hashes are available for scoped workspace paths, supporting more precise change tracking.
  * States without tracked files now return an empty file-hash collection.

* **Tests**
  * Added coverage confirming file hashes are correctly reported for initialized workspace files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->