### PR TITLE
fix(git): authenticate transactional workspace closure

### DIFF
--- a/.claude/skills/bifrost-build/generated/openapi-digest.md
+++ b/.claude/skills/bifrost-build/generated/openapi-digest.md
@@ -507,12 +507,14 @@
 | POST | `/api/workflows/{workflow_id}/roles` |
 | DELETE | `/api/workflows/{workflow_id}/roles/{role_id}` |
 | POST | `/api/workspace-repo-changesets` |
+| GET | `/api/workspace-repo-changesets/recoverable-git-closures` |
 | GET | `/api/workspace-repo-changesets/state` |
 | GET | `/api/workspace-repo-changesets/{changeset_id}` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/abort` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/activate` |
 | GET | `/api/workspace-repo-changesets/{changeset_id}/diff` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/files` |
+| POST | `/api/workspace-repo-changesets/{changeset_id}/retry-git-closure` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/validate` |
 | POST | `/auth/admin/revoke-user` |
 | GET | `/auth/cli/authorize` |

--- a/api/src/repositories/workspace_repo_changesets.py
+++ b/api/src/repositories/workspace_repo_changesets.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.orm.workspace_repo_changesets import WorkspaceRepoChangeset
@@ -40,3 +40,30 @@ class WorkspaceRepoChangesetRepository:
             )
         )
         return int((await self.db.execute(stmt)).scalar_one())
+
+    async def list_retryable_git_failures(
+        self, organization_id: UUID, *, scope: str | None = None
+    ) -> list[WorkspaceRepoChangeset]:
+        failure_phase = WorkspaceRepoChangeset.failure_detail["phase"].astext
+        failure_state = WorkspaceRepoChangeset.failure_detail["state"].astext
+        stmt = (
+            select(WorkspaceRepoChangeset)
+            .where(
+                WorkspaceRepoChangeset.organization_id == organization_id,
+                failure_state == "failed",
+                or_(
+                    and_(
+                        WorkspaceRepoChangeset.status == "activated",
+                        failure_phase == "git_closure",
+                    ),
+                    and_(
+                        WorkspaceRepoChangeset.status == "committed_unpushed",
+                        failure_phase == "git_push",
+                    ),
+                ),
+            )
+            .order_by(WorkspaceRepoChangeset.updated_at.desc())
+        )
+        if scope is not None:
+            stmt = stmt.where(WorkspaceRepoChangeset.scope == scope)
+        return list((await self.db.execute(stmt)).scalars().all())

