### PR TITLE
Preserve activated files during workspace Git closure

### DIFF
--- a/api/src/routers/workspace_repo_changesets.py
+++ b/api/src/routers/workspace_repo_changesets.py
@@ -46,8 +46,16 @@ async def _service(db: DbSession, org_id: UUID | None) -> WorkspaceRepoChangeset
             config.branch,
         )
 
-        async def commit(message: str, push: bool) -> tuple[str | None, str | None]:
-            return await git.commit_workspace_changes(message, push=push)
+        async def commit(
+            message: str,
+            push: bool,
+            expected_file_hashes: dict[str, str | None],
+        ) -> tuple[str | None, str | None]:
+            return await git.commit_workspace_changes(
+                message,
+                push=push,
+                expected_file_hashes=expected_file_hashes,
+            )
 
         callback = commit
     return WorkspaceRepoChangesetService(db, org_id, commit_callback=callback)

--- a/api/src/routers/workspace_repo_changesets.py
+++ b/api/src/routers/workspace_repo_changesets.py
@@ -49,12 +49,12 @@ async def _service(db: DbSession, org_id: UUID | None) -> WorkspaceRepoChangeset
         async def commit(
             message: str,
             push: bool,
-            expected_file_hashes: dict[str, str | None],
+            expected_file_hashes: dict[str, str | None] | None = None,
         ) -> tuple[str | None, str | None]:
             return await git.commit_workspace_changes(
                 message,
                 push=push,
-                expected_file_hashes=expected_file_hashes,
+                expected_file_hashes=expected_file_hashes or {},
             )
 
         callback = commit

--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Literal
 
 import yaml
 from git import Repo as GitRepo
+from git.exc import GitCommandError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -892,7 +893,13 @@ class GitHubSyncService:
             logger.error(f"Commit failed: {e}", exc_info=True)
             return CommitResult(success=False, error=str(e))
 
-    async def commit_workspace_changes(self, message: str, *, push: bool = False) -> tuple[str | None, str | None]:
+    async def commit_workspace_changes(
+        self,
+        message: str,
+        *,
+        push: bool = False,
+        expected_file_hashes: dict[str, str | None] | None = None,
+    ) -> tuple[str | None, str | None]:
         """Commit the current authoritative S3 workspace, optionally pushing it.
 
         Unlike ``desktop_commit`` this uses ``checkout()`` so direct workspace
@@ -901,13 +908,27 @@ class GitHubSyncService:
         """
         async with self.repo_manager.checkout() as work_dir:
             repo = self._open_or_init(work_dir)
+            self._prepare_expected_workspace_files(
+                work_dir,
+                repo,
+                expected_file_hashes or {},
+            )
             result = await self._do_commit(work_dir, repo, message)
             if not result.success:
                 raise RuntimeError(result.error or "Git commit failed")
+            self._verify_expected_workspace_tree(repo, expected_file_hashes or {})
             commit_sha = result.commit_sha
             if push:
                 reconciliation_error = self._reconcile_remote_before_workspace_push(
                     work_dir, repo
+                )
+                self._verify_expected_workspace_files(
+                    work_dir,
+                    expected_file_hashes or {},
+                )
+                self._verify_expected_workspace_tree(
+                    repo,
+                    expected_file_hashes or {},
                 )
                 if reconciliation_error:
                     return commit_sha, reconciliation_error
@@ -916,6 +937,89 @@ class GitHubSyncService:
                     return commit_sha, pushed.error or "Git push failed"
                 commit_sha = pushed.commit_sha or commit_sha
             return commit_sha, None
