### PR TITLE
Reconcile advanced branch during workspace Git closure

### DIFF
--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -726,6 +726,42 @@ class GitHubSyncService:
             pushed_commits=ahead,
         )
 
+    def _reconcile_remote_before_workspace_push(
+        self, work_dir: Path, repo: GitRepo
+    ) -> str | None:
+        """Merge an advanced remote branch before closing a workspace commit.
+
+        A workspace changeset can remain activated while Git closure is retried
+        later. The configured production branch may advance during that gap, so
+        pushing the preserved local commit directly would be non-fast-forward.
+        Fetch and merge the remote history without replaying workspace
+        activation or importing remote files into the live workspace.
+        """
+        remote_ref = f"origin/{self.branch}"
+        try:
+            repo.remotes.origin.fetch(self.branch)
+            commits_behind = int(repo.git.rev_list("--count", f"HEAD..{remote_ref}"))
+        except Exception as exc:
+            return f"Failed to fetch remote branch before workspace push: {exc}"
+
+        if commits_behind == 0:
+            return None
+
+        try:
+            repo.git.merge("--no-edit", remote_ref)
+        except Exception as exc:
+            try:
+                if (work_dir / ".git" / "MERGE_HEAD").exists():
+                    repo.git.merge("--abort")
+            except Exception as abort_exc:
+                logger.error(
+                    "Failed to abort workspace Git closure merge: %s", abort_exc
+                )
+            return (
+                f"Failed to merge advanced remote branch before workspace push: {exc}"
+            )
+        return None
+
     # -----------------------------------------------------------------
     # Desktop-style operations: fetch, status, commit, sync, resolve, diff
     # -----------------------------------------------------------------
@@ -850,6 +886,11 @@ class GitHubSyncService:
                 raise RuntimeError(result.error or "Git commit failed")
             commit_sha = result.commit_sha
             if push:
+                reconciliation_error = self._reconcile_remote_before_workspace_push(
+                    work_dir, repo
+                )
+                if reconciliation_error:
+                    return commit_sha, reconciliation_error
                 pushed = self._do_push(work_dir, repo)
                 if not pushed.success:
                     return commit_sha, pushed.error or "Git push failed"

--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -742,6 +742,13 @@ class GitHubSyncService:
             repo.remotes.origin.fetch(self.branch)
             commits_behind = int(repo.git.rev_list("--count", f"HEAD..{remote_ref}"))
         except Exception as exc:
+            error_text = str(exc).lower()
+            if (
+                "not found" in error_text
+                or "empty" in error_text
+                or "couldn't find remote ref" in error_text
+            ):
+                return None
             return f"Failed to fetch remote branch before workspace push: {exc}"
 
         if commits_behind == 0:

--- a/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
+++ b/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
@@ -119,6 +119,36 @@ async def test_workspace_repo_commit_closure_returns_remote_reconciliation_error
     service._do_push.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_workspace_repo_commit_closure_pushes_when_remote_branch_is_missing(
+    tmp_path,
+):
+    service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
+
+    @asynccontextmanager
+    async def checkout():
+        yield tmp_path
+
+    service.repo_manager = SimpleNamespace(checkout=checkout)
+    repo = Mock()
+    repo.remotes.origin.fetch.side_effect = RuntimeError(
+        "couldn't find remote ref production-live"
+    )
+    service._open_or_init = Mock(return_value=repo)
+    service._do_commit = AsyncMock(
+        return_value=SimpleNamespace(success=True, commit_sha="a" * 40, error=None)
+    )
+    service._do_push = Mock(
+        return_value=SimpleNamespace(success=True, commit_sha="b" * 40, error=None)
+    )
+
+    sha, push_error = await service.commit_workspace_changes("agent change", push=True)
+
+    assert sha == "b" * 40
+    assert push_error is None
+    service._do_push.assert_called_once_with(tmp_path, repo)
+
+
 def test_workspace_repo_remote_reconciliation_merges_advanced_branch(tmp_path):
     service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
     service.branch = "production-live"

