### PR TITLE
Support unrelated workspace Git histories

### DIFF
--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -735,7 +735,10 @@ class GitHubSyncService:
         later. The configured production branch may advance during that gap, so
         pushing the preserved local commit directly would be non-fast-forward.
         Fetch and merge the remote history without replaying workspace
-        activation or importing remote files into the live workspace.
+        activation or importing remote files into the live workspace. Older
+        workspace repositories and their configured production branches may
+        have been initialized independently, so the merge must also support
+        unrelated root histories while retaining normal conflict protection.
         """
         remote_ref = f"origin/{self.branch}"
         try:
@@ -755,7 +758,7 @@ class GitHubSyncService:
             return None
 
         try:
-            repo.git.merge("--no-edit", remote_ref)
+            repo.git.merge("--no-edit", "--allow-unrelated-histories", remote_ref)
         except Exception as exc:
             try:
                 if (work_dir / ".git" / "MERGE_HEAD").exists():

--- a/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
+++ b/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
@@ -149,7 +149,9 @@ async def test_workspace_repo_commit_closure_pushes_when_remote_branch_is_missin
     service._do_push.assert_called_once_with(tmp_path, repo)
 
 
-def test_workspace_repo_remote_reconciliation_merges_advanced_branch(tmp_path):
+def test_workspace_repo_remote_reconciliation_merges_advanced_unrelated_branch(
+    tmp_path,
+):
     service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
     service.branch = "production-live"
     repo = Mock()
@@ -160,7 +162,9 @@ def test_workspace_repo_remote_reconciliation_merges_advanced_branch(tmp_path):
     assert error is None
     repo.remotes.origin.fetch.assert_called_once_with("production-live")
     repo.git.rev_list.assert_called_once_with("--count", "HEAD..origin/production-live")
-    repo.git.merge.assert_called_once_with("--no-edit", "origin/production-live")
+    repo.git.merge.assert_called_once_with(
+        "--no-edit", "--allow-unrelated-histories", "origin/production-live"
+    )
 
 
 def test_workspace_repo_remote_reconciliation_aborts_conflicted_merge(tmp_path):


### PR DESCRIPTION
## What changed

- Allow guarded workspace Git closure to merge an advanced `production-live` branch when the local workspace repo and remote branch have unrelated root histories.
- Retain the existing no-force-push behavior and conflict abort protection.
- Update the focused regression assertion for the exact merge contract.

## Root cause

The prior reconciliation fix correctly fetched the advanced production branch, but Git refused the merge because the historical workspace repository and GitHub `production-live` branch were initialized independently. The retry therefore remained `committed_unpushed` without changing the remote.

## Validation

- Focused platform tests: 7 passed.
- Ruff passed for both changed files.

## Production Release Notes

Workspace Git-closure retries can now safely reconcile independently initialized production branch history before pushing. Conflicts still abort without a force-push, and live workspace activation is not replayed. Roll back this commit if independently rooted branch reconciliation causes an unexpected conflict; the changeset remains retryable and activation-preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace synchronization now supports merging remote branches with unrelated histories.
  * Existing conflict handling, abort behavior, and error reporting remain unchanged.

* **Tests**
  * Updated reconciliation coverage for advanced branches with unrelated histories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->