+
+    @staticmethod
+    def _verify_expected_workspace_files(
+        work_dir: Path,
+        expected_file_hashes: dict[str, str | None],
+    ) -> None:
+        """Fail when the materialized workspace differs from activated content."""
+        mismatches: list[str] = []
+        for path, expected_hash in expected_file_hashes.items():
+            file_path = GitRepoManager._safe_local_path(work_dir, path)
+            if expected_hash is None:
+                if file_path.exists():
+                    mismatches.append(f"{path}: expected deletion")
+                continue
+            if not file_path.is_file():
+                mismatches.append(f"{path}: missing")
+                continue
+            actual_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+            if actual_hash != expected_hash:
+                mismatches.append(
+                    f"{path}: expected {expected_hash}, found {actual_hash}"
+                )
+        if mismatches:
+            raise RuntimeError(
+                "Workspace Git checkout does not match activated changeset: "
+                + "; ".join(mismatches)
+            )
+
+    @classmethod
+    def _prepare_expected_workspace_files(
+        cls,
+        work_dir: Path,
+        repo: GitRepo,
+        expected_file_hashes: dict[str, str | None],
+    ) -> None:
+        """Validate activated files and make tracked paths visible to Git staging."""
+        cls._verify_expected_workspace_files(work_dir, expected_file_hashes)
+        for path in expected_file_hashes:
+            try:
+                repo.git.ls_files("--error-unmatch", "--", path)
+            except GitCommandError:
+                continue
+            repo.git.update_index(
+                "--no-assume-unchanged",
+                "--no-skip-worktree",
+                "--",
+                path,
+            )
+
+    @staticmethod
+    def _verify_expected_workspace_tree(
+        repo: GitRepo,
+        expected_file_hashes: dict[str, str | None],
+    ) -> None:
+        """Verify the commit tree contains each activated write or deletion."""
+        if not expected_file_hashes:
+            return
+        if not repo.head.is_valid():
+            raise RuntimeError("Workspace Git closure did not create a valid HEAD")
+
+        mismatches: list[str] = []
+        for path, expected_hash in expected_file_hashes.items():
+            try:
+                blob = repo.head.commit.tree / path
+            except KeyError:
+                blob = None
+            if expected_hash is None:
+                if blob is not None:
+                    mismatches.append(f"{path}: expected deletion")
+                continue
+            if blob is None or blob.type != "blob":
+                mismatches.append(f"{path}: missing from commit tree")
+                continue
+            actual_hash = hashlib.sha256(blob.data_stream.read()).hexdigest()
+            if actual_hash != expected_hash:
+                mismatches.append(
+                    f"{path}: expected {expected_hash}, committed {actual_hash}"
+                )
+        if mismatches:
+            raise RuntimeError(
+                "Workspace Git commit does not match activated changeset: "
+                + "; ".join(mismatches)
+            )
 
     async def desktop_sync(self, job_id: str | None = None, confirm_deletes: bool = False) -> "SyncResult":
         """Combined pull + push. The ONLY place entity import + S3 sync-up happen.

--- a/api/src/services/github_sync.py
+++ b/api/src/services/github_sync.py
@@ -999,27 +999,38 @@ class GitHubSyncService:
 
         mismatches: list[str] = []
         for path, expected_hash in expected_file_hashes.items():
-            try:
-                blob = repo.head.commit.tree / path
-            except KeyError:
-                blob = None
-            if expected_hash is None:
-                if blob is not None:
-                    mismatches.append(f"{path}: expected deletion")
-                continue
-            if blob is None or blob.type != "blob":
-                mismatches.append(f"{path}: missing from commit tree")
-                continue
-            actual_hash = hashlib.sha256(blob.data_stream.read()).hexdigest()
-            if actual_hash != expected_hash:
-                mismatches.append(
-                    f"{path}: expected {expected_hash}, committed {actual_hash}"
-                )
+            mismatch = GitHubSyncService._expected_workspace_tree_mismatch(
+                repo,
+                path,
+                expected_hash,
+            )
+            if mismatch:
+                mismatches.append(mismatch)
         if mismatches:
             raise RuntimeError(
                 "Workspace Git commit does not match activated changeset: "
                 + "; ".join(mismatches)
             )
+
+    @staticmethod
+    def _expected_workspace_tree_mismatch(
+        repo: GitRepo,
+        path: str,
+        expected_hash: str | None,
+    ) -> str | None:
+        """Return the path-specific commit-tree contract violation, if any."""
+        try:
+            blob = repo.head.commit.tree / path
+        except KeyError:
+            blob = None
+        if expected_hash is None:
+            return f"{path}: expected deletion" if blob is not None else None
+        if blob is None or blob.type != "blob":
+            return f"{path}: missing from commit tree"
+        actual_hash = hashlib.sha256(blob.data_stream.read()).hexdigest()
+        if actual_hash != expected_hash:
+            return f"{path}: expected {expected_hash}, committed {actual_hash}"
+        return None
 
     async def desktop_sync(self, job_id: str | None = None, confirm_deletes: bool = False) -> "SyncResult":
         """Combined pull + push. The ONLY place entity import + S3 sync-up happen.

--- a/api/src/services/workspace_repo_changesets.py
+++ b/api/src/services/workspace_repo_changesets.py
@@ -61,7 +61,10 @@ def require_organization_id(organization_id: UUID | None) -> UUID:
     return organization_id
 
 
