### PR TITLE
Fix immutable release publication for v2.0.0-rc.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1344,7 +1344,24 @@ jobs:
               --owner ${{ github.repository_owner }}
             ```
 
-          draft: false
+          # Immutable releases only accept asset uploads while they are drafts.
+          # Publish in the next step after every asset has been uploaded.
+          draft: true
           prerelease: ${{ steps.get_version.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+          PRERELEASE: ${{ steps.get_version.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          args=(--draft=false)
+          if [ "$PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          else
+            args+=(--latest)
+          fi
+          gh release edit "$VERSION" "${args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1299,6 +1299,24 @@ jobs:
           body: |
             ## Bifrost ${{ steps.get_version.outputs.version }}
 
+            ### Highlights
+
+            - Immutable Solution deployments with compare-and-swap activation and runtime pinning.
+            - Standalone v2 applications, SDK streaming, and a more capable local development workflow.
+            - Security hardening across authentication, multi-tenancy boundaries, path containment, and dependency supply chains.
+            - Expanded diagnostics, OpenTelemetry coverage, and worker-capacity controls.
+
+            ### Upgrade notes
+
+            This is a major-version release candidate. The legacy `bifrost export` and
+            `bifrost import` commands have been removed; Solutions are their
+            lifecycle-aware replacement. CLI consumers must use a CLI build matching
+            the server contract version.
+
+            ### Contributors
+
+            Thomas Bray, Jack Musick, and Paul Szatkowski.
+
             ### Docker Images
 
             **API:**

--- a/api/tests/unit/jobs/schedulers/test_deferred_execution_promoter.py
+++ b/api/tests/unit/jobs/schedulers/test_deferred_execution_promoter.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.enums import ExecutionStatus
 from src.models.orm.executions import Execution
@@ -11,6 +13,7 @@ from src.models.orm.executions import Execution
 
 PATH_PUBLISH = "src.jobs.schedulers.deferred_execution_promoter._publish_pending"
 PATH_DB_CTX = "src.jobs.schedulers.deferred_execution_promoter.get_db_context"
+PATH_DATETIME = "src.jobs.schedulers.deferred_execution_promoter.datetime"
 
 
 def _new_scheduled(when: datetime) -> Execution:
@@ -25,6 +28,16 @@ def _new_scheduled(when: datetime) -> Execution:
         executed_by=None,
         executed_by_name="user",
     )
+
+
+async def _cancel_existing_scheduled(session: AsyncSession) -> None:
+    """Keep assertions independent from rows committed by earlier tests."""
+    await session.execute(
+        update(Execution)
+        .where(Execution.status == ExecutionStatus.SCHEDULED)
+        .values(status=ExecutionStatus.CANCELLED)
+    )
+    await session.commit()
 
 
 class _DbCtx:
@@ -48,7 +61,13 @@ class _DbCtx:
 async def test_promotes_due_rows(db_session):
     from src.jobs.schedulers.deferred_execution_promoter import promote_due_executions
 
-    due = _new_scheduled(datetime.now(timezone.utc) - timedelta(seconds=1))
+    await _cancel_existing_scheduled(db_session)
+    # Keep the row in the real scheduler's future, then advance only the clock
+    # used by the promoter under test. The Docker test stack runs the scheduler
+    # every two seconds, so a genuinely overdue row can otherwise be consumed
+    # between this commit and the direct promoter call below.
+    now = datetime.now(timezone.utc)
+    due = _new_scheduled(now + timedelta(hours=1))
     due.execution_context = {
         "is_platform_admin": False,
         "is_provider_org": True,
@@ -59,8 +78,10 @@ async def test_promotes_due_rows(db_session):
 
     with (
         patch(PATH_DB_CTX, return_value=_DbCtx(db_session)),
+        patch(PATH_DATETIME) as promoter_datetime,
         patch(PATH_PUBLISH, new=AsyncMock()) as pub,
     ):
+        promoter_datetime.now.return_value = now + timedelta(hours=2)
         promoted, failed = await promote_due_executions()
 
     assert promoted == 1
@@ -77,6 +98,7 @@ async def test_promotes_due_rows(db_session):
 async def test_leaves_future_rows(db_session):
     from src.jobs.schedulers.deferred_execution_promoter import promote_due_executions
 
+    await _cancel_existing_scheduled(db_session)
     future = _new_scheduled(datetime.now(timezone.utc) + timedelta(hours=1))
     db_session.add(future)
     await db_session.commit()
@@ -98,6 +120,7 @@ async def test_leaves_future_rows(db_session):
 async def test_skips_cancelled_rows(db_session):
     from src.jobs.schedulers.deferred_execution_promoter import promote_due_executions
 
+    await _cancel_existing_scheduled(db_session)
     cancelled = _new_scheduled(datetime.now(timezone.utc) - timedelta(minutes=1))
     cancelled.status = ExecutionStatus.CANCELLED
     db_session.add(cancelled)
@@ -118,14 +141,18 @@ async def test_skips_cancelled_rows(db_session):
 async def test_reverts_on_publish_failure(db_session):
     from src.jobs.schedulers.deferred_execution_promoter import promote_due_executions
 
-    due = _new_scheduled(datetime.now(timezone.utc) - timedelta(seconds=1))
+    await _cancel_existing_scheduled(db_session)
+    now = datetime.now(timezone.utc)
+    due = _new_scheduled(now + timedelta(hours=1))
     db_session.add(due)
     await db_session.commit()
 
     with (
         patch(PATH_DB_CTX, return_value=_DbCtx(db_session)),
+        patch(PATH_DATETIME) as promoter_datetime,
         patch(PATH_PUBLISH, new=AsyncMock(side_effect=RuntimeError("rabbit down"))),
     ):
+        promoter_datetime.now.return_value = now + timedelta(hours=2)
         promoted, failed = await promote_due_executions()
 
     assert promoted == 0

--- a/api/tests/unit/test_repo_security_hardening.py
+++ b/api/tests/unit/test_repo_security_hardening.py
@@ -77,6 +77,21 @@ def test_docs_noop_workflow_cannot_spoof_required_ci_check_names() -> None:
     assert job_names.isdisjoint(REQUIRED_CI_CHECK_NAMES)
 
 
+def test_release_assets_upload_before_immutable_release_publication() -> None:
+    ci = _load_yaml(".github/workflows/ci.yml")
+    steps = ci["jobs"]["create-release"]["steps"]
+    create_index = next(
+        index for index, step in enumerate(steps) if step["name"] == "Create release"
+    )
+    publish_index = next(
+        index for index, step in enumerate(steps) if step["name"] == "Publish release"
+    )
+
+    assert steps[create_index]["with"]["draft"] is True
+    assert publish_index > create_index
+    assert 'gh release edit "$VERSION" "${args[@]}"' in steps[publish_index]["run"]
+
+
 def test_dependabot_lock_validation_does_not_commit_to_pr_branch() -> None:
     workflow = _load_yaml(".github/workflows/dependabot-lockfile-regen.yml")
     text = _read(".github/workflows/dependabot-lockfile-regen.yml")

--- a/api/tests/unit/test_repo_security_hardening.py
+++ b/api/tests/unit/test_repo_security_hardening.py
@@ -87,9 +87,18 @@ def test_release_assets_upload_before_immutable_release_publication() -> None:
         index for index, step in enumerate(steps) if step["name"] == "Publish release"
     )
 
-    assert steps[create_index]["with"]["draft"] is True
+    create_with = steps[create_index]["with"]
+    publish_run = steps[publish_index]["run"]
+
+    assert create_with["draft"] is True
+    assert "${{ steps.source_tarball.outputs.tarball }}" in create_with["files"]
+    assert "${{ steps.source_tarball.outputs.tarball }}.sha256" in create_with["files"]
+    assert "${{ steps.source_tarball.outputs.tarball }}.sigstore" in create_with["files"]
     assert publish_index > create_index
-    assert 'gh release edit "$VERSION" "${args[@]}"' in steps[publish_index]["run"]
+    assert "--draft=false" in publish_run
+    assert "args+=(--prerelease)" in publish_run
+    assert "args+=(--latest)" in publish_run
+    assert 'gh release edit "$VERSION" "${args[@]}"' in publish_run
 
 
 def test_dependabot_lock_validation_does_not_commit_to_pr_branch() -> None:

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",


### PR DESCRIPTION
## Summary
- upload release assets to a draft before publishing immutable releases
- publish prereleases only after every asset is present
- bump plugin manifests to v2.0.0-rc.2
- add a static regression test for release ordering

## Verification
- ./test.sh tests/unit/test_repo_security_hardening.py -q (12 passed)
- ./test.sh quality api (0 errors, 0 warnings)

Closes the release-publication recovery portion of #499.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated plugin versions to `2.0.0-rc.2`.

* **Improvements**
  * Release assets are now uploaded before publication, supporting reliable draft-to-published release workflows while preserving prerelease and latest-release status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->