--- a/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
+++ b/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
@@ -54,11 +54,15 @@ async def test_workspace_repo_commit_closure_pushes_only_when_requested(tmp_path
     service._do_push = Mock(
         return_value=SimpleNamespace(success=True, commit_sha="b" * 40, error=None)
     )
+    service._reconcile_remote_before_workspace_push = Mock(return_value=None)
 
     sha, push_error = await service.commit_workspace_changes("agent change", push=True)
 
     assert sha == "b" * 40
     assert push_error is None
+    service._reconcile_remote_before_workspace_push.assert_called_once_with(
+        tmp_path, repo
+    )
     service._do_push.assert_called_once_with(tmp_path, repo)
 
 
@@ -79,8 +83,69 @@ async def test_workspace_repo_commit_closure_returns_commit_when_push_fails(tmp_
     service._do_push = Mock(
         return_value=SimpleNamespace(success=False, commit_sha=None, error="rejected")
     )
+    service._reconcile_remote_before_workspace_push = Mock(return_value=None)
 
     sha, push_error = await service.commit_workspace_changes("agent change", push=True)
 
     assert sha == "a" * 40
     assert push_error == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_workspace_repo_commit_closure_returns_remote_reconciliation_error(
+    tmp_path,
+):
+    service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
+
+    @asynccontextmanager
+    async def checkout():
+        yield tmp_path
+
+    service.repo_manager = SimpleNamespace(checkout=checkout)
+    repo = Mock()
+    service._open_or_init = Mock(return_value=repo)
+    service._do_commit = AsyncMock(
+        return_value=SimpleNamespace(success=True, commit_sha="a" * 40, error=None)
+    )
+    service._reconcile_remote_before_workspace_push = Mock(
+        return_value="remote merge failed"
+    )
+    service._do_push = Mock()
+
+    sha, push_error = await service.commit_workspace_changes("agent change", push=True)
+
+    assert sha == "a" * 40
+    assert push_error == "remote merge failed"
+    service._do_push.assert_not_called()
+
+
+def test_workspace_repo_remote_reconciliation_merges_advanced_branch(tmp_path):
+    service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
+    service.branch = "production-live"
+    repo = Mock()
+    repo.git.rev_list.return_value = "2"
+
+    error = service._reconcile_remote_before_workspace_push(tmp_path, repo)
+
+    assert error is None
+    repo.remotes.origin.fetch.assert_called_once_with("production-live")
+    repo.git.rev_list.assert_called_once_with("--count", "HEAD..origin/production-live")
+    repo.git.merge.assert_called_once_with("--no-edit", "origin/production-live")
+
+
+def test_workspace_repo_remote_reconciliation_aborts_conflicted_merge(tmp_path):
+    service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
+    service.branch = "production-live"
+    repo = Mock()
+    repo.git.rev_list.return_value = "1"
+    repo.git.merge.side_effect = [RuntimeError("conflict"), None]
+    merge_head = tmp_path / ".git" / "MERGE_HEAD"
+    merge_head.parent.mkdir()
+    merge_head.write_text("remote-sha\n")
+
+    error = service._reconcile_remote_before_workspace_push(tmp_path, repo)
+
+    assert error == (
+        "Failed to merge advanced remote branch before workspace push: conflict"
+    )
+    assert repo.git.merge.call_args_list[-1].args == ("--abort",)


### PR DESCRIPTION
## What changed

- Fetch and merge an advanced configured remote branch before a workspace changeset pushes its preserved local commit.
- Abort a conflicted reconciliation cleanly and retain an explicit retryable closure error.
- Keep reconciliation scoped to Git history: no workspace activation replay and no remote entity import.

## Root cause

The authenticated retry created the preserved workspace commit, but `production-live` had advanced since the original closure failure. A direct push was therefore rejected as non-fast-forward.

## Validation

- `ruff check` passed for both changed files.
- `pytest tests/unit/services/test_workspace_repo_changeset_git_closure.py -q` — 6 passed.
- Coverage includes an advanced branch, conflicted merge abort, reconciliation failure, successful push, and push failure.

## Operational impact

Once deployed, retrying changeset `1f959f0a-75da-4397-b2e3-dd21027566ac` will merge current `production-live` history before pushing, without force-push or replaying live workspace activation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace pushes now reconcile with newer remote changes before pushing.
  * Prevents overwriting remote updates when the branch has advanced.
  * Reports clear errors when remote synchronization or merging fails.
  * Automatically aborts conflicted merges and skips the push to protect changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->