-CommitCallback = Callable[[str, bool], Awaitable[tuple[str | None, str | None]]]
+CommitCallback = Callable[
+    [str, bool, dict[str, str | None]],
+    Awaitable[tuple[str | None, str | None]],
+]
 
 
 class WorkspaceRepoChangesetService:
@@ -477,8 +480,18 @@ class WorkspaceRepoChangesetService:
         await self.db.flush()
         await self.db.commit()
         try:
+            expected_file_hashes = {
+                item["path"]: (
+                    item.get("after_hash")
+                    if item.get("operation") == "write"
+                    else None
+                )
+                for item in row.mutations
+            }
             commit_sha, push_error = await self.commit_callback(
-                request.commit_message, request.push
+                request.commit_message,
+                request.push,
+                expected_file_hashes,
             )
         except Exception as exc:
             await self.db.rollback()

--- a/api/tests/unit/routers/test_workspace_repo_changesets.py
+++ b/api/tests/unit/routers/test_workspace_repo_changesets.py
@@ -40,4 +40,8 @@ async def test_service_uses_authenticated_github_remote(monkeypatch):
         )
     ]
     assert result == ("a" * 40, None)
-    commit_workspace_changes.assert_awaited_once_with("release source", push=True)
+    commit_workspace_changes.assert_awaited_once_with(
+        "release source",
+        push=True,
+        expected_file_hashes={},
+    )

--- a/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
+++ b/api/tests/unit/services/test_workspace_repo_changeset_git_closure.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+import hashlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -6,6 +7,14 @@ import pytest
 from git import Repo as GitRepo
 
 from src.services.github_sync import GitHubSyncService
+
+
+def _init_repo(path):
+    repo = GitRepo.init(path)
+    repo.config_writer().set_value("user", "name", "Test").set_value(
+        "user", "email", "test@example.com"
+    ).release()
+    return repo
 
 
 @pytest.mark.asyncio
