### PR TITLE
fix(oauth): serialize rotating token refreshes

### DIFF
--- a/api/src/repositories/oauth.py
+++ b/api/src/repositories/oauth.py
@@ -350,7 +350,7 @@ class OAuthTokenRepository(OrgScopedRepository[OAuthToken]):
         super().__init__(session, org_id, user_id, is_superuser, is_external)
 
     async def get_org_level_for_provider(
-        self, provider_id: UUID
+        self, provider_id: UUID, *, for_update: bool = False
     ) -> Any:
         """Get the org-level OAuth token for a provider (``user_id IS NULL``).
 
@@ -368,19 +368,23 @@ class OAuthTokenRepository(OrgScopedRepository[OAuthToken]):
 
         Args:
             provider_id: ``OAuthProvider`` UUID.
+            for_update: Lock the selected token row until the current
+                transaction completes. OAuth refresh callers use this to
+                serialize rotating refresh tokens.
 
         Returns:
             ``OAuthToken`` or ``None`` if not found in either scope.
         """
         # Try org-specific first (if we have an org).
         if self.org_id is not None:
-            result = await self.session.execute(
-                select(OAuthToken).where(
-                    OAuthToken.provider_id == provider_id,
-                    OAuthToken.organization_id == self.org_id,
-                    OAuthToken.user_id.is_(None),
-                )
+            query = select(OAuthToken).where(
+                OAuthToken.provider_id == provider_id,
+                OAuthToken.organization_id == self.org_id,
+                OAuthToken.user_id.is_(None),
             )
+            if for_update:
+                query = query.with_for_update()
+            result = await self.session.execute(query)
             token = result.scalars().first()
             if token is not None:
                 return token
@@ -391,11 +395,12 @@ class OAuthTokenRepository(OrgScopedRepository[OAuthToken]):
             return None
 
         # Fall back to global.
-        result = await self.session.execute(
-            select(OAuthToken).where(
-                OAuthToken.provider_id == provider_id,
-                OAuthToken.organization_id.is_(None),
-                OAuthToken.user_id.is_(None),
-            )
+        query = select(OAuthToken).where(
+            OAuthToken.provider_id == provider_id,
+            OAuthToken.organization_id.is_(None),
+            OAuthToken.user_id.is_(None),
         )
+        if for_update:
+            query = query.with_for_update()
+        result = await self.session.execute(query)
         return result.scalars().first()

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -1381,7 +1381,13 @@ async def sdk_integrations_refresh_token(
         )
         stored_token = None
         if provider.oauth_flow_type == "authorization_code":
-            stored_token = await token_repo.get_org_level_for_provider(provider.id)
+            # Providers may rotate refresh tokens. Hold a row lock through
+            # refresh + persistence so concurrent workflow 401 retries cannot
+            # both submit the same one-time refresh token.
+            stored_token = await token_repo.get_org_level_for_provider(
+                provider.id,
+                for_update=True,
+            )
             if not stored_token or not stored_token.encrypted_refresh_token:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/tests/unit/repositories/test_oauth_repository.py
+++ b/api/tests/unit/repositories/test_oauth_repository.py
@@ -195,6 +195,25 @@ class TestOAuthTokenRepositoryCrossTenantIsolation:
         query = str(session.execute.call_args.args[0])
         assert "FOR UPDATE" in query
 
+    async def test_for_update_locks_org_token_without_global_fallback(
+        self, session
+    ) -> None:
+        """An org token wins and is locked before any global lookup."""
+        provider_id = uuid4()
+        org_token = MagicMock(organization_id=ORG_A)
+        session.execute.return_value = _result_returning(org_token)
+
+        repo = OAuthTokenRepository(session, org_id=ORG_A, is_superuser=True)
+        result = await repo.get_org_level_for_provider(
+            provider_id,
+            for_update=True,
+        )
+
+        assert result is org_token
+        assert session.execute.call_count == 1
+        query = str(session.execute.call_args.args[0])
+        assert "FOR UPDATE" in query
+
 
 class TestOAuthProviderRepositoryCascade:
     """Provider lookup also gets cascade for the same reasons as token."""

--- a/api/tests/unit/repositories/test_oauth_repository.py
+++ b/api/tests/unit/repositories/test_oauth_repository.py
@@ -179,6 +179,22 @@ class TestOAuthTokenRepositoryCrossTenantIsolation:
         # Only the global query; org-specific is skipped when org_id is None.
         assert session.execute.call_count == 1
 
+    async def test_for_update_locks_the_selected_token_row(self, session) -> None:
+        """Rotating refresh-token callers can serialize on the token row."""
+        provider_id = uuid4()
+        global_token = MagicMock(organization_id=None)
+        session.execute.return_value = _result_returning(global_token)
+
+        repo = OAuthTokenRepository(session, org_id=None, is_superuser=True)
+        result = await repo.get_org_level_for_provider(
+            provider_id,
+            for_update=True,
+        )
+
+        assert result is global_token
+        query = str(session.execute.call_args.args[0])
+        assert "FOR UPDATE" in query
+
 
 class TestOAuthProviderRepositoryCascade:
     """Provider lookup also gets cascade for the same reasons as token."""

--- a/api/tests/unit/routers/test_cli_refresh_token.py
+++ b/api/tests/unit/routers/test_cli_refresh_token.py
@@ -258,6 +258,8 @@ class TestRefreshTokenAuthorizationCode:
             result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
 
         assert result.refreshed is True
+        token_query = str(mock_db.execute.call_args_list[1].args[0])
+        assert "FOR UPDATE" in token_query
         response_payload = result.model_dump()
         assert "access_token" not in response_payload
         assert "refresh_token" not in response_payload


### PR DESCRIPTION
## Summary
- lock the selected authorization-code token row through refresh and persistence
- prevent concurrent workflow 401 retries from submitting the same rotating refresh token
- preserve existing org/global token cascade behavior

## Production evidence
Recent concurrent handle_ninjaone_alert executions intermittently failed with NinjaOne invalid_token, while a sibling execution at the same timestamp and later executions succeeded. This matches a rotating refresh-token race, not persistent bad credentials.

## Validation
- 22 focused repository/router tests passed
- 10 external-integration isolation tests passed
- Ruff passed on all changed files
- 4 database-backed scope tests could not start locally because the configured Postgres hostname is unavailable; CI remains authoritative for those

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token refresh reliability by preventing concurrent refresh attempts from using the same one-time refresh token.
  * Added safeguards to serialize authorization-code token refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->