### PR TITLE
Fix Azure Git object synchronization

### DIFF
--- a/api/src/services/git_repo_manager.py
+++ b/api/src/services/git_repo_manager.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator, Awaitable, Iterable
+from contextlib import asynccontextmanager
 from pathlib import Path, PurePosixPath
+from uuid import uuid4
 
 import redis.asyncio as redis
 
@@ -168,9 +169,14 @@ class GitRepoManager:
             destination = self._safe_local_path(target, path)
             async with semaphore:
                 content = await storage.read(path)
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            await asyncio.to_thread(destination.write_bytes, content)
-            downloaded_hashes[path] = hashlib.sha256(content).hexdigest()
+            content_hash = hashlib.sha256(content).hexdigest()
+            if destination.is_file():
+                current = await asyncio.to_thread(destination.read_bytes)
+                if hashlib.sha256(current).hexdigest() == content_hash:
+                    downloaded_hashes[path] = content_hash
+                    return
+            await asyncio.to_thread(self._replace_local_file, destination, content)
+            downloaded_hashes[path] = content_hash
 
         await self._run_transfers(
             download(path) for path in paths if not path.endswith("/")
@@ -243,6 +249,17 @@ class GitRepoManager:
         ):
             raise ValueError(f"Unsafe repository object path: {relative_path!r}")
         return destination
+
+    @staticmethod
+    def _replace_local_file(destination: Path, content: bytes) -> None:
+        """Atomically replace a local object without writing through its mode bits."""
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(f".{destination.name}.{uuid4().hex}.tmp")
+        try:
+            temporary.write_bytes(content)
+            temporary.replace(destination)
+        finally:
+            temporary.unlink(missing_ok=True)
 
     async def has_git_dir(self) -> bool:
         """Check if .git/HEAD exists in S3 _repo/ (quick existence check)."""

--- a/api/tests/unit/services/test_git_repo_manager.py
+++ b/api/tests/unit/services/test_git_repo_manager.py
@@ -280,6 +280,42 @@ class TestAzureBlobSync:
         aws.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_sync_down_preserves_identical_readonly_git_object(
+        self, azure_manager, tmp_path
+    ):
+        git_object = tmp_path / ".git" / "objects" / "00" / "readonly"
+        git_object.parent.mkdir(parents=True)
+        git_object.write_bytes(b"existing-object")
+        git_object.chmod(0o444)
+        storage = MagicMock()
+        storage.list = AsyncMock(return_value=[".git/objects/00/readonly"])
+        storage.read = AsyncMock(return_value=b"existing-object")
+
+        with patch("src.services.repo_storage.RepoStorage", return_value=storage):
+            await azure_manager.sync_down(tmp_path)
+
+        assert git_object.read_bytes() == b"existing-object"
+        assert git_object.stat().st_mode & 0o777 == 0o444
+
+    @pytest.mark.asyncio
+    async def test_sync_down_atomically_replaces_changed_readonly_git_object(
+        self, azure_manager, tmp_path
+    ):
+        git_object = tmp_path / ".git" / "objects" / "00" / "readonly"
+        git_object.parent.mkdir(parents=True)
+        git_object.write_bytes(b"stale-object")
+        git_object.chmod(0o444)
+        storage = MagicMock()
+        storage.list = AsyncMock(return_value=[".git/objects/00/readonly"])
+        storage.read = AsyncMock(return_value=b"remote-object")
+
+        with patch("src.services.repo_storage.RepoStorage", return_value=storage):
+            await azure_manager.sync_down(tmp_path)
+
+        assert git_object.read_bytes() == b"remote-object"
+        assert not list(git_object.parent.glob(".readonly.*.tmp"))
+
+    @pytest.mark.asyncio
     async def test_sync_up_writes_changes_and_deletes_removed_objects(
         self, azure_manager, tmp_path
     ):


### PR DESCRIPTION
## Summary

- Skip Azure Blob downloads when the existing local file already has the remote content hash.
- Atomically replace changed local files instead of writing through existing mode bits.
- Cover both identical and changed read-only Git loose objects.

## Root cause

Git intentionally creates loose object files read-only. The Azure Blob implementation of `GitRepoManager.sync_down()` downloaded every object and called `Path.write_bytes()` directly on the persistent checkout. A second transactional Git closure therefore attempted to truncate an existing read-only object and failed with `Permission denied` after workspace activation had already succeeded.

The production changeset remains recoverable and will be retried after this platform fix is promoted.

## Risk and rollout

Delivery lane: **Lane 3 — platform/live operations**.

- The change is limited to Azure Blob materialization of the platform Git checkout.
- Identical files retain their existing mode and are not rewritten.
- Changed files are written to a same-directory temporary file and atomically renamed over the destination, so read-only Git objects do not block convergence.
- Rollback is the previous platform image; the preserved production changeset can remain pending until the fixed image is live.

## Validation

- `./test.sh tests/unit/services/test_git_repo_manager.py -q` — 32 passed
- `./test.sh quality api` — pyright and Ruff passed with zero errors

## Live evidence

- Production service health remained green.
- Exact workspace source readback matched the reviewed file.
- Git closure and its dedicated retry both failed on an existing read-only loose object under `/tmp/git/.git/objects`.
- No ticket webhooks were replayed and no catch-up tickets were created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Azure and object-storage synchronization by skipping downloads when local files are unchanged.
  - Updated changed files safely and atomically, reducing the risk of partial or corrupted files.
  - Preserved content and permissions for existing read-only Git objects.
  - Removed temporary synchronization files after updates complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->