@@ -36,6 +45,76 @@ async def test_workspace_repo_commit_closure_syncs_storage_and_does_not_push_by_
     assert events == ["sync-down", "sync-up"]
     service._do_commit.assert_awaited_once_with(tmp_path, repo, "agent change")
     service._do_push.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workspace_repo_commit_closure_stages_assume_unchanged_activated_file(
+    tmp_path,
+):
+    repo = _init_repo(tmp_path)
+    tracked = tmp_path / "features" / "activated.py"
+    tracked.parent.mkdir()
+    tracked.write_bytes(b"old\n")
+    repo.index.add(["features/activated.py"])
+    repo.index.commit("initial")
+    repo.git.update_index("--assume-unchanged", "features/activated.py")
+    activated = b"new activated content\n"
+    tracked.write_bytes(activated)
+
+    @asynccontextmanager
+    async def checkout():
+        yield tmp_path
+
+    service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
+    service.repo_manager = SimpleNamespace(checkout=checkout)
+    service._open_or_init = Mock(return_value=repo)
+    service._regenerate_manifest_to_dir = AsyncMock()
+    service._run_preflight = AsyncMock(return_value=SimpleNamespace(valid=True))
+
+    sha, push_error = await service.commit_workspace_changes(
+        "activated source",
+        expected_file_hashes={
+            "features/activated.py": hashlib.sha256(activated).hexdigest()
+        },
+    )
+
+    assert push_error is None
+    assert sha == repo.head.commit.hexsha
+    blob = repo.head.commit.tree / "features/activated.py"
+    assert blob.data_stream.read() == activated
+
+
+@pytest.mark.asyncio
+async def test_workspace_repo_commit_closure_rejects_stale_materialized_file_without_sync_up(
+    tmp_path,
+):
+    repo = _init_repo(tmp_path)
+    tracked = tmp_path / "features" / "activated.py"
+    tracked.parent.mkdir()
+    tracked.write_bytes(b"stale\n")
+    repo.index.add(["features/activated.py"])
+    repo.index.commit("initial")
+    events = []
+
+    @asynccontextmanager
+    async def checkout():
+        events.append("sync-down")
+        yield tmp_path
+        events.append("sync-up")
+
+    service = GitHubSyncService(Mock(), "https://example.test/org/repo.git")
+    service.repo_manager = SimpleNamespace(checkout=checkout)
+    service._open_or_init = Mock(return_value=repo)
+
+    with pytest.raises(RuntimeError, match="does not match activated changeset"):
+        await service.commit_workspace_changes(
+            "activated source",
+            expected_file_hashes={
+                "features/activated.py": hashlib.sha256(b"activated\n").hexdigest()
+            },
+        )
+
+    assert events == ["sync-down"]
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/test_workspace_repo_changesets.py
+++ b/api/tests/unit/services/test_workspace_repo_changesets.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from uuid import uuid4
@@ -350,9 +351,9 @@ async def test_activation_persists_failure_when_compensation_also_fails(monkeypa
 async def test_activation_closes_with_commit_without_push_by_default(monkeypatch):
     calls = []
 
-    async def commit(message, push):
+    async def commit(message, push, expected_file_hashes):
         assert svc.db.commits == 2  # activation, then durable Git-pending marker
-        calls.append((message, push))
+        calls.append((message, push, expected_file_hashes))
         return "a" * 40, None
 
     svc = WorkspaceRepoChangesetService(
@@ -391,12 +392,14 @@ async def test_activation_closes_with_commit_without_push_by_default(monkeypatch
     )
     assert closed.status == "committed"
     assert closed.commit_sha == "a" * 40
-    assert calls == [("agent change", False)]
+    assert calls == [
+        ("agent change", False, {"features/a.txt": hashlib.sha256(b"A").hexdigest()})
+    ]
 
 
 @pytest.mark.asyncio
 async def test_git_commit_failure_preserves_activation_with_recovery_evidence(monkeypatch):
-    async def commit(_message, _push):
+    async def commit(_message, _push, _expected_file_hashes):
         raise RuntimeError("git commit failed")
 
     svc = WorkspaceRepoChangesetService(
@@ -448,8 +451,8 @@ async def test_git_commit_failure_preserves_activation_with_recovery_evidence(mo
 async def test_retry_git_closure_does_not_replay_workspace_activation(monkeypatch):
     callback_calls = []
 
-    async def failing_commit(message, push):
-        callback_calls.append((message, push))
+    async def failing_commit(message, push, expected_file_hashes):
+        callback_calls.append((message, push, expected_file_hashes))
         raise RuntimeError("credentials unavailable")
 
     svc = WorkspaceRepoChangesetService(
@@ -494,8 +497,8 @@ async def test_retry_git_closure_does_not_replay_workspace_activation(monkeypatc
     assert failed.status == "activated"
     assert CountingStorage.writes == 1
 
-    async def successful_commit(message, push):
-        callback_calls.append((message, push))
+    async def successful_commit(message, push, expected_file_hashes):
+        callback_calls.append((message, push, expected_file_hashes))
         return "b" * 40, None
 
     svc.commit_callback = successful_commit
@@ -508,9 +511,10 @@ async def test_retry_git_closure_does_not_replay_workspace_activation(monkeypatc
     assert closed.commit_sha == "b" * 40
     assert closed.failure_detail is None
     assert CountingStorage.writes == 1
+    expected_file_hashes = {"features/a.txt": hashlib.sha256(b"A").hexdigest()}
     assert callback_calls == [
-        ("release source", True),
-        ("release source", True),
+        ("release source", True, expected_file_hashes),
+        ("release source", True, expected_file_hashes),
     ]
 
 
@@ -562,7 +566,7 @@ async def test_recoverable_git_closures_are_scope_bounded():
 
 @pytest.mark.asyncio
 async def test_activation_records_committed_unpushed_without_rolling_back(monkeypatch):
-    async def commit(_message, _push):
+    async def commit(_message, _push, _expected_file_hashes):
         return "a" * 40, "remote rejected push"
 
     svc = WorkspaceRepoChangesetService(


### PR DESCRIPTION
## Summary
- pass each activated changeset mutation hash into Git closure
- clear hidden Git index flags on affected tracked paths before staging
- reject stale materialized files or commit-tree mismatches before sync-back/push

## Incident evidence
The production closure advanced `production-live`, but the target file in the pushed tree retained SHA-256 `00d844...` while the activated changeset required `27cb39...`. The previous checkout then synced the stale tree back to object storage. This change makes that state impossible to report as committed.

## Validation
- 26 focused workspace changeset/Git closure tests passed
- API Ruff and Pyright: 0 errors, 0 warnings
- real Git regression test covers an `assume-unchanged` activated file
- regression test proves a stale checkout raises before sync-up

## Production impact
Required to safely repair the exact backup-restore workflow source in `production-live` and authoritative object storage. No Halo ticket, schedule, or restore behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added workspace integrity checks before staging, committing, and pushing changes.
  * Prevented stale, missing, unexpected, or modified files from being committed.
  * Ensured tracked files with hidden Git status flags are correctly detected and included.
  * Improved commit retry handling by consistently validating expected file contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->