--- a/api/src/routers/workspace_repo_changesets.py
+++ b/api/src/routers/workspace_repo_changesets.py
@@ -112,6 +112,24 @@ async def begin_workspace_repo_changeset(
         raise _translate(exc) from exc
 
 
+@router.get(
+    "/recoverable-git-closures",
+    response_model=list[WorkspaceRepoChangesetResponse],
+)
+async def list_recoverable_workspace_repo_git_closures(
+    ctx: Context,
+    db: DbSession,
+    user: CurrentSuperuser,
+    scope: str | None = None,
+):
+    try:
+        return await (await _service(db, ctx.org_id)).recoverable_git_closures(
+            scope=scope
+        )
+    except Exception as exc:
+        raise _translate(exc) from exc
+
+
 @router.get("/{changeset_id}", response_model=WorkspaceRepoChangesetResponse)
 async def show_workspace_repo_changeset(
     changeset_id: UUID, ctx: Context, db: DbSession, user: CurrentSuperuser

--- a/api/src/routers/workspace_repo_changesets.py
+++ b/api/src/routers/workspace_repo_changesets.py
@@ -31,13 +31,20 @@ router = APIRouter(
 
 async def _service(db: DbSession, org_id: UUID | None) -> WorkspaceRepoChangesetService:
     org_id = require_organization_id(org_id)
-    from src.services.github_config import get_github_config
+    from src.services.github_config import (
+        build_authenticated_github_url,
+        get_github_config,
+    )
     from src.services.github_sync import GitHubSyncService
 
     config = await get_github_config(db, org_id)
     callback = None
-    if config and config.repo_url:
-        git = GitHubSyncService(db, config.repo_url, config.branch)
+    if config and config.repo_url and config.token:
+        git = GitHubSyncService(
+            db,
+            build_authenticated_github_url(config.repo_url, config.token),
+            config.branch,
+        )
 
         async def commit(message: str, push: bool) -> tuple[str | None, str | None]:
             return await git.commit_workspace_changes(message, push=push)
@@ -160,6 +167,25 @@ async def activate_workspace_repo_changeset(
     try:
         return await (await _service(db, ctx.org_id)).activate(
             changeset_id, request, user.email
+        )
+    except Exception as exc:
+        raise _translate(exc) from exc
+
+
+@router.post(
+    "/{changeset_id}/retry-git-closure",
+    response_model=WorkspaceRepoChangesetResponse,
+)
+async def retry_workspace_repo_git_closure(
+    changeset_id: UUID,
+    request: WorkspaceRepoActivateRequest,
+    ctx: Context,
+    db: DbSession,
+    user: CurrentSuperuser,
+):
+    try:
+        return await (await _service(db, ctx.org_id)).retry_git_closure(
+            changeset_id, request
         )
     except Exception as exc:
         raise _translate(exc) from exc

--- a/api/src/scheduler/main.py
+++ b/api/src/scheduler/main.py
@@ -386,17 +386,9 @@ class Scheduler:
     @staticmethod
     def _build_clone_url_from_config(config) -> str:
         """Build an authenticated git clone URL from a GitHubConfig object."""
-        repo_url = config.repo_url
+        from src.services.github_config import build_authenticated_github_url
 
-        # Extract owner/repo from URL
-        if repo_url.startswith("https://github.com/"):
-            repo = repo_url.replace("https://github.com/", "")
-            if repo.endswith(".git"):
-                repo = repo[:-4]
-        else:
-            repo = repo_url
-
-        return f"https://x-access-token:{config.token}@github.com/{repo}.git"
+        return build_authenticated_github_url(config.repo_url, config.token)
 
     async def _handle_reimport(self, data: dict) -> None:
         """

--- a/api/src/services/github_config.py
+++ b/api/src/services/github_config.py
@@ -6,6 +6,7 @@ Handles encrypted storage of GitHub integration configuration.
 
 import base64
 import logging
+import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
@@ -29,6 +30,16 @@ class GitHubConfig:
     branch: str
     status: str
     last_synced_at: str | None = None
+
+
+def build_authenticated_github_url(repo_url: str, token: str) -> str:
+    """Return the authenticated HTTPS URL used by GitPython operations."""
+    normalized = repo_url.strip()
+    prefix = "https://github.com/"
+    repository = normalized[len(prefix) :] if normalized.startswith(prefix) else normalized
+    repository = repository.removesuffix(".git").strip("/")
+    encoded_token = urllib.parse.quote(token, safe="")
+    return f"https://x-access-token:{encoded_token}@github.com/{repository}.git"
 
 
 def _get_fernet() -> Fernet:

--- a/api/src/services/github_config.py
+++ b/api/src/services/github_config.py
@@ -37,7 +37,7 @@ def build_authenticated_github_url(repo_url: str, token: str) -> str:
     normalized = repo_url.strip()
     prefix = "https://github.com/"
     repository = normalized[len(prefix) :] if normalized.startswith(prefix) else normalized
-    repository = repository.removesuffix(".git").strip("/")
+    repository = repository.strip("/").removesuffix(".git")
     encoded_token = urllib.parse.quote(token, safe="")
     return f"https://x-access-token:{encoded_token}@github.com/{repository}.git"
 

--- a/api/src/services/workspace_repo_changesets.py
+++ b/api/src/services/workspace_repo_changesets.py
@@ -439,6 +439,15 @@ class WorkspaceRepoChangesetService:
             )
         return await self._complete_git_closure(changeset_id, request)
 
+    async def recoverable_git_closures(
+        self, *, scope: str | None = None
+    ) -> list[WorkspaceRepoChangesetResponse]:
+        """List this organization's explicit failed Git closure records."""
+        rows = await self.rows.list_retryable_git_failures(
+            self.organization_id, scope=scope
+        )
+        return [self._response(row) for row in rows]
+
     async def _complete_git_closure(
         self,
         changeset_id: UUID,

--- a/api/src/services/workspace_repo_changesets.py
+++ b/api/src/services/workspace_repo_changesets.py
@@ -67,6 +67,10 @@ CommitCallback = Callable[[str, bool], Awaitable[tuple[str | None, str | None]]]
 class WorkspaceRepoChangesetService:
     ACTIVE = {"open", "staged", "validated"}
     ABORTABLE = ACTIVE | {"conflicted"}
+    RETRYABLE_GIT_FAILURES = {
+        ("activated", "git_closure"),
+        ("committed_unpushed", "git_push"),
+    }
 
     def __init__(
         self,
@@ -407,6 +411,40 @@ class WorkspaceRepoChangesetService:
                 raise RuntimeError(row.error) from exc
             raise
 
+        return await self._complete_git_closure(changeset_id, request)
+
+    async def retry_git_closure(
+        self,
+        changeset_id: UUID,
+        request: WorkspaceRepoActivateRequest,
+    ) -> WorkspaceRepoChangesetResponse:
+        """Retry only failed Git closure after workspace activation succeeded."""
+        await self.db.execute(
+            text(
+                "SELECT pg_advisory_xact_lock(hashtext('bifrost:workspace-repo-changesets'))"
+            )
+        )
+        row = await self._required(changeset_id, for_update=True)
+        failure = row.failure_detail if isinstance(row.failure_detail, dict) else {}
+        retry_key = (row.status, str(failure.get("phase") or ""))
+        if retry_key not in self.RETRYABLE_GIT_FAILURES or failure.get("state") != "failed":
+            raise ChangesetInvalid(
+                f"changeset in {row.status!r} state does not have a retryable Git closure failure"
+            )
+        if not request.commit_message:
+            raise ChangesetInvalid("retrying Git closure requires commit_message")
+        if row.status == "committed_unpushed" and not request.push:
+            raise ChangesetInvalid(
+                "retrying an unpushed changeset requires push=true"
+            )
+        return await self._complete_git_closure(changeset_id, request)
+
+    async def _complete_git_closure(
+        self,
+        changeset_id: UUID,
+        request: WorkspaceRepoActivateRequest,
+    ) -> WorkspaceRepoChangesetResponse:
+        row = await self._required(changeset_id, for_update=True)
         if not request.commit_message:
             return self._response(row)
         if self.commit_callback is None:

--- a/api/tests/e2e/platform/test_workspace_repo_changesets.py
+++ b/api/tests/e2e/platform/test_workspace_repo_changesets.py
@@ -1,10 +1,16 @@
 """HTTP contract coverage for authoritative workspace _repo changesets."""
 
 import base64
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
+from git import Repo as GitRepo
+from sqlalchemy import delete, select
 
+from src.models.orm.config import SystemConfig
+from src.models.orm.users import User
+from src.models.orm.workspace_repo_changesets import WorkspaceRepoChangeset
+from src.services.github_config import save_github_config
 from src.services.repo_storage import RepoStorage
 
 
@@ -78,3 +84,136 @@ def test_workspace_repo_changeset_stages_validates_and_activates_atomically(
         import asyncio
 
         asyncio.run(RepoStorage().delete(path))
+
+
+@pytest.mark.e2e
+def test_workspace_repo_git_closure_retry_requires_authentication(e2e_client):
+    response = e2e_client.post(
+        f"/api/workspace-repo-changesets/{uuid4()}/retry-git-closure",
+        json={"commit_message": "e2e retry", "push": True},
+    )
+
+    assert response.status_code in {401, 403}
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_workspace_repo_git_closure_retry_is_org_scoped_and_state_guarded(
+    e2e_client, platform_admin, org1, db_session
+):
+    admin = (
+        await db_session.execute(
+            select(User).where(User.id == platform_admin.user_id)
+        )
+    ).scalar_one()
+    assert admin.organization_id is not None
+    cross_org = WorkspaceRepoChangeset(
+        organization_id=UUID(org1["id"]),
+        scope=f"test_changesets_{uuid4().hex}",
+        base_revision="0" * 64,
+        base_files={},
+        mutations=[],
+        status="activated",
+        created_by=admin.id,
+        failure_detail={"phase": "git_closure", "state": "failed"},
+    )
+    db_session.add(cross_org)
+    await db_session.commit()
+    try:
+        scoped = e2e_client.post(
+            f"/api/workspace-repo-changesets/{cross_org.id}/retry-git-closure",
+            headers=platform_admin.headers,
+            json={"commit_message": "e2e retry", "push": True},
+        )
+        assert scoped.status_code == 404, scoped.text
+
+        started = e2e_client.post(
+            "/api/workspace-repo-changesets",
+            headers=platform_admin.headers,
+            json={"scope": f"test_changesets_{uuid4().hex}"},
+        )
+        assert started.status_code == 201, started.text
+        invalid = e2e_client.post(
+            f"/api/workspace-repo-changesets/{started.json()['id']}/retry-git-closure",
+            headers=platform_admin.headers,
+            json={"commit_message": "e2e retry", "push": True},
+        )
+        assert invalid.status_code == 422, invalid.text
+    finally:
+        await db_session.execute(
+            delete(WorkspaceRepoChangeset).where(
+                WorkspaceRepoChangeset.id.in_([cross_org.id, started.json()["id"]])
+            )
+        )
+        await db_session.commit()
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_workspace_repo_git_closure_retry_succeeds_without_reactivation(
+    e2e_client, platform_admin, db_session, tmp_path
+):
+    admin = (
+        await db_session.execute(
+            select(User).where(User.id == platform_admin.user_id)
+        )
+    ).scalar_one()
+    assert admin.organization_id is not None
+    await save_github_config(
+        db_session,
+        admin.organization_id,
+        "e2e-placeholder-token",
+        "https://github.com/example/repo",
+        "main",
+        "e2e",
+    )
+    repo = GitRepo.init(tmp_path)
+    with repo.config_writer() as config:
+        config.set_value("user", "name", "Bifrost E2E")
+        config.set_value("user", "email", "e2e@example.test")
+    seed = tmp_path / "README.md"
+    seed.write_text("e2e git closure seed\n")
+    repo.index.add([seed.name])
+    repo.index.commit("seed e2e repository")
+    storage = RepoStorage()
+    for repo_path in tmp_path.rglob("*"):
+        if repo_path.is_file():
+            relative = repo_path.relative_to(tmp_path).as_posix()
+            await storage.write(relative, repo_path.read_bytes())
+    assert await storage.exists(".git/HEAD")
+    row = WorkspaceRepoChangeset(
+        organization_id=admin.organization_id,
+        scope=f"test_changesets_{uuid4().hex}",
+        base_revision="0" * 64,
+        base_files={},
+        mutations=[],
+        status="activated",
+        created_by=admin.id,
+        activated_revision="a" * 64,
+        failure_detail={"phase": "git_closure", "state": "failed"},
+    )
+    db_session.add(row)
+    await db_session.commit()
+    try:
+        retried = e2e_client.post(
+            f"/api/workspace-repo-changesets/{row.id}/retry-git-closure",
+            headers=platform_admin.headers,
+            json={"commit_message": "e2e retry", "push": False},
+        )
+
+        assert retried.status_code == 200, retried.text
+        assert retried.json()["status"] == "committed", retried.text
+        assert retried.json()["activated_revision"] == "a" * 64
+        assert retried.json()["failure_detail"] is None
+    finally:
+        await db_session.execute(
+            delete(WorkspaceRepoChangeset).where(WorkspaceRepoChangeset.id == row.id)
+        )
+        await db_session.execute(
+            delete(SystemConfig).where(
+                SystemConfig.organization_id == admin.organization_id,
+                SystemConfig.category == "github",
+                SystemConfig.key == "integration",
+            )
+        )
+        await db_session.commit()

--- a/api/tests/unit/routers/test_workspace_repo_changesets.py
+++ b/api/tests/unit/routers/test_workspace_repo_changesets.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from src.routers import workspace_repo_changesets
+
+
+@pytest.mark.asyncio
+async def test_service_uses_authenticated_github_remote(monkeypatch):
+    organization_id = uuid4()
+    config = SimpleNamespace(
+        repo_url="https://github.com/example/repo",
+        token="token:/@ value",
+        branch="production-live",
+    )
+    get_config = AsyncMock(return_value=config)
+    commit_workspace_changes = AsyncMock(return_value=("a" * 40, None))
+    constructor_args = []
+
+    class GitService:
+        def __init__(self, db, repo_url, branch):
+            constructor_args.append((db, repo_url, branch))
+            self.commit_workspace_changes = commit_workspace_changes
+
+    monkeypatch.setattr("src.services.github_config.get_github_config", get_config)
+    monkeypatch.setattr("src.services.github_sync.GitHubSyncService", GitService)
+    db = Mock()
+
+    service = await workspace_repo_changesets._service(db, organization_id)
+    assert service.commit_callback is not None
+    result = await service.commit_callback("release source", True)
+
+    assert constructor_args == [
+        (
+            db,
+            "https://x-access-token:token%3A%2F%40%20value@github.com/example/repo.git",
+            "production-live",
+        )
+    ]
+    assert result == ("a" * 40, None)
+    commit_workspace_changes.assert_awaited_once_with("release source", push=True)

--- a/api/tests/unit/services/test_github_config.py
+++ b/api/tests/unit/services/test_github_config.py
@@ -11,6 +11,7 @@ from src.services import github_config
 from src.services.github_config import (
     GitHubConfig,
     _parse_org_id,
+    build_authenticated_github_url,
     delete_github_config,
     get_github_config,
     save_github_config,
@@ -65,6 +66,25 @@ def test_parse_org_id_accepts_global_none_uuid_and_invalid() -> None:
     assert _parse_org_id(org_uuid) == org_uuid
     assert _parse_org_id(str(org_uuid)) == org_uuid
     assert _parse_org_id("not-a-uuid") is None
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "expected_repository"),
+    [
+        ("https://github.com/example/repo", "example/repo"),
+        ("https://github.com/example/repo.git", "example/repo"),
+        ("example/repo", "example/repo"),
+    ],
+)
+def test_build_authenticated_github_url_normalizes_repo_and_encodes_token(
+    repo_url: str, expected_repository: str
+) -> None:
+    result = build_authenticated_github_url(repo_url, "token:/@ value")
+
+    assert result == (
+        f"https://x-access-token:token%3A%2F%40%20value@github.com/"
+        f"{expected_repository}.git"
+    )
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_github_config.py
+++ b/api/tests/unit/services/test_github_config.py
@@ -73,6 +73,7 @@ def test_parse_org_id_accepts_global_none_uuid_and_invalid() -> None:
     [
         ("https://github.com/example/repo", "example/repo"),
         ("https://github.com/example/repo.git", "example/repo"),
+        ("https://github.com/example/repo.git/", "example/repo"),
         ("example/repo", "example/repo"),
     ],
 )

--- a/api/tests/unit/services/test_workspace_repo_changesets.py
+++ b/api/tests/unit/services/test_workspace_repo_changesets.py
@@ -433,6 +433,103 @@ async def test_git_commit_failure_preserves_activation_with_recovery_evidence(mo
 
 
 @pytest.mark.asyncio
+async def test_retry_git_closure_does_not_replay_workspace_activation(monkeypatch):
+    callback_calls = []
+
+    async def failing_commit(message, push):
+        callback_calls.append((message, push))
+        raise RuntimeError("credentials unavailable")
+
+    svc = WorkspaceRepoChangesetService(
+        FakeDB(),
+        uuid4(),
+        repo=MemoryRepo({"features/a.txt": b"a"}),
+        commit_callback=failing_commit,
+    )
+    svc.rows = MemoryRows()
+    row = await svc.begin(WorkspaceRepoChangesetBegin(scope="features"), uuid4())
+    await svc.stage(
+        row.id,
+        WorkspaceRepoFileMutationRequest(
+            path="features/a.txt",
+            operation="write",
+            content_base64=base64.b64encode(b"A").decode(),
+        ),
+    )
+    stored = svc.rows.items[row.id]
+    stored.validation = {"valid": True}
+    stored.status = "validated"
+
+    class CountingStorage:
+        writes = 0
+
+        def __init__(self, _db):
+            pass
+
+        async def write_file(self, path, content, **_kwargs):
+            type(self).writes += 1
+            await svc.repo.write(path, content)
+            return SimpleNamespace(pending_deactivations=[])
+
+    monkeypatch.setattr(
+        "src.services.workspace_repo_changesets.FileStorageService", CountingStorage
+    )
+    failed = await svc.activate(
+        row.id,
+        WorkspaceRepoActivateRequest(commit_message="release source", push=True),
+        "tester",
+    )
+    assert failed.status == "activated"
+    assert CountingStorage.writes == 1
+
+    async def successful_commit(message, push):
+        callback_calls.append((message, push))
+        return "b" * 40, None
+
+    svc.commit_callback = successful_commit
+    closed = await svc.retry_git_closure(
+        row.id,
+        WorkspaceRepoActivateRequest(commit_message="release source", push=True),
+    )
+
+    assert closed.status == "committed"
+    assert closed.commit_sha == "b" * 40
+    assert closed.failure_detail is None
+    assert CountingStorage.writes == 1
+    assert callback_calls == [
+        ("release source", True),
+        ("release source", True),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retry_git_closure_rejects_non_retryable_state():
+    svc = service({"features/a.txt": b"a"})
+    row = await svc.begin(WorkspaceRepoChangesetBegin(scope="features"), uuid4())
+
+    with pytest.raises(ChangesetInvalid, match="does not have a retryable"):
+        await svc.retry_git_closure(
+            row.id,
+            WorkspaceRepoActivateRequest(commit_message="release source", push=True),
+        )
+
+
+@pytest.mark.asyncio
+async def test_retry_committed_unpushed_requires_push():
+    svc = service({"features/a.txt": b"a"})
+    row = await svc.begin(WorkspaceRepoChangesetBegin(scope="features"), uuid4())
+    stored = svc.rows.items[row.id]
+    stored.status = "committed_unpushed"
+    stored.failure_detail = {"phase": "git_push", "state": "failed"}
+
+    with pytest.raises(ChangesetInvalid, match="requires push=true"):
+        await svc.retry_git_closure(
+            row.id,
+            WorkspaceRepoActivateRequest(commit_message="release source"),
+        )
+
+
+@pytest.mark.asyncio
 async def test_activation_records_committed_unpushed_without_rolling_back(monkeypatch):
     async def commit(_message, _push):
         return "a" * 40, "remote rejected push"

--- a/api/tests/unit/services/test_workspace_repo_changesets.py
+++ b/api/tests/unit/services/test_workspace_repo_changesets.py
@@ -65,6 +65,18 @@ class MemoryRows:
             for row in self.items.values()
         )
 
+    async def list_retryable_git_failures(self, organization_id, *, scope=None):
+        return [
+            row
+            for row in self.items.values()
+            if row.organization_id == organization_id
+            and (scope is None or row.scope == scope)
+            and row.failure_detail
+            and row.failure_detail.get("state") == "failed"
+            and (row.status, row.failure_detail.get("phase"))
+            in WorkspaceRepoChangesetService.RETRYABLE_GIT_FAILURES
+        ]
+
 
 class FakeDB:
     def __init__(self):
@@ -527,6 +539,25 @@ async def test_retry_committed_unpushed_requires_push():
             row.id,
             WorkspaceRepoActivateRequest(commit_message="release source"),
         )
+
+
+@pytest.mark.asyncio
+async def test_recoverable_git_closures_are_scope_bounded():
+    svc = service({"features/a.txt": b"a", "features/b.txt": b"b"})
+    first = await svc.begin(
+        WorkspaceRepoChangesetBegin(scope="features/a.txt"), uuid4()
+    )
+    second = await svc.begin(
+        WorkspaceRepoChangesetBegin(scope="features/b.txt"), uuid4()
+    )
+    for row in (first, second):
+        stored = svc.rows.items[row.id]
+        stored.status = "activated"
+        stored.failure_detail = {"phase": "git_closure", "state": "failed"}
+
+    result = await svc.recoverable_git_closures(scope="features/a.txt")
+
+    assert [row.id for row in result] == [first.id]
 
 
 @pytest.mark.asyncio

--- a/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/openapi-digest.md
@@ -507,12 +507,14 @@
 | POST | `/api/workflows/{workflow_id}/roles` |
 | DELETE | `/api/workflows/{workflow_id}/roles/{role_id}` |
 | POST | `/api/workspace-repo-changesets` |
+| GET | `/api/workspace-repo-changesets/recoverable-git-closures` |
 | GET | `/api/workspace-repo-changesets/state` |
 | GET | `/api/workspace-repo-changesets/{changeset_id}` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/abort` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/activate` |
 | GET | `/api/workspace-repo-changesets/{changeset_id}/diff` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/files` |
+| POST | `/api/workspace-repo-changesets/{changeset_id}/retry-git-closure` |
 | POST | `/api/workspace-repo-changesets/{changeset_id}/validate` |
 | POST | `/auth/admin/revoke-user` |
 | GET | `/auth/cli/authorize` |


### PR DESCRIPTION
## Outcome
Transactional workspace changesets now use the saved GitHub credential when committing and pushing, instead of overwriting the persistent origin with an unauthenticated URL. An explicit recovery listing and retry endpoint can identify and finish Git closure for an already-activated changeset without replaying source activation.

## Delivery lane
Lane 3: Platform or live operations. This touches saved GitHub credential use and production source Git closure. Human review is required.

## Sensitive-path and risk notes
- Uses the existing encrypted GitHub integration token and established authenticated-remote convention.
- Recovery listing is organization- and optionally scope-bounded.
- Retry is restricted to recorded failed Git-closure states.
- Workspace activation is never replayed by retry.
- Committed-but-unpushed recovery requires `push=true`.

## Verification
- `./test.sh tests/unit/services/test_github_config.py tests/unit/services/test_workspace_repo_changesets.py tests/unit/services/test_workspace_repo_changeset_git_closure.py` (28 passed before recovery listing)
- `./test.sh tests/unit/services/test_workspace_repo_changesets.py tests/unit/routers/test_workspace_repo_changesets.py` (16 passed after recovery listing)
- `./test.sh quality api` (Pyright 0 errors; Ruff passed after final changes)

## Live verification after deploy
List recoverable closures for the exact backup-restore source path, require exactly one failed result, retry it with the same commit message and `push=true`, then verify the `production-live` remote branch and read back the exact workspace source revision.

## Rollback
Revert this PR. The already-activated workspace source remains authoritative; the retry route only operates on explicit recorded